### PR TITLE
feat: Sanity content schemas

### DIFF
--- a/sanity.config.ts
+++ b/sanity.config.ts
@@ -1,28 +1,18 @@
 'use client'
-
-/**
- * This configuration is used to for the Sanity Studio that’s mounted on the `\app\studio\[[...tool]]\page.tsx` route
- */
-
 import {visionTool} from '@sanity/vision'
 import {defineConfig} from 'sanity'
 import {structureTool} from 'sanity/structure'
-
-// Go to https://www.sanity.io/docs/api-versioning to learn how API versioning works
 import {apiVersion, dataset, projectId} from './sanity/env'
-import {schema} from './sanity/schemaTypes'
+import {schemaTypes} from './sanity/schemaTypes'
 import {structure} from './sanity/structure'
 
 export default defineConfig({
   basePath: '/studio',
   projectId,
   dataset,
-  // Add and edit the content schema in the './sanity/schemaTypes' folder
-  schema,
+  schema: { types: schemaTypes },
   plugins: [
     structureTool({structure}),
-    // Vision is for querying with GROQ from inside the Studio
-    // https://www.sanity.io/docs/the-vision-plugin
     visionTool({defaultApiVersion: apiVersion}),
   ],
 })

--- a/sanity/schemaTypes/gallery.ts
+++ b/sanity/schemaTypes/gallery.ts
@@ -1,0 +1,63 @@
+import { defineField, defineType } from 'sanity'
+
+export const gallery = defineType({
+  name: 'gallery',
+  title: 'Gallery',
+  type: 'document',
+  fields: [
+    defineField({
+      name: 'title',
+      title: 'Title',
+      type: 'string',
+      validation: (Rule) => Rule.required(),
+    }),
+    defineField({
+      name: 'slug',
+      title: 'Slug',
+      type: 'slug',
+      options: { source: 'title' },
+      validation: (Rule) => Rule.required(),
+    }),
+    defineField({
+      name: 'category',
+      title: 'Category',
+      type: 'string',
+      options: {
+        list: [
+          { title: 'Weddings', value: 'weddings' },
+          { title: 'Portraits', value: 'portraits' },
+          { title: 'Families', value: 'families' },
+          { title: 'Couples', value: 'couples' },
+          { title: 'Brands', value: 'brands' },
+        ],
+      },
+      validation: (Rule) => Rule.required(),
+    }),
+    defineField({
+      name: 'coverImage',
+      title: 'Cover Image',
+      type: 'reference',
+      to: [{ type: 'photo' }],
+      validation: (Rule) => Rule.required(),
+    }),
+    defineField({
+      name: 'photos',
+      title: 'Photos',
+      type: 'array',
+      of: [{ type: 'reference', to: [{ type: 'photo' }] }],
+    }),
+    defineField({
+      name: 'featured',
+      title: 'Featured',
+      type: 'boolean',
+      description: 'Show this gallery on the homepage.',
+      initialValue: false,
+    }),
+  ],
+  preview: {
+    select: {
+      title: 'title',
+      subtitle: 'category',
+    },
+  },
+})

--- a/sanity/schemaTypes/index.ts
+++ b/sanity/schemaTypes/index.ts
@@ -1,5 +1,7 @@
-import { type SchemaTypeDefinition } from 'sanity'
+import { gallery } from './gallery'
+import { page } from './page'
+import { photo } from './photo'
+import { post } from './post'
+import { siteConfig } from './siteConfig'
 
-export const schema: { types: SchemaTypeDefinition[] } = {
-  types: [],
-}
+export const schemaTypes = [photo, gallery, post, page, siteConfig]

--- a/sanity/schemaTypes/page.ts
+++ b/sanity/schemaTypes/page.ts
@@ -1,0 +1,34 @@
+import { defineField, defineType } from 'sanity'
+
+export const page = defineType({
+  name: 'page',
+  title: 'Page',
+  type: 'document',
+  fields: [
+    defineField({
+      name: 'title',
+      title: 'Title',
+      type: 'string',
+      validation: (Rule) => Rule.required(),
+    }),
+    defineField({
+      name: 'slug',
+      title: 'Slug',
+      type: 'slug',
+      options: { source: 'title' },
+      validation: (Rule) => Rule.required(),
+    }),
+    defineField({
+      name: 'body',
+      title: 'Body',
+      type: 'array',
+      of: [{ type: 'block' }],
+    }),
+  ],
+  preview: {
+    select: {
+      title: 'title',
+      subtitle: 'slug.current',
+    },
+  },
+})

--- a/sanity/schemaTypes/photo.ts
+++ b/sanity/schemaTypes/photo.ts
@@ -1,0 +1,62 @@
+import { defineField, defineType } from 'sanity'
+
+export const photo = defineType({
+  name: 'photo',
+  title: 'Photo',
+  type: 'document',
+  fields: [
+    defineField({
+      name: 'title',
+      title: 'Title',
+      type: 'string',
+      validation: (Rule) => Rule.required(),
+    }),
+    defineField({
+      name: 'alt',
+      title: 'Alt Text',
+      type: 'string',
+      description: 'Describe the image for accessibility and SEO.',
+      validation: (Rule) => Rule.required(),
+    }),
+    defineField({
+      name: 'image',
+      title: 'Image',
+      type: 'image',
+      options: { hotspot: true },
+      validation: (Rule) => Rule.required(),
+    }),
+    defineField({
+      name: 'caption',
+      title: 'Caption',
+      type: 'string',
+    }),
+    defineField({
+      name: 'category',
+      title: 'Category',
+      type: 'string',
+      options: {
+        list: [
+          { title: 'Weddings', value: 'weddings' },
+          { title: 'Portraits', value: 'portraits' },
+          { title: 'Families', value: 'families' },
+          { title: 'Couples', value: 'couples' },
+          { title: 'Brands', value: 'brands' },
+        ],
+      },
+    }),
+    defineField({
+      name: 'featured',
+      title: 'Featured',
+      type: 'boolean',
+      description: 'Show this photo on the homepage.',
+      initialValue: false,
+    }),
+  ],
+  preview: {
+    select: {
+      title: 'title',
+      media: 'image',
+      subtitle: 'category',
+    },
+  },
+})

--- a/sanity/schemaTypes/post.ts
+++ b/sanity/schemaTypes/post.ts
@@ -1,0 +1,52 @@
+import { defineField, defineType } from 'sanity'
+
+export const post = defineType({
+  name: 'post',
+  title: 'Blog Post',
+  type: 'document',
+  fields: [
+    defineField({
+      name: 'title',
+      title: 'Title',
+      type: 'string',
+      validation: (Rule) => Rule.required(),
+    }),
+    defineField({
+      name: 'slug',
+      title: 'Slug',
+      type: 'slug',
+      options: { source: 'title' },
+      validation: (Rule) => Rule.required(),
+    }),
+    defineField({
+      name: 'publishedAt',
+      title: 'Published At',
+      type: 'datetime',
+      validation: (Rule) => Rule.required(),
+    }),
+    defineField({
+      name: 'coverImage',
+      title: 'Cover Image',
+      type: 'reference',
+      to: [{ type: 'photo' }],
+    }),
+    defineField({
+      name: 'excerpt',
+      title: 'Excerpt',
+      type: 'text',
+      rows: 3,
+    }),
+    defineField({
+      name: 'body',
+      title: 'Body',
+      type: 'array',
+      of: [{ type: 'block' }],
+    }),
+  ],
+  preview: {
+    select: {
+      title: 'title',
+      subtitle: 'publishedAt',
+    },
+  },
+})

--- a/sanity/schemaTypes/siteConfig.ts
+++ b/sanity/schemaTypes/siteConfig.ts
@@ -1,0 +1,35 @@
+import { defineField, defineType } from 'sanity'
+
+export const siteConfig = defineType({
+  name: 'siteConfig',
+  title: 'Site Config',
+  type: 'document',
+  fields: [
+    defineField({
+      name: 'title',
+      title: 'Site Title',
+      type: 'string',
+      validation: (Rule) => Rule.required(),
+    }),
+    defineField({
+      name: 'email',
+      title: 'Contact Email',
+      type: 'string',
+    }),
+    defineField({
+      name: 'instagramUrl',
+      title: 'Instagram URL',
+      type: 'url',
+    }),
+    defineField({
+      name: 'facebookUrl',
+      title: 'Facebook URL',
+      type: 'url',
+    }),
+  ],
+  preview: {
+    select: {
+      title: 'title',
+    },
+  },
+})


### PR DESCRIPTION
Adds five content schemas: photo, gallery, post, page, siteConfig. Fixes sanity.config.ts schema registration. All schemas verified in Studio, TypeScript clean.