### PR TITLE
feat: blog pages — cover images, individual post pages with Portable Text

### DIFF
--- a/app/blog/[slug]/page.module.css
+++ b/app/blog/[slug]/page.module.css
@@ -1,0 +1,219 @@
+.main {
+  background: var(--color-bg);
+  min-height: 100vh;
+}
+
+/* ── Header / Hero ────────────────────────────────────────── */
+
+.header {
+  position: relative;
+}
+
+.coverImage {
+  position: relative;
+  width: 100%;
+  height: 65vh;
+  min-height: 380px;
+  overflow: hidden;
+}
+
+.coverPhoto {
+  object-fit: cover;
+}
+
+.coverOverlay {
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(
+    to bottom,
+    rgba(12,12,12,0.3) 0%,
+    rgba(12,12,12,0.1) 40%,
+    rgba(12,12,12,0.7) 100%
+  );
+}
+
+.headerContent {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  padding: 3rem var(--padding-x);
+}
+
+/* When no cover image, headerContent is static */
+.header:not(:has(.coverImage)) .headerContent {
+  position: static;
+  padding-top: calc(var(--padding-block) * 2);
+  padding-bottom: 3rem;
+  border-bottom: 1px solid #1a1a1a;
+  max-width: 860px;
+  margin: 0 auto;
+}
+
+.eyebrow {
+  font-family: var(--font-body);
+  font-size: 0.7rem;
+  letter-spacing: 0.25em;
+  text-transform: uppercase;
+  color: rgba(255,255,255,0.7);
+  margin-bottom: 0.75rem;
+}
+
+.header:not(:has(.coverImage)) .eyebrow {
+  color: var(--color-detail);
+}
+
+.title {
+  font-family: var(--font-display);
+  font-size: clamp(2rem, 5vw, 4rem);
+  font-weight: 400;
+  color: #fff;
+  line-height: 1.1;
+  margin-bottom: 0.75rem;
+}
+
+.header:not(:has(.coverImage)) .title {
+  color: var(--color-heading);
+}
+
+.date {
+  font-family: var(--font-body);
+  font-size: 0.7rem;
+  letter-spacing: 0.15em;
+  text-transform: uppercase;
+  color: rgba(255,255,255,0.6);
+}
+
+.header:not(:has(.coverImage)) .date {
+  color: var(--color-detail);
+}
+
+/* ── Article body ─────────────────────────────────────────── */
+
+.article {
+  max-width: 720px;
+  margin: 0 auto;
+  padding: 4rem var(--padding-x);
+}
+
+.excerpt {
+  font-family: var(--font-body);
+  font-size: 1.1rem;
+  line-height: 1.8;
+  color: var(--color-body);
+  margin-bottom: 2.5rem;
+  padding-bottom: 2.5rem;
+  border-bottom: 1px solid #1a1a1a;
+  font-style: italic;
+}
+
+/* ── Portable Text styles ─────────────────────────────────── */
+
+.body {
+  font-family: var(--font-body);
+  font-size: 1rem;
+  line-height: 1.9;
+  color: var(--color-body);
+}
+
+.body p {
+  margin-bottom: 1.5rem;
+}
+
+.body h2 {
+  font-family: var(--font-display);
+  font-size: clamp(1.5rem, 3vw, 2.5rem);
+  font-weight: 400;
+  color: var(--color-heading);
+  margin: 3rem 0 1rem;
+  line-height: 1.15;
+}
+
+.body h3 {
+  font-family: var(--font-heading);
+  font-size: 1rem;
+  font-weight: 500;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--color-heading);
+  margin: 2.5rem 0 0.75rem;
+}
+
+.body strong {
+  color: var(--color-heading);
+  font-weight: 500;
+}
+
+.body em {
+  font-style: italic;
+  color: var(--color-detail);
+}
+
+.body a {
+  color: var(--color-heading);
+  text-decoration: underline;
+  text-underline-offset: 3px;
+  transition: opacity 0.2s ease;
+}
+
+.body a:hover {
+  opacity: 0.7;
+}
+
+.body ul,
+.body ol {
+  padding-left: 1.5rem;
+  margin-bottom: 1.5rem;
+}
+
+.body li {
+  margin-bottom: 0.5rem;
+}
+
+.body blockquote {
+  border-left: 2px solid var(--color-detail);
+  margin: 2rem 0;
+  padding: 0.5rem 0 0.5rem 1.5rem;
+  font-style: italic;
+  color: var(--color-detail);
+}
+
+/* ── Footer ───────────────────────────────────────────────── */
+
+.footer {
+  max-width: 720px;
+  margin: 0 auto;
+  padding: 0 var(--padding-x) 6rem;
+  border-top: 1px solid #1a1a1a;
+  padding-top: 2.5rem;
+}
+
+.back {
+  font-family: var(--font-body);
+  font-size: 0.7rem;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  color: var(--color-detail);
+  text-decoration: none;
+  transition: color 0.2s ease;
+}
+
+.back:hover {
+  color: var(--color-heading);
+}
+
+/* ── Responsive ───────────────────────────────────────────── */
+
+@media (max-width: 768px) {
+  .coverImage {
+    height: 45vh;
+  }
+
+  .headerContent {
+    padding: 2rem var(--padding-x);
+  }
+
+  .article {
+    padding: 2.5rem var(--padding-x);
+  }
+}

--- a/app/blog/[slug]/page.tsx
+++ b/app/blog/[slug]/page.tsx
@@ -1,0 +1,83 @@
+import type { Metadata } from 'next'
+import { notFound } from 'next/navigation'
+import Link from 'next/link'
+import Image from 'next/image'
+import { PortableText } from '@portabletext/react'
+import { sanityFetch } from '@/sanity/lib/live'
+import { client } from '@/sanity/lib/client'
+import { postBySlugQuery, postsQuery } from '@/sanity/queries'
+import { urlFor } from '@/sanity/lib/image'
+import styles from './page.module.css'
+
+type Props = { params: Promise<{ slug: string }> }
+
+export async function generateStaticParams() {
+  const posts = await client.fetch(postsQuery)
+  return posts.map(({ slug }: { slug: { current: string } }) => ({
+    slug: slug.current,
+  }))
+}
+
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+  const { slug } = await params
+  const { data: post } = await sanityFetch({ query: postBySlugQuery, params: { slug } })
+  if (!post) return { title: 'Post | Tynnell Hollins Photography' }
+  return {
+    title: `${post.title} | Tynnell Hollins Photography`,
+    description: post.excerpt ?? undefined,
+  }
+}
+
+export default async function BlogPostPage({ params }: Props) {
+  const { slug } = await params
+  const { data: post } = await sanityFetch({ query: postBySlugQuery, params: { slug } })
+
+  if (!post) notFound()
+
+  return (
+    <main className={styles.main}>
+
+      {/* ── Hero ─────────────────────────────────────────────── */}
+      <header className={styles.header}>
+        {post.coverImage && (
+          <div className={styles.coverImage}>
+            <Image
+              src={urlFor(post.coverImage.image).width(1600).height(800).fit('crop').auto('format').url()}
+              alt={post.coverImage.alt ?? post.title}
+              fill
+              priority
+              sizes="100vw"
+              className={styles.coverPhoto}
+            />
+            <div className={styles.coverOverlay} />
+          </div>
+        )}
+        <div className={styles.headerContent}>
+          <p className={styles.eyebrow}>Journal</p>
+          <h1 className={styles.title}>{post.title}</h1>
+          <p className={styles.date}>
+            {new Date(post.publishedAt).toLocaleDateString('en-US', {
+              year: 'numeric', month: 'long', day: 'numeric',
+            })}
+          </p>
+        </div>
+      </header>
+
+      {/* ── Body ─────────────────────────────────────────────── */}
+      <article className={styles.article}>
+        {post.excerpt && <p className={styles.excerpt}>{post.excerpt}</p>}
+        {post.body && (
+          <div className={styles.body}>
+            <PortableText value={post.body} />
+          </div>
+        )}
+      </article>
+
+      {/* ── Back link ────────────────────────────────────────── */}
+      <div className={styles.footer}>
+        <Link href="/blog" className={styles.back}>← Back to Journal</Link>
+      </div>
+
+    </main>
+  )
+}

--- a/app/blog/page.module.css
+++ b/app/blog/page.module.css
@@ -44,12 +44,39 @@
 }
 
 .card {
-  padding: 3rem 2.5rem;
   border-right: 1px solid #1a1a1a;
   border-bottom: 1px solid #1a1a1a;
   display: flex;
   flex-direction: column;
+}
+
+.cardImageLink {
+  display: block;
+  overflow: hidden;
+}
+
+.cardImage {
+  position: relative;
+  aspect-ratio: 3 / 2;
+  overflow: hidden;
+  background: #1a1a1a;
+}
+
+.cardPhoto {
+  object-fit: cover;
+  transition: transform 0.5s ease;
+}
+
+.cardImageLink:hover .cardPhoto {
+  transform: scale(1.03);
+}
+
+.cardBody {
+  padding: 2rem 2.5rem 3rem;
+  display: flex;
+  flex-direction: column;
   gap: 0.75rem;
+  flex: 1;
 }
 
 .cardCategory {

--- a/app/blog/page.tsx
+++ b/app/blog/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from 'next'
 import Link from 'next/link'
 import Image from 'next/image'
+import type { SanityImageSource } from '@sanity/image-url/lib/types/types'
 import { sanityFetch } from '@/sanity/lib/live'
 import { postsQuery } from '@/sanity/queries'
 import { urlFor } from '@/sanity/lib/image'
@@ -12,7 +13,7 @@ type PostSummary = {
   slug: { current: string }
   publishedAt: string
   excerpt?: string
-  coverImage?: { image: unknown; alt?: string }
+  coverImage?: { image: SanityImageSource; alt?: string }
 }
 
 export const metadata: Metadata = {

--- a/app/blog/page.tsx
+++ b/app/blog/page.tsx
@@ -6,6 +6,15 @@ import { postsQuery } from '@/sanity/queries'
 import { urlFor } from '@/sanity/lib/image'
 import styles from './page.module.css'
 
+type PostSummary = {
+  _id: string
+  title: string
+  slug: { current: string }
+  publishedAt: string
+  excerpt?: string
+  coverImage?: { image: unknown; alt?: string }
+}
+
 export const metadata: Metadata = {
   title: 'Blog | Tynnell Hollins Photography',
   description: 'Photography tips, session guides, and stories from behind the lens by Tynnell Hollins.',
@@ -25,7 +34,7 @@ export default async function BlogPage() {
 
       {/* ── Posts grid ───────────────────────────────────────── */}
       <section className={styles.grid} aria-label="Blog posts">
-        {posts && posts.length > 0 ? posts.map((post) => (
+        {posts && posts.length > 0 ? (posts as PostSummary[]).map((post) => (
           <article key={post._id} className={styles.card}>
             {post.coverImage && (
               <Link href={`/blog/${post.slug.current}`} className={styles.cardImageLink} tabIndex={-1} aria-hidden="true">

--- a/app/blog/page.tsx
+++ b/app/blog/page.tsx
@@ -1,7 +1,9 @@
 import type { Metadata } from 'next'
 import Link from 'next/link'
-import { client } from '@/sanity/lib/client'
+import Image from 'next/image'
+import { sanityFetch } from '@/sanity/lib/live'
 import { postsQuery } from '@/sanity/queries'
+import { urlFor } from '@/sanity/lib/image'
 import styles from './page.module.css'
 
 export const metadata: Metadata = {
@@ -9,19 +11,8 @@ export const metadata: Metadata = {
   description: 'Photography tips, session guides, and stories from behind the lens by Tynnell Hollins.',
 }
 
-export const revalidate = 60
-
-interface SanityPost {
-  _id: string
-  title: string
-  slug: { current: string }
-  publishedAt: string
-  excerpt?: string
-  coverImage?: { image: { asset: { _ref: string } }; alt: string }
-}
-
 export default async function BlogPage() {
-  const posts: SanityPost[] = await client.fetch(postsQuery)
+  const { data: posts } = await sanityFetch({ query: postsQuery })
 
   return (
     <main className={styles.main}>
@@ -34,22 +25,41 @@ export default async function BlogPage() {
 
       {/* ── Posts grid ───────────────────────────────────────── */}
       <section className={styles.grid} aria-label="Blog posts">
-        {posts.length > 0 ? posts.map((post) => (
+        {posts && posts.length > 0 ? posts.map((post) => (
           <article key={post._id} className={styles.card}>
-            <h2 className={styles.cardTitle}>
-              <Link href={`/blog/${post.slug.current}`} className={styles.cardLink}>
-                {post.title}
+            {post.coverImage && (
+              <Link href={`/blog/${post.slug.current}`} className={styles.cardImageLink} tabIndex={-1} aria-hidden="true">
+                <div className={styles.cardImage}>
+                  <Image
+                    src={urlFor(post.coverImage.image).width(600).height(400).fit('crop').auto('format').url()}
+                    alt={post.coverImage.alt ?? post.title}
+                    fill
+                    sizes="(max-width: 768px) 100vw, 33vw"
+                    className={styles.cardPhoto}
+                  />
+                </div>
               </Link>
-            </h2>
-            <p className={styles.cardDate}>
-              {new Date(post.publishedAt).toLocaleDateString('en-US', {
-                year: 'numeric', month: 'long', day: 'numeric',
-              })}
-            </p>
-            {post.excerpt && <p className={styles.cardExcerpt}>{post.excerpt}</p>}
-            <Link href={`/blog/${post.slug.current}`} className={styles.readMore} aria-label={`Read: ${post.title}`}>
-              Read More
-            </Link>
+            )}
+            <div className={styles.cardBody}>
+              <p className={styles.cardDate}>
+                {new Date(post.publishedAt).toLocaleDateString('en-US', {
+                  year: 'numeric', month: 'long', day: 'numeric',
+                })}
+              </p>
+              <h2 className={styles.cardTitle}>
+                <Link href={`/blog/${post.slug.current}`} className={styles.cardLink}>
+                  {post.title}
+                </Link>
+              </h2>
+              {post.excerpt && <p className={styles.cardExcerpt}>{post.excerpt}</p>}
+              <Link
+                href={`/blog/${post.slug.current}`}
+                className={styles.readMore}
+                aria-label={`Read: ${post.title}`}
+              >
+                Read More →
+              </Link>
+            </div>
           </article>
         )) : (
           <p className={styles.emptyState}>

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "tynnell-hollins-photography",
       "version": "0.1.0",
       "dependencies": {
+        "@portabletext/react": "^6.0.3",
         "@sanity/image-url": "^1.2.0",
         "@sanity/vision": "^4.22.0",
         "next": "14.2.35",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "@portabletext/react": "^6.0.3",
     "@sanity/image-url": "^1.2.0",
     "@sanity/vision": "^4.22.0",
     "next": "14.2.35",


### PR DESCRIPTION
## Summary
- Blog list updated to use sanityFetch + cover images with hover zoom
- `/blog/[slug]` — cover image hero (65vh), excerpt pull quote, full Portable Text body
- Portable Text styled: h2, h3, p, blockquote, ul, a, strong, em
- Graceful fallback when no cover image
- generateStaticParams for static generation
- Installs @portabletext/react

## Test plan
- [ ] Visit /blog — confirm empty state shows correctly
- [ ] Add a blog post in Studio, confirm it appears on the list
- [ ] Click through to post — confirm Portable Text renders correctly
- [ ] Verify no-cover-image fallback works