### PR TITLE
feat: portfolio pages — Sanity data, category filter, gallery detail pages

### DIFF
--- a/app/portfolio/PortfolioGrid.tsx
+++ b/app/portfolio/PortfolioGrid.tsx
@@ -1,0 +1,134 @@
+'use client'
+import { useState } from 'react'
+import Image from 'next/image'
+import Link from 'next/link'
+import { urlFor } from '@/sanity/lib/image'
+import styles from './page.module.css'
+
+const CATEGORIES = [
+  { label: 'All',       value: 'all' },
+  { label: 'Weddings',  value: 'weddings' },
+  { label: 'Portraits', value: 'portraits' },
+  { label: 'Families',  value: 'families' },
+  { label: 'Couples',   value: 'couples' },
+  { label: 'Brands',    value: 'brands' },
+]
+
+type Photo = {
+  _id: string
+  title: string
+  alt: string
+  image: object
+  category: string
+}
+
+type Gallery = {
+  _id: string
+  title: string
+  slug: { current: string }
+  category: string
+  featured: boolean
+  coverImage: { _id: string; image: object; alt: string } | null
+  photoCount: number
+}
+
+type Props = {
+  photos: Photo[]
+  galleries: Gallery[]
+}
+
+export default function PortfolioGrid({ photos, galleries }: Props) {
+  const [activeCategory, setActiveCategory] = useState('all')
+  const [view, setView] = useState<'photos' | 'galleries'>('photos')
+
+  const filteredPhotos = activeCategory === 'all'
+    ? photos
+    : photos.filter(p => p.category === activeCategory)
+
+  const filteredGalleries = activeCategory === 'all'
+    ? galleries
+    : galleries.filter(g => g.category === activeCategory)
+
+  return (
+    <>
+      {/* View toggle */}
+      <div className={styles.viewToggle}>
+        <button
+          className={`${styles.toggleBtn} ${view === 'photos' ? styles.toggleActive : ''}`}
+          onClick={() => setView('photos')}
+        >
+          All Photos
+        </button>
+        <button
+          className={`${styles.toggleBtn} ${view === 'galleries' ? styles.toggleActive : ''}`}
+          onClick={() => setView('galleries')}
+        >
+          Galleries
+        </button>
+      </div>
+
+      {/* Category filter */}
+      <div className={styles.filterBar}>
+        {CATEGORIES.map(cat => (
+          <button
+            key={cat.value}
+            className={`${styles.filterBtn} ${activeCategory === cat.value ? styles.filterBtnActive : ''}`}
+            onClick={() => setActiveCategory(cat.value)}
+          >
+            {cat.label}
+          </button>
+        ))}
+      </div>
+
+      {/* Photos grid */}
+      {view === 'photos' && (
+        <div className={styles.grid}>
+          {filteredPhotos.length > 0 ? filteredPhotos.map(photo => (
+            <div key={photo._id} className={styles.imageSlot}>
+              <Image
+                src={urlFor(photo.image).width(800).height(600).fit('crop').auto('format').url()}
+                alt={photo.alt ?? photo.title}
+                fill
+                sizes="(max-width: 480px) 100vw, (max-width: 768px) 50vw, 33vw"
+                className={styles.photo}
+              />
+            </div>
+          )) : (
+            <p className={styles.empty}>No photos in this category yet.</p>
+          )}
+        </div>
+      )}
+
+      {/* Galleries grid */}
+      {view === 'galleries' && (
+        <div className={styles.grid}>
+          {filteredGalleries.length > 0 ? filteredGalleries.map(gallery => (
+            <Link
+              key={gallery._id}
+              href={`/portfolio/${gallery.slug.current}`}
+              className={styles.galleryCard}
+            >
+              {gallery.coverImage ? (
+                <Image
+                  src={urlFor(gallery.coverImage.image).width(800).height(600).fit('crop').auto('format').url()}
+                  alt={gallery.coverImage.alt ?? gallery.title}
+                  fill
+                  sizes="(max-width: 480px) 100vw, (max-width: 768px) 50vw, 33vw"
+                  className={styles.photo}
+                />
+              ) : (
+                <div className={styles.nocover} />
+              )}
+              <div className={styles.galleryOverlay}>
+                <span className={styles.galleryTitle}>{gallery.title}</span>
+                <span className={styles.galleryCount}>{gallery.photoCount} photos</span>
+              </div>
+            </Link>
+          )) : (
+            <p className={styles.empty}>No galleries yet.</p>
+          )}
+        </div>
+      )}
+    </>
+  )
+}

--- a/app/portfolio/[slug]/page.module.css
+++ b/app/portfolio/[slug]/page.module.css
@@ -1,0 +1,131 @@
+.main {
+  background: var(--color-bg);
+  min-height: 100vh;
+}
+
+/* ── Hero ─────────────────────────────────────────────────── */
+
+.hero {
+  position: relative;
+  width: 100%;
+  height: 70vh;
+  min-height: 400px;
+  overflow: hidden;
+}
+
+.heroImage {
+  object-fit: cover;
+}
+
+.heroOverlay {
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(to top, rgba(0,0,0,0.65) 0%, rgba(0,0,0,0.1) 60%, transparent 100%);
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-end;
+  padding: 3rem var(--padding-x);
+}
+
+.eyebrow {
+  font-family: var(--font-body);
+  font-size: 0.7rem;
+  letter-spacing: 0.25em;
+  text-transform: uppercase;
+  color: rgba(255,255,255,0.7);
+  margin-bottom: 0.5rem;
+}
+
+.heading {
+  font-family: var(--font-display);
+  font-size: clamp(2.5rem, 6vw, 5rem);
+  font-weight: 400;
+  color: #fff;
+  line-height: 1;
+  margin-bottom: 0.5rem;
+}
+
+.photoCount {
+  font-family: var(--font-body);
+  font-size: 0.7rem;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  color: rgba(255,255,255,0.6);
+}
+
+/* ── Content ──────────────────────────────────────────────── */
+
+.content {
+  max-width: var(--max-width);
+  margin: 0 auto;
+  padding: 3rem var(--padding-x) var(--padding-block);
+}
+
+.back {
+  display: inline-block;
+  font-family: var(--font-body);
+  font-size: 0.7rem;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  color: var(--color-detail);
+  text-decoration: none;
+  margin-bottom: 3rem;
+  transition: color 0.2s ease;
+}
+
+.back:hover {
+  color: var(--color-heading);
+}
+
+/* ── Grid ─────────────────────────────────────────────────── */
+
+.grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 1.5rem;
+}
+
+.imageSlot {
+  position: relative;
+  aspect-ratio: 4 / 3;
+  background: #1a1a1a;
+  overflow: hidden;
+}
+
+.photo {
+  object-fit: cover;
+  transition: transform 0.5s ease;
+}
+
+.imageSlot:hover .photo {
+  transform: scale(1.03);
+}
+
+.empty {
+  font-family: var(--font-body);
+  font-size: 0.8rem;
+  color: var(--color-detail);
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  text-align: center;
+  padding: 4rem 0;
+  opacity: 0.5;
+}
+
+/* ── Responsive ───────────────────────────────────────────── */
+
+@media (max-width: 768px) {
+  .grid {
+    grid-template-columns: repeat(2, 1fr);
+  }
+
+  .hero {
+    height: 50vh;
+  }
+}
+
+@media (max-width: 480px) {
+  .grid {
+    grid-template-columns: 1fr;
+  }
+}

--- a/app/portfolio/[slug]/page.tsx
+++ b/app/portfolio/[slug]/page.tsx
@@ -1,0 +1,83 @@
+import type { Metadata } from 'next'
+import { notFound } from 'next/navigation'
+import Link from 'next/link'
+import Image from 'next/image'
+import { sanityFetch } from '@/sanity/lib/live'
+import { client } from '@/sanity/lib/client'
+import { galleryBySlugQuery, allGallerySlugsQuery } from '@/sanity/queries'
+import { urlFor } from '@/sanity/lib/image'
+import styles from './page.module.css'
+
+type Props = { params: Promise<{ slug: string }> }
+
+export async function generateStaticParams() {
+  const slugs = await client.fetch(allGallerySlugsQuery)
+  return slugs.map(({ slug }: { slug: string }) => ({ slug }))
+}
+
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+  const { slug } = await params
+  const { data: gallery } = await sanityFetch({ query: galleryBySlugQuery, params: { slug } })
+  if (!gallery) return { title: 'Gallery | Tynnell Hollins Photography' }
+  return {
+    title: `${gallery.title} | Tynnell Hollins Photography`,
+    description: `${gallery.title} — a ${gallery.category} session by Tynnell Hollins Photography.`,
+  }
+}
+
+export default async function GalleryPage({ params }: Props) {
+  const { slug } = await params
+  const { data: gallery } = await sanityFetch({ query: galleryBySlugQuery, params: { slug } })
+
+  if (!gallery) notFound()
+
+  const photos = gallery.photos ?? []
+
+  return (
+    <main className={styles.main}>
+      {/* Hero */}
+      {gallery.coverImage && (
+        <div className={styles.hero}>
+          <Image
+            src={urlFor(gallery.coverImage.image).width(1600).height(900).fit('crop').auto('format').url()}
+            alt={gallery.coverImage.alt ?? gallery.title}
+            fill
+            priority
+            className={styles.heroImage}
+            sizes="100vw"
+          />
+          <div className={styles.heroOverlay}>
+            <p className={styles.eyebrow}>{gallery.category}</p>
+            <h1 className={styles.heading}>{gallery.title}</h1>
+            <p className={styles.photoCount}>{photos.length} photos</p>
+          </div>
+        </div>
+      )}
+
+      {/* Back link + grid */}
+      <div className={styles.content}>
+        <Link href="/portfolio" className={styles.back}>
+          ← Back to Portfolio
+        </Link>
+
+        {photos.length > 0 ? (
+          <div className={styles.grid}>
+            {photos.map((photo: { _id: string; image: object; alt: string; title: string }) => (
+              <div key={photo._id} className={styles.imageSlot}>
+                <Image
+                  src={urlFor(photo.image).width(800).height(600).fit('crop').auto('format').url()}
+                  alt={photo.alt ?? photo.title}
+                  fill
+                  sizes="(max-width: 480px) 100vw, (max-width: 768px) 50vw, 33vw"
+                  className={styles.photo}
+                />
+              </div>
+            ))}
+          </div>
+        ) : (
+          <p className={styles.empty}>Photos coming soon.</p>
+        )}
+      </div>
+    </main>
+  )
+}

--- a/app/portfolio/page.module.css
+++ b/app/portfolio/page.module.css
@@ -11,12 +11,22 @@
   margin-bottom: 3rem;
 }
 
+.eyebrow {
+  font-family: var(--font-body);
+  font-size: 0.7rem;
+  letter-spacing: 0.25em;
+  text-transform: uppercase;
+  color: var(--color-detail);
+  margin-bottom: 0.75rem;
+}
+
 .heading {
   font-family: var(--font-display);
   font-size: clamp(3rem, 7vw, 6rem);
-  font-weight: 700;
+  font-weight: 400;
   color: var(--color-heading);
   margin-bottom: 0.5rem;
+  line-height: 1;
 }
 
 .subheading {
@@ -26,6 +36,42 @@
   letter-spacing: 0.15em;
   text-transform: uppercase;
 }
+
+/* ── View toggle ──────────────────────────────────────────── */
+
+.viewToggle {
+  display: flex;
+  justify-content: center;
+  gap: 0;
+  margin-bottom: 2rem;
+  border: 1px solid rgba(214, 209, 206, 0.2);
+  width: fit-content;
+  margin-inline: auto;
+}
+
+.toggleBtn {
+  font-family: var(--font-body);
+  font-size: 0.7rem;
+  letter-spacing: 0.15em;
+  text-transform: uppercase;
+  color: var(--color-detail);
+  background: transparent;
+  border: none;
+  padding: 0.6rem 1.5rem;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.toggleBtn:hover {
+  color: var(--color-heading);
+}
+
+.toggleActive {
+  background: rgba(214, 209, 206, 0.1);
+  color: var(--color-heading);
+}
+
+/* ── Filter bar ───────────────────────────────────────────── */
 
 .filterBar {
   display: flex;
@@ -53,6 +99,14 @@
   border-color: var(--color-heading);
 }
 
+.filterBtnActive {
+  color: var(--color-heading);
+  border-color: var(--color-heading);
+  background: rgba(214, 209, 206, 0.08);
+}
+
+/* ── Grid ─────────────────────────────────────────────────── */
+
 .grid {
   display: grid;
   grid-template-columns: repeat(3, 1fr);
@@ -60,27 +114,96 @@
 }
 
 .imageSlot {
+  position: relative;
   aspect-ratio: 4 / 3;
   background: #1a1a1a;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  border: 1px dashed rgba(214, 209, 206, 0.1);
+  overflow: hidden;
 }
 
-.placeholderLabel {
+.photo {
+  object-fit: cover;
+  transition: transform 0.5s ease;
+}
+
+.imageSlot:hover .photo {
+  transform: scale(1.03);
+}
+
+/* ── Gallery cards ────────────────────────────────────────── */
+
+.galleryCard {
+  position: relative;
+  aspect-ratio: 4 / 3;
+  background: #1a1a1a;
+  overflow: hidden;
+  display: block;
+  text-decoration: none;
+}
+
+.galleryCard:hover .photo {
+  transform: scale(1.03);
+}
+
+.nocover {
+  width: 100%;
+  height: 100%;
+  background: #1a1a1a;
+}
+
+.galleryOverlay {
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(to top, rgba(0,0,0,0.7) 0%, transparent 50%);
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-end;
+  padding: 1.25rem;
+  opacity: 0;
+  transition: opacity 0.3s ease;
+}
+
+.galleryCard:hover .galleryOverlay {
+  opacity: 1;
+}
+
+.galleryTitle {
+  font-family: var(--font-display);
+  font-size: 1.5rem;
+  color: #fff;
+  line-height: 1.1;
+}
+
+.galleryCount {
   font-family: var(--font-body);
-  font-size: 0.7rem;
+  font-size: 0.65rem;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  color: rgba(255,255,255,0.7);
+  margin-top: 0.25rem;
+}
+
+/* ── Empty state ──────────────────────────────────────────── */
+
+.empty {
+  font-family: var(--font-body);
+  font-size: 0.8rem;
   color: var(--color-detail);
   letter-spacing: 0.1em;
   text-transform: uppercase;
-  opacity: 0.4;
+  grid-column: 1 / -1;
+  text-align: center;
+  padding: 4rem 0;
+  opacity: 0.5;
 }
+
+/* ── Responsive ───────────────────────────────────────────── */
 
 @media (max-width: 768px) {
   .grid {
     grid-template-columns: repeat(2, 1fr);
   }
+
+  .gap { gap: 1rem; }
 }
 
 @media (max-width: 480px) {

--- a/app/portfolio/page.tsx
+++ b/app/portfolio/page.tsx
@@ -1,24 +1,28 @@
+import type { Metadata } from 'next'
+import { sanityFetch } from '@/sanity/lib/live'
+import { allPhotosQuery, galleriesQuery } from '@/sanity/queries'
+import PortfolioGrid from './PortfolioGrid'
 import styles from './page.module.css'
 
-export default function PortfolioPage() {
+export const metadata: Metadata = {
+  title: 'Portfolio | Tynnell Hollins Photography',
+  description: 'Browse the full collection — weddings, portraits, families, couples, and more.',
+}
+
+export default async function PortfolioPage() {
+  const [{ data: photos }, { data: galleries }] = await Promise.all([
+    sanityFetch({ query: allPhotosQuery }),
+    sanityFetch({ query: galleriesQuery }),
+  ])
+
   return (
     <main className={styles.main}>
       <div className={styles.header}>
+        <p className={styles.eyebrow}>The Work</p>
         <h1 className={styles.heading}>Portfolio</h1>
-        <p className={styles.subheading}>The full collection</p>
+        <p className={styles.subheading}>Every story, every moment, every face</p>
       </div>
-      <div className={styles.filterBar}>
-        {['All', 'Weddings', 'Portraits', 'Engagements', 'Family', 'Graduation', 'Sports'].map((cat) => (
-          <button key={cat} className={styles.filterBtn}>{cat}</button>
-        ))}
-      </div>
-      <div className={styles.grid}>
-        {Array.from({ length: 12 }).map((_, i) => (
-          <div key={i} className={styles.imageSlot}>
-            <span className={styles.placeholderLabel}>Photo {i + 1}</span>
-          </div>
-        ))}
-      </div>
+      <PortfolioGrid photos={photos ?? []} galleries={galleries ?? []} />
     </main>
   )
 }

--- a/sanity/lib/live.ts
+++ b/sanity/lib/live.ts
@@ -7,4 +7,5 @@ import { client } from './client'
 export const { sanityFetch, SanityLive } = defineLive({
   client,
   serverToken: process.env.SANITY_API_TOKEN,
+  browserToken: false,
 });

--- a/sanity/queries.ts
+++ b/sanity/queries.ts
@@ -28,6 +28,20 @@ export const galleriesQuery = groq`
   }
 `
 
+export const galleryBySlugQuery = groq`
+  *[_type == "gallery" && slug.current == $slug][0] {
+    _id, title, slug, category,
+    coverImage->{ _id, image, alt },
+    photos[]->{ _id, title, alt, image, category }
+  }
+`
+
+export const allGallerySlugsQuery = groq`
+  *[_type == "gallery" && defined(slug.current)] {
+    "slug": slug.current
+  }
+`
+
 // ── Testimonials ──────────────────────────────────────────────
 export const testimonialsQuery = groq`
   *[_type == "testimonial"] | order(order asc) {


### PR DESCRIPTION
## Summary
- Replaces placeholder grid with live Sanity photos
- View toggle: All Photos / Galleries
- Category filter (All, Weddings, Portraits, Families, Couples, Brands) — client-side, instant
- Hover zoom on all images
- Gallery cards show title + photo count on hover
- `/portfolio/[slug]` — cover image hero, full photo grid, back link, generateStaticParams
- Silences browserToken warning in defineLive

## Test plan
- [ ] Visit /portfolio — confirm filter buttons work, empty state shows correctly
- [ ] Add a photo in Sanity Studio, confirm it appears in the grid
- [ ] Create a gallery in Studio, confirm it appears under Galleries view
- [ ] Navigate to /portfolio/[slug] — confirm gallery detail page renders