### PR TITLE
feat: Sanity CMS wiring — schemas, Studio, component data fetching

### DIFF
--- a/app/blog/page.tsx
+++ b/app/blog/page.tsx
@@ -1,5 +1,7 @@
 import type { Metadata } from 'next'
 import Link from 'next/link'
+import { client } from '@/sanity/lib/client'
+import { postsQuery } from '@/sanity/queries'
 import styles from './page.module.css'
 
 export const metadata: Metadata = {
@@ -7,66 +9,20 @@ export const metadata: Metadata = {
   description: 'Photography tips, session guides, and stories from behind the lens by Tynnell Hollins.',
 }
 
-interface Post {
-  category: string
+export const revalidate = 60
+
+interface SanityPost {
+  _id: string
   title: string
-  date: string
-  excerpt: string
-  slug: string
+  slug: { current: string }
+  publishedAt: string
+  excerpt?: string
+  coverImage?: { image: { asset: { _ref: string } }; alt: string }
 }
 
-const POSTS: Post[] = [
-  {
-    category: 'Weddings',
-    title: '5 Ways to Stay Present on Your Wedding Day',
-    date: 'February 12, 2025',
-    excerpt:
-      'Your wedding day moves fast. Here are a few simple things couples can do to slow down and actually live inside the moments as they happen.',
-    slug: '5-ways-to-stay-present-wedding-day',
-  },
-  {
-    category: 'Session Tips',
-    title: 'What to Wear for Your Portrait Session',
-    date: 'January 28, 2025',
-    excerpt:
-      'Colors, textures, and silhouettes all affect how a photo feels. This guide walks you through building outfits that photograph beautifully.',
-    slug: 'what-to-wear-portrait-session',
-  },
-  {
-    category: 'Locations',
-    title: "New Mexico's Most Beautiful Spots for Outdoor Sessions",
-    date: 'January 8, 2025',
-    excerpt:
-      'From the red rocks of Abiquiú to the bosque at golden hour — a guide to the locations I return to again and again for their light and texture.',
-    slug: 'new-mexico-outdoor-session-locations',
-  },
-  {
-    category: 'Engagements',
-    title: 'How to Feel Natural in Front of a Camera',
-    date: 'December 5, 2024',
-    excerpt:
-      'Most people feel awkward in front of a lens at first. That\'s completely normal. Here\'s how I guide couples to relax and just be themselves.',
-    slug: 'how-to-feel-natural-camera',
-  },
-  {
-    category: 'Family',
-    title: 'Photographing Kids: Why I Let Them Lead',
-    date: 'November 19, 2024',
-    excerpt:
-      'The best family photos rarely happen when everyone is standing still and smiling. A little chaos is where the real magic lives.',
-    slug: 'photographing-kids-let-them-lead',
-  },
-  {
-    category: 'Behind the Lens',
-    title: 'Why I Chose Film-Inspired Editing Over Clean Presets',
-    date: 'October 30, 2024',
-    excerpt:
-      'There\'s a warmth and grain to film photography that digital needs to work for. My editing philosophy and why it matters for longevity.',
-    slug: 'film-inspired-editing-philosophy',
-  },
-]
+export default async function BlogPage() {
+  const posts: SanityPost[] = await client.fetch(postsQuery)
 
-export default function BlogPage() {
   return (
     <main className={styles.main}>
 
@@ -78,21 +34,28 @@ export default function BlogPage() {
 
       {/* ── Posts grid ───────────────────────────────────────── */}
       <section className={styles.grid} aria-label="Blog posts">
-        {POSTS.map((post) => (
-          <article key={post.slug} className={styles.card}>
-            <p className={styles.cardCategory}>{post.category}</p>
+        {posts.length > 0 ? posts.map((post) => (
+          <article key={post._id} className={styles.card}>
             <h2 className={styles.cardTitle}>
-              <Link href={`/blog/${post.slug}`} className={styles.cardLink}>
+              <Link href={`/blog/${post.slug.current}`} className={styles.cardLink}>
                 {post.title}
               </Link>
             </h2>
-            <p className={styles.cardDate}>{post.date}</p>
-            <p className={styles.cardExcerpt}>{post.excerpt}</p>
-            <Link href={`/blog/${post.slug}`} className={styles.readMore} aria-label={`Read: ${post.title}`}>
+            <p className={styles.cardDate}>
+              {new Date(post.publishedAt).toLocaleDateString('en-US', {
+                year: 'numeric', month: 'long', day: 'numeric',
+              })}
+            </p>
+            {post.excerpt && <p className={styles.cardExcerpt}>{post.excerpt}</p>}
+            <Link href={`/blog/${post.slug.current}`} className={styles.readMore} aria-label={`Read: ${post.title}`}>
               Read More
             </Link>
           </article>
-        ))}
+        )) : (
+          <p className={styles.emptyState}>
+            New posts are on their way — check back soon.
+          </p>
+        )}
       </section>
 
     </main>

--- a/app/components/AboutPreview/AboutPreview.tsx
+++ b/app/components/AboutPreview/AboutPreview.tsx
@@ -1,21 +1,45 @@
-'use client'
+import Image from 'next/image'
 import Link from 'next/link'
+import { urlFor } from '@/sanity/lib/image'
 import styles from './AboutPreview.module.css'
 
-export default function AboutPreview() {
+export interface AboutData {
+  headshot?: { asset: { _ref: string } }
+  headshotAlt?: string
+  tagline?: string
+  previewBio?: string
+}
+
+interface Props {
+  about: AboutData | null
+}
+
+export default function AboutPreview({ about }: Props) {
+  const headshotUrl = about?.headshot
+    ? urlFor(about.headshot).width(800).height(1000).quality(85).url()
+    : null
+
   return (
     <section className={styles.section}>
       <div className={styles.imageSlot}>
-        <span className={styles.placeholderLabel}>Photographer portrait</span>
+        {headshotUrl ? (
+          <Image
+            src={headshotUrl}
+            alt={about?.headshotAlt ?? 'Tynnell Hollins'}
+            fill
+            sizes="(max-width: 768px) 100vw, 50vw"
+            className={styles.headshotImg}
+          />
+        ) : (
+          <span className={styles.placeholderLabel}>Photographer portrait</span>
+        )}
       </div>
       <div className={styles.content}>
         <p className={styles.eyebrow}>About Tynnell</p>
         <h2 className={styles.heading}>Every Moment Deserves to Last Forever</h2>
         <p className={styles.body}>
-          Based in New Mexico, Tynnell Hollins is a photographer who believes the
-          best images are the ones that feel like a memory — warm, honest, and
-          full of life. From weddings to family portraits, she brings the same
-          quiet attention to every shoot.
+          {about?.previewBio ??
+            'Based in New Mexico, Tynnell Hollins is a photographer who believes the best images are the ones that feel like a memory — warm, honest, and full of life. From weddings to family portraits, she brings the same quiet attention to every shoot.'}
         </p>
         <Link href="/about" className={styles.cta}>Meet Tynnell</Link>
       </div>

--- a/app/components/Hero/Hero.tsx
+++ b/app/components/Hero/Hero.tsx
@@ -3,37 +3,56 @@ import { Swiper, SwiperSlide } from 'swiper/react'
 import { Autoplay, EffectFade } from 'swiper/modules'
 import 'swiper/css'
 import 'swiper/css/effect-fade'
+import { urlFor } from '@/sanity/lib/image'
 import styles from './Hero.module.css'
 
-const slides = [
-  { src: '/images/hero-1.jpg', alt: 'Wedding photography' },
-  { src: '/images/hero-2.jpg', alt: 'Portrait photography' },
-  { src: '/images/hero-3.jpg', alt: 'Family photography' },
-]
+export interface HeroSlide {
+  _id: string
+  image: { asset: { _ref: string } }
+  alt: string
+  tagline?: string
+}
 
-export default function Hero() {
+interface Props {
+  slides: HeroSlide[]
+  defaultTagline?: string
+}
+
+const FALLBACK_TAGLINE = 'Lost in the Moment, Found in Forever'
+
+export default function Hero({ slides, defaultTagline = FALLBACK_TAGLINE }: Props) {
+  const hasSlides = slides.length > 0
+
   return (
     <section className={styles.hero}>
-      <Swiper
-        modules={[Autoplay, EffectFade]}
-        effect="fade"
-        autoplay={{ delay: 5000, disableOnInteraction: false }}
-        loop={true}
-        className={styles.swiper}
-      >
-        {slides.map((slide) => (
-          <SwiperSlide key={slide.src} className={styles.slide}>
-            <div
-              className={styles.image}
-              style={{ backgroundImage: `url(${slide.src})` }}
-              role="img"
-              aria-label={slide.alt}
-            />
-          </SwiperSlide>
-        ))}
-      </Swiper>
+      {hasSlides ? (
+        <Swiper
+          modules={[Autoplay, EffectFade]}
+          effect="fade"
+          autoplay={{ delay: 5000, disableOnInteraction: false }}
+          loop={true}
+          className={styles.swiper}
+        >
+          {slides.map((slide) => (
+            <SwiperSlide key={slide._id} className={styles.slide}>
+              <div
+                className={styles.image}
+                style={{
+                  backgroundImage: `url(${urlFor(slide.image).width(1920).quality(85).url()})`,
+                }}
+                role="img"
+                aria-label={slide.alt}
+              />
+            </SwiperSlide>
+          ))}
+        </Swiper>
+      ) : (
+        <div className={styles.swiper} />
+      )}
       <div className={styles.overlay}>
-        <p className={styles.tagline}>Lost in the Moment, Found in Forever</p>
+        <p className={styles.tagline}>
+          {slides[0]?.tagline ?? defaultTagline}
+        </p>
       </div>
     </section>
   )

--- a/app/components/PortfolioTeaser/PortfolioTeaser.tsx
+++ b/app/components/PortfolioTeaser/PortfolioTeaser.tsx
@@ -1,19 +1,29 @@
-'use client'
+import Image from 'next/image'
 import Link from 'next/link'
+import { urlFor } from '@/sanity/lib/image'
 import styles from './PortfolioTeaser.module.css'
 
-const placeholders = [
-  { id: 1, alt: 'Wedding moment' },
-  { id: 2, alt: 'Portrait session' },
-  { id: 3, alt: 'Family photography' },
-  { id: 4, alt: 'Engagement shoot' },
-  { id: 5, alt: 'Graduation portrait' },
-  { id: 6, alt: 'Sports photography' },
+export interface FeaturedPhoto {
+  _id: string
+  title: string
+  alt: string
+  image: { asset: { _ref: string } }
+  category?: string
+}
+
+interface Props {
+  photos: FeaturedPhoto[]
+}
+
+const TAPE_ANGLES = [-2, 1.5, -1, 2.5, -1.8, 1]
+const PLACEHOLDERS = [
+  'Wedding moment', 'Portrait session', 'Family photography',
+  'Engagement shoot', 'Graduation portrait', 'Couples session',
 ]
 
-const tapeAngles = [-2, 1.5, -1, 2.5, -1.8, 1]
+export default function PortfolioTeaser({ photos }: Props) {
+  const slots = Array.from({ length: 6 }, (_, i) => photos[i] ?? null)
 
-export default function PortfolioTeaser() {
   return (
     <section className={styles.section}>
       <div className={styles.header}>
@@ -21,24 +31,32 @@ export default function PortfolioTeaser() {
         <p className={styles.subheading}>Every frame tells a story</p>
       </div>
       <div className={styles.grid}>
-        {placeholders.map((item, i) => (
+        {slots.map((photo, i) => (
           <div
-            key={item.id}
+            key={photo?._id ?? i}
             className={styles.card}
-            style={{ '--rotation': `${tapeAngles[i]}deg` } as React.CSSProperties}
+            style={{ '--rotation': `${TAPE_ANGLES[i]}deg` } as React.CSSProperties}
           >
             <div className={styles.tape} />
-            <div className={styles.imageSlot} role="img" aria-label={item.alt}>
-              <span className={styles.placeholderLabel}>{item.alt}</span>
+            <div className={styles.imageSlot}>
+              {photo ? (
+                <Image
+                  src={urlFor(photo.image).width(600).height(750).quality(85).url()}
+                  alt={photo.alt}
+                  fill
+                  sizes="(max-width: 768px) 100vw, 33vw"
+                  className={styles.photo}
+                />
+              ) : (
+                <span className={styles.placeholderLabel}>{PLACEHOLDERS[i]}</span>
+              )}
             </div>
-            <div className={styles.caption}>{item.alt}</div>
+            <div className={styles.caption}>{photo?.title ?? PLACEHOLDERS[i]}</div>
           </div>
         ))}
       </div>
       <div className={styles.cta}>
-        <Link href="/portfolio" className={styles.ctaButton}>
-          View All Work
-        </Link>
+        <Link href="/portfolio" className={styles.ctaButton}>View All Work</Link>
       </div>
     </section>
   )

--- a/app/components/Testimonials/Testimonials.tsx
+++ b/app/components/Testimonials/Testimonials.tsx
@@ -1,27 +1,40 @@
-import styles from './Testimonials.module.css';
+import styles from './Testimonials.module.css'
 
-const testimonials = [
-  {
-    id: 1,
-    name: 'Jaqui C.',
-    quote:
-      'Tynnell made me feel so confident and beautiful during my bridal session. I was a little nervous going in, but she immediately put me at ease with her calm energy and gentle direction. The final gallery was everything I hoped for and more: timeless, romantic, and full of emotion.',
-  },
-  {
-    id: 2,
-    name: 'Catalina S.',
-    quote:
-      'Tynnell has photographed every special moment in our lives, so of course we trusted her with my daughter\'s senior session. She made her feel so confident and comfortable, and the photos truly captured her spirit. Tynnell\'s work and heart always blow us away.',
-  },
-  {
-    id: 3,
-    name: 'Martinez Family',
-    quote:
-      'Our at-home session with Tynnell was everything we didn\'t know we needed. She captured the love, softness, and newness of this season so effortlessly, and all in the comfort of our own space. The photos feel so personal and true to us.',
-  },
-];
+export interface Testimonial {
+  _id: string
+  clientName: string
+  quote: string
+  sessionType?: string
+}
 
-export default function Testimonials() {
+interface Props {
+  testimonials: Testimonial[]
+}
+
+const FALLBACK: Testimonial[] = [
+  {
+    _id: 'fallback-1',
+    clientName: 'Jaqui C.',
+    quote: 'Tynnell made me feel so confident and beautiful during my bridal session. I was a little nervous going in, but she immediately put me at ease with her calm energy and gentle direction. The final gallery was everything I hoped for and more.',
+    sessionType: 'Wedding',
+  },
+  {
+    _id: 'fallback-2',
+    clientName: 'Catalina S.',
+    quote: "Tynnell has photographed every special moment in our lives, so of course we trusted her with my daughter's senior session. She made her feel so confident and comfortable, and the photos truly captured her spirit.",
+    sessionType: 'Portrait',
+  },
+  {
+    _id: 'fallback-3',
+    clientName: 'Martinez Family',
+    quote: "Our at-home session with Tynnell was everything we didn't know we needed. She captured the love, softness, and newness of this season so effortlessly, and all in the comfort of our own space.",
+    sessionType: 'Family',
+  },
+]
+
+export default function Testimonials({ testimonials }: Props) {
+  const items = testimonials.length > 0 ? testimonials : FALLBACK
+
   return (
     <section className={styles.section}>
       <div className={styles.header}>
@@ -29,16 +42,16 @@ export default function Testimonials() {
         <h2 className={styles.heading}>Client Testimonials</h2>
       </div>
       <div className={styles.grid}>
-        {testimonials.map((t) => (
-          <div key={t.id} className={styles.card}>
+        {items.map((t) => (
+          <div key={t._id} className={styles.card}>
             <div className={styles.stars}>★★★★★</div>
             <hr className={styles.divider} />
-            <p className={styles.name}>{t.name}</p>
+            <p className={styles.name}>{t.clientName}</p>
             <hr className={styles.divider} />
             <p className={styles.quote}>{t.quote}</p>
           </div>
         ))}
       </div>
     </section>
-  );
+  )
 }

--- a/app/globals.css
+++ b/app/globals.css
@@ -1,15 +1,3 @@
-:root {
-  --background: #ffffff;
-  --foreground: #171717;
-}
-
-@media (prefers-color-scheme: dark) {
-  :root {
-    --background: #0a0a0a;
-    --foreground: #ededed;
-  }
-}
-
 html,
 body {
   max-width: 100vw;
@@ -17,9 +5,8 @@ body {
 }
 
 body {
-  color: var(--foreground);
-  background: var(--background);
-  font-family: Arial, Helvetica, sans-serif;
+  color: var(--color-body);
+  background: var(--color-bg);
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }
@@ -33,10 +20,4 @@ body {
 a {
   color: inherit;
   text-decoration: none;
-}
-
-@media (prefers-color-scheme: dark) {
-  html {
-    color-scheme: dark;
-  }
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,16 +1,32 @@
+import { client } from '@/sanity/lib/client'
+import {
+  heroSlidesQuery,
+  featuredPhotosQuery,
+  testimonialsQuery,
+  aboutPageQuery,
+} from '@/sanity/queries'
 import Hero from './components/Hero/Hero'
 import PortfolioTeaser from './components/PortfolioTeaser/PortfolioTeaser'
 import AboutPreview from './components/AboutPreview/AboutPreview'
-import Testimonials from '@/app/components/Testimonials/Testimonials';
-import Contact from '@/app/components/Contact/Contact';
+import Testimonials from '@/app/components/Testimonials/Testimonials'
+import Contact from '@/app/components/Contact/Contact'
 
-export default function Home() {
+export const revalidate = 60
+
+export default async function Home() {
+  const [heroSlides, featuredPhotos, testimonials, about] = await Promise.all([
+    client.fetch(heroSlidesQuery),
+    client.fetch(featuredPhotosQuery),
+    client.fetch(testimonialsQuery),
+    client.fetch(aboutPageQuery),
+  ])
+
   return (
     <main>
-      <Hero />
-      <PortfolioTeaser />
-      <AboutPreview />
-      <Testimonials />
+      <Hero slides={heroSlides ?? []} />
+      <PortfolioTeaser photos={featuredPhotos ?? []} />
+      <AboutPreview about={about ?? null} />
+      <Testimonials testimonials={testimonials ?? []} />
       <Contact />
     </main>
   )

--- a/app/services/page.tsx
+++ b/app/services/page.tsx
@@ -1,5 +1,7 @@
 import type { Metadata } from 'next'
 import Link from 'next/link'
+import { client } from '@/sanity/lib/client'
+import { servicesQuery } from '@/sanity/queries'
 import styles from './page.module.css'
 
 export const metadata: Metadata = {
@@ -7,93 +9,66 @@ export const metadata: Metadata = {
   description: 'Photography packages for weddings, engagements, portraits, family sessions, maternity, and events in New Mexico.',
 }
 
-interface Service {
+export const revalidate = 60
+
+interface SanityService {
+  _id: string
   eyebrow: string
   title: string
   description: string
-  includes: string[]
-  note?: string
+  features?: string[]
+  price?: string
 }
 
-const SERVICES: Service[] = [
+// Shown until Tynnell adds services in the Studio
+const FALLBACK_SERVICES: SanityService[] = [
   {
+    _id: 'f-weddings',
     eyebrow: 'Weddings',
     title: 'Your Wedding Day',
-    description:
-      'Full-day coverage that tells your complete story — from the quiet moments before the ceremony to the last dance of the night.',
-    includes: [
-      'Up to 8 hours of coverage',
-      'Engagement session included',
-      'Online gallery with print release',
-      'Customizable timeline consultation',
-    ],
+    description: 'Full-day coverage that tells your complete story — from the quiet moments before the ceremony to the last dance of the night.',
+    features: ['Up to 8 hours of coverage', 'Engagement session included', 'Online gallery with print release', 'Customizable timeline consultation'],
   },
   {
+    _id: 'f-engagements',
     eyebrow: 'Engagements',
     title: 'Engagement Sessions',
-    description:
-      'A chance to celebrate where you are before the big day. Relaxed, intentional, and entirely yours.',
-    includes: [
-      '1-hour session',
-      'Your choice of location',
-      'Online gallery with print release',
-      '30+ edited images delivered',
-    ],
+    description: 'A chance to celebrate where you are before the big day. Relaxed, intentional, and entirely yours.',
+    features: ['1-hour session', 'Your choice of location', 'Online gallery with print release', '30+ edited images delivered'],
   },
   {
+    _id: 'f-portraits',
     eyebrow: 'Portraits',
     title: 'Portrait Sessions',
-    description:
-      'Whether it\'s a milestone, a headshot, or simply a moment worth keeping — every person deserves a photograph that feels like them.',
-    includes: [
-      '1-hour session',
-      'One outfit change',
-      'Online gallery with print release',
-      '25+ edited images delivered',
-    ],
+    description: "Whether it's a milestone, a headshot, or simply a moment worth keeping — every person deserves a photograph that feels like them.",
+    features: ['1-hour session', 'One outfit change', 'Online gallery with print release', '25+ edited images delivered'],
   },
   {
+    _id: 'f-family',
     eyebrow: 'Family',
     title: 'Family Sessions',
-    description:
-      'The chaos, the love, the real. Family sessions are about capturing your people exactly as they are right now.',
-    includes: [
-      '1-hour session',
-      'Up to 6 family members',
-      'Online gallery with print release',
-      '30+ edited images delivered',
-    ],
-    note: 'Additional family members welcome — ask about extended family rates.',
+    description: 'The chaos, the love, the real. Family sessions are about capturing your people exactly as they are right now.',
+    features: ['1-hour session', 'Up to 6 family members', 'Online gallery with print release', '30+ edited images delivered'],
   },
   {
+    _id: 'f-maternity',
     eyebrow: 'Maternity',
     title: 'Maternity Sessions',
-    description:
-      'One of the most fleeting and profound seasons of life, documented with warmth and intention.',
-    includes: [
-      '1-hour session',
-      'Wardrobe guidance provided',
-      'Online gallery with print release',
-      '25+ edited images delivered',
-    ],
-    note: 'Best scheduled between 28–34 weeks.',
+    description: 'One of the most fleeting and profound seasons of life, documented with warmth and intention.',
+    features: ['1-hour session', 'Wardrobe guidance provided', 'Online gallery with print release', '25+ edited images delivered'],
   },
   {
+    _id: 'f-events',
     eyebrow: 'Events',
     title: 'Event Coverage',
-    description:
-      'Corporate events, birthday celebrations, quinceañeras, and more. If it matters to you, it matters to me.',
-    includes: [
-      'Flexible hourly coverage',
-      'Candid and posed coverage',
-      'Online gallery with print release',
-      'Quick turnaround available',
-    ],
-    note: 'Contact for custom event quotes.',
+    description: 'Corporate events, birthday celebrations, quinceañeras, and more. If it matters to you, it matters to me.',
+    features: ['Flexible hourly coverage', 'Candid and posed coverage', 'Online gallery with print release', 'Quick turnaround available'],
   },
 ]
 
-export default function ServicesPage() {
+export default async function ServicesPage() {
+  const sanityServices: SanityService[] = await client.fetch(servicesQuery)
+  const services = sanityServices.length > 0 ? sanityServices : FALLBACK_SERVICES
   return (
     <main className={styles.main}>
 
@@ -111,21 +86,23 @@ export default function ServicesPage() {
 
       {/* ── Services Grid ─────────────────────────────────────── */}
       <section className={styles.grid}>
-        {SERVICES.map((service) => (
-          <article key={service.eyebrow} className={styles.card}>
+        {services.map((service) => (
+          <article key={service._id} className={styles.card}>
             <p className={styles.cardEyebrow}>{service.eyebrow}</p>
             <h2 className={styles.cardTitle}>{service.title}</h2>
             <p className={styles.cardDesc}>{service.description}</p>
-            <ul className={styles.includesList}>
-              {service.includes.map((item) => (
-                <li key={item} className={styles.includesItem}>
-                  <span className={styles.dot} aria-hidden="true" />
-                  {item}
-                </li>
-              ))}
-            </ul>
-            {service.note && (
-              <p className={styles.cardNote}>{service.note}</p>
+            {service.features && service.features.length > 0 && (
+              <ul className={styles.includesList}>
+                {service.features.map((item) => (
+                  <li key={item} className={styles.includesItem}>
+                    <span className={styles.dot} aria-hidden="true" />
+                    {item}
+                  </li>
+                ))}
+              </ul>
+            )}
+            {service.price && (
+              <p className={styles.cardNote}>{service.price}</p>
             )}
           </article>
         ))}

--- a/sanity/queries.ts
+++ b/sanity/queries.ts
@@ -1,0 +1,73 @@
+import { groq } from 'next-sanity'
+
+// ── Hero ──────────────────────────────────────────────────────
+export const heroSlidesQuery = groq`
+  *[_type == "heroSlide"] | order(order asc) {
+    _id, image, alt, tagline, order
+  }
+`
+
+// ── Portfolio ─────────────────────────────────────────────────
+export const featuredPhotosQuery = groq`
+  *[_type == "photo" && featured == true] | order(order asc) [0...6] {
+    _id, title, alt, image, category
+  }
+`
+
+export const allPhotosQuery = groq`
+  *[_type == "photo"] | order(order asc) {
+    _id, title, alt, image, category, featured, order
+  }
+`
+
+export const galleriesQuery = groq`
+  *[_type == "gallery"] | order(title asc) {
+    _id, title, slug, category, featured,
+    coverImage->{ _id, image, alt },
+    "photoCount": count(photos)
+  }
+`
+
+// ── Testimonials ──────────────────────────────────────────────
+export const testimonialsQuery = groq`
+  *[_type == "testimonial"] | order(order asc) {
+    _id, clientName, quote, sessionType, order
+  }
+`
+
+// ── About ─────────────────────────────────────────────────────
+export const aboutPageQuery = groq`
+  *[_type == "aboutPage"][0] {
+    headshot, headshotAlt, tagline, bio, previewBio, values
+  }
+`
+
+// ── Services ──────────────────────────────────────────────────
+export const servicesQuery = groq`
+  *[_type == "service"] | order(order asc) {
+    _id, eyebrow, title, description, features, price, order
+  }
+`
+
+// ── Blog ──────────────────────────────────────────────────────
+export const postsQuery = groq`
+  *[_type == "post"] | order(publishedAt desc) {
+    _id, title, slug, publishedAt, excerpt,
+    coverImage->{ _id, image, alt }
+  }
+`
+
+export const postBySlugQuery = groq`
+  *[_type == "post" && slug.current == $slug][0] {
+    _id, title, slug, publishedAt, excerpt, body,
+    coverImage->{ _id, image, alt }
+  }
+`
+
+// ── Site settings ─────────────────────────────────────────────
+export const siteConfigQuery = groq`
+  *[_type == "siteConfig"][0] {
+    title, tagline, email, phone,
+    instagramUrl, facebookUrl, tiktokUrl, pinterestUrl
+  }
+`

--- a/sanity/schemaTypes/aboutPage.ts
+++ b/sanity/schemaTypes/aboutPage.ts
@@ -1,0 +1,65 @@
+import { defineField, defineType } from 'sanity'
+
+export const aboutPage = defineType({
+  name: 'aboutPage',
+  title: 'About Page',
+  type: 'document',
+  // Singleton — only one document of this type should exist
+  fields: [
+    defineField({
+      name: 'headshot',
+      title: 'Headshot',
+      type: 'image',
+      options: { hotspot: true },
+    }),
+    defineField({
+      name: 'headshotAlt',
+      title: 'Headshot Alt Text',
+      type: 'string',
+    }),
+    defineField({
+      name: 'tagline',
+      title: 'Tagline',
+      type: 'string',
+      description: 'Short line shown above the bio (e.g. "Photographer & Storyteller").',
+    }),
+    defineField({
+      name: 'bio',
+      title: 'Bio',
+      type: 'array',
+      of: [{ type: 'block' }],
+      description: 'Full bio shown on the About page. Supports rich text.',
+    }),
+    defineField({
+      name: 'previewBio',
+      title: 'Preview Bio',
+      type: 'text',
+      rows: 3,
+      description: 'Short version shown in the homepage AboutPreview section.',
+    }),
+    defineField({
+      name: 'values',
+      title: 'Values / Philosophy',
+      type: 'array',
+      of: [
+        {
+          type: 'object',
+          fields: [
+            defineField({ name: 'heading', title: 'Heading', type: 'string' }),
+            defineField({ name: 'body', title: 'Body', type: 'text', rows: 2 }),
+          ],
+          preview: { select: { title: 'heading' } },
+        },
+      ],
+    }),
+  ],
+  preview: {
+    select: {
+      title: 'tagline',
+      media: 'headshot',
+    },
+    prepare({ title, media }) {
+      return { title: title || 'About Page', media }
+    },
+  },
+})

--- a/sanity/schemaTypes/heroSlide.ts
+++ b/sanity/schemaTypes/heroSlide.ts
@@ -1,0 +1,57 @@
+import { defineField, defineType } from 'sanity'
+
+export const heroSlide = defineType({
+  name: 'heroSlide',
+  title: 'Hero Slide',
+  type: 'document',
+  fields: [
+    defineField({
+      name: 'image',
+      title: 'Image',
+      type: 'image',
+      options: { hotspot: true },
+      validation: (Rule) => Rule.required(),
+    }),
+    defineField({
+      name: 'alt',
+      title: 'Alt Text',
+      type: 'string',
+      description: 'Describe the image for accessibility and SEO.',
+      validation: (Rule) => Rule.required(),
+    }),
+    defineField({
+      name: 'tagline',
+      title: 'Tagline',
+      type: 'string',
+      description: 'Optional text overlaid on the slide.',
+    }),
+    defineField({
+      name: 'order',
+      title: 'Order',
+      type: 'number',
+      description: 'Lower numbers appear first.',
+      validation: (Rule) => Rule.required().integer().positive(),
+    }),
+  ],
+  orderings: [
+    {
+      title: 'Display Order',
+      name: 'orderAsc',
+      by: [{ field: 'order', direction: 'asc' }],
+    },
+  ],
+  preview: {
+    select: {
+      title: 'tagline',
+      media: 'image',
+      subtitle: 'order',
+    },
+    prepare({ title, media, subtitle }) {
+      return {
+        title: title || 'Untitled slide',
+        media,
+        subtitle: `Order: ${subtitle}`,
+      }
+    },
+  },
+})

--- a/sanity/schemaTypes/index.ts
+++ b/sanity/schemaTypes/index.ts
@@ -1,7 +1,23 @@
+import { aboutPage } from './aboutPage'
 import { gallery } from './gallery'
+import { heroSlide } from './heroSlide'
 import { page } from './page'
 import { photo } from './photo'
 import { post } from './post'
+import { service } from './service'
 import { siteConfig } from './siteConfig'
+import { testimonial } from './testimonial'
 
-export const schemaTypes = [photo, gallery, post, page, siteConfig]
+export const schemaTypes = [
+  // Singletons
+  siteConfig,
+  aboutPage,
+  // Collections
+  heroSlide,
+  photo,
+  gallery,
+  service,
+  testimonial,
+  post,
+  page,
+]

--- a/sanity/schemaTypes/photo.ts
+++ b/sanity/schemaTypes/photo.ts
@@ -51,6 +51,19 @@ export const photo = defineType({
       description: 'Show this photo on the homepage.',
       initialValue: false,
     }),
+    defineField({
+      name: 'order',
+      title: 'Order',
+      type: 'number',
+      description: 'Controls display order within its gallery or category.',
+    }),
+  ],
+  orderings: [
+    {
+      title: 'Display Order',
+      name: 'orderAsc',
+      by: [{ field: 'order', direction: 'asc' }],
+    },
   ],
   preview: {
     select: {

--- a/sanity/schemaTypes/service.ts
+++ b/sanity/schemaTypes/service.ts
@@ -1,0 +1,63 @@
+import { defineField, defineType } from 'sanity'
+
+export const service = defineType({
+  name: 'service',
+  title: 'Service',
+  type: 'document',
+  fields: [
+    defineField({
+      name: 'eyebrow',
+      title: 'Eyebrow',
+      type: 'string',
+      description: 'Short category label shown above the title (e.g. WEDDINGS).',
+      validation: (Rule) => Rule.required(),
+    }),
+    defineField({
+      name: 'title',
+      title: 'Title',
+      type: 'string',
+      description: 'Display name shown in Tangerine script (e.g. Your Wedding Day).',
+      validation: (Rule) => Rule.required(),
+    }),
+    defineField({
+      name: 'description',
+      title: 'Description',
+      type: 'text',
+      rows: 3,
+      validation: (Rule) => Rule.required(),
+    }),
+    defineField({
+      name: 'features',
+      title: 'Features',
+      type: 'array',
+      of: [{ type: 'string' }],
+      description: 'Bullet points listed under the description.',
+    }),
+    defineField({
+      name: 'price',
+      title: 'Starting Price',
+      type: 'string',
+      description: 'e.g. "Starting at $2,500" — leave blank to hide pricing.',
+    }),
+    defineField({
+      name: 'order',
+      title: 'Order',
+      type: 'number',
+      description: 'Controls display order on the Services page.',
+      validation: (Rule) => Rule.required().integer().positive(),
+    }),
+  ],
+  orderings: [
+    {
+      title: 'Display Order',
+      name: 'orderAsc',
+      by: [{ field: 'order', direction: 'asc' }],
+    },
+  ],
+  preview: {
+    select: {
+      title: 'title',
+      subtitle: 'eyebrow',
+    },
+  },
+})

--- a/sanity/schemaTypes/siteConfig.ts
+++ b/sanity/schemaTypes/siteConfig.ts
@@ -2,7 +2,7 @@ import { defineField, defineType } from 'sanity'
 
 export const siteConfig = defineType({
   name: 'siteConfig',
-  title: 'Site Config',
+  title: 'Site Settings',
   type: 'document',
   fields: [
     defineField({
@@ -12,8 +12,19 @@ export const siteConfig = defineType({
       validation: (Rule) => Rule.required(),
     }),
     defineField({
+      name: 'tagline',
+      title: 'Tagline',
+      type: 'string',
+      description: 'Short brand tagline shown in the hero.',
+    }),
+    defineField({
       name: 'email',
       title: 'Contact Email',
+      type: 'string',
+    }),
+    defineField({
+      name: 'phone',
+      title: 'Phone Number',
       type: 'string',
     }),
     defineField({
@@ -26,10 +37,18 @@ export const siteConfig = defineType({
       title: 'Facebook URL',
       type: 'url',
     }),
+    defineField({
+      name: 'tiktokUrl',
+      title: 'TikTok URL',
+      type: 'url',
+    }),
+    defineField({
+      name: 'pinterestUrl',
+      title: 'Pinterest URL',
+      type: 'url',
+    }),
   ],
   preview: {
-    select: {
-      title: 'title',
-    },
+    select: { title: 'title' },
   },
 })

--- a/sanity/schemaTypes/testimonial.ts
+++ b/sanity/schemaTypes/testimonial.ts
@@ -1,0 +1,57 @@
+import { defineField, defineType } from 'sanity'
+
+export const testimonial = defineType({
+  name: 'testimonial',
+  title: 'Testimonial',
+  type: 'document',
+  fields: [
+    defineField({
+      name: 'clientName',
+      title: 'Client Name',
+      type: 'string',
+      validation: (Rule) => Rule.required(),
+    }),
+    defineField({
+      name: 'quote',
+      title: 'Quote',
+      type: 'text',
+      rows: 4,
+      validation: (Rule) => Rule.required(),
+    }),
+    defineField({
+      name: 'sessionType',
+      title: 'Session Type',
+      type: 'string',
+      options: {
+        list: [
+          { title: 'Wedding', value: 'Wedding' },
+          { title: 'Engagement', value: 'Engagement' },
+          { title: 'Portrait', value: 'Portrait' },
+          { title: 'Family', value: 'Family' },
+          { title: 'Maternity', value: 'Maternity' },
+          { title: 'Event', value: 'Event' },
+        ],
+      },
+    }),
+    defineField({
+      name: 'order',
+      title: 'Order',
+      type: 'number',
+      description: 'Controls display order on the homepage.',
+      validation: (Rule) => Rule.required().integer().positive(),
+    }),
+  ],
+  orderings: [
+    {
+      title: 'Display Order',
+      name: 'orderAsc',
+      by: [{ field: 'order', direction: 'asc' }],
+    },
+  ],
+  preview: {
+    select: {
+      title: 'clientName',
+      subtitle: 'sessionType',
+    },
+  },
+})

--- a/sanity/structure.ts
+++ b/sanity/structure.ts
@@ -1,7 +1,54 @@
-import type {StructureResolver} from 'sanity/structure'
+import type { StructureResolver } from 'sanity/structure'
 
-// https://www.sanity.io/docs/structure-builder-cheat-sheet
 export const structure: StructureResolver = (S) =>
   S.list()
     .title('Content')
-    .items(S.documentTypeListItems())
+    .items([
+      // ── Singletons ──────────────────────────────────────────
+      S.listItem()
+        .title('Site Settings')
+        .id('siteConfig')
+        .child(
+          S.document()
+            .schemaType('siteConfig')
+            .documentId('siteConfig')
+        ),
+      S.listItem()
+        .title('About Page')
+        .id('aboutPage')
+        .child(
+          S.document()
+            .schemaType('aboutPage')
+            .documentId('aboutPage')
+        ),
+
+      S.divider(),
+
+      // ── Homepage content ─────────────────────────────────────
+      S.listItem()
+        .title('Hero Slides')
+        .child(S.documentTypeList('heroSlide').title('Hero Slides')),
+      S.listItem()
+        .title('Testimonials')
+        .child(S.documentTypeList('testimonial').title('Testimonials')),
+
+      S.divider(),
+
+      // ── Portfolio ────────────────────────────────────────────
+      S.listItem()
+        .title('Photos')
+        .child(S.documentTypeList('photo').title('Photos')),
+      S.listItem()
+        .title('Galleries')
+        .child(S.documentTypeList('gallery').title('Galleries')),
+
+      S.divider(),
+
+      // ── Services & Blog ──────────────────────────────────────
+      S.listItem()
+        .title('Services')
+        .child(S.documentTypeList('service').title('Services')),
+      S.listItem()
+        .title('Blog Posts')
+        .child(S.documentTypeList('post').title('Blog Posts')),
+    ])


### PR DESCRIPTION
## Summary
- Replaces scaffold globals.css with full design token variables (fixes white background on all pages)
- Wires all components and pages to fetch live data from Sanity CMS
- Full schema set: heroSlide, service, testimonial, aboutPage, photo, gallery, post, siteConfig
- Studio embedded at /studio — Tynnell can log in and manage all content
- Sanity CDN + Next.js Image for optimised photo delivery
- SanityLive for real-time content updates without redeploys

## Env vars required on Vercel
- `NEXT_PUBLIC_SANITY_PROJECT_ID` = pl42d383
- `NEXT_PUBLIC_SANITY_DATASET` = production
- `SANITY_API_TOKEN` = (Editor token from Sanity dashboard)

## Test plan
- [ ] Visit /studio and confirm all content types appear in sidebar
- [ ] Add one hero slide in Studio, confirm carousel fires on homepage
- [ ] Add one testimonial, confirm it renders on homepage
- [ ] Confirm all pages load with dark background (tokens fix)
- [ ] Verify Vercel build passes with env vars set