### PR TITLE
feat: about page — Sanity wiring, headshot, bio, values

### DIFF
--- a/app/about/page.module.css
+++ b/app/about/page.module.css
@@ -43,12 +43,18 @@
 }
 
 .storyImage {
+  position: relative;
   aspect-ratio: 3 / 4;
   background: var(--color-bg-accent);
   border: 1px solid #1e1e1e;
   display: flex;
   align-items: center;
   justify-content: center;
+  overflow: hidden;
+}
+
+.headshotImg {
+  object-fit: cover;
 }
 
 .placeholderLabel {
@@ -91,6 +97,33 @@
   line-height: 1.85;
   color: var(--color-body);
   margin: 0;
+}
+
+/* Portable Text bio from Sanity */
+.bioBody {
+  font-family: var(--font-mono);
+  font-size: 0.8rem;
+  font-weight: 300;
+  line-height: 1.85;
+  color: var(--color-body);
+}
+
+.bioBody p {
+  margin: 0 0 1.25rem;
+}
+
+.bioBody p:last-child {
+  margin-bottom: 0;
+}
+
+.bioBody strong {
+  font-weight: 500;
+  color: var(--color-heading);
+}
+
+.bioBody em {
+  font-style: italic;
+  color: var(--color-detail);
 }
 
 /* ── Philosophy ───────────────────────────────────────────── */

--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from 'next'
 import Link from 'next/link'
 import Image from 'next/image'
 import { PortableText } from '@portabletext/react'
+import type { PortableTextBlock } from '@portabletext/types'
 import type { SanityImageSource } from '@sanity/image-url/lib/types/types'
 import { sanityFetch } from '@/sanity/lib/live'
 import { aboutPageQuery } from '@/sanity/queries'
@@ -17,7 +18,7 @@ type AboutPage = {
   headshot?: SanityImageSource
   headshotAlt?: string
   tagline?: string
-  bio?: unknown[]
+  bio?: PortableTextBlock[]
   values?: string[]
 }
 

--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -1,5 +1,11 @@
 import type { Metadata } from 'next'
 import Link from 'next/link'
+import Image from 'next/image'
+import { PortableText } from '@portabletext/react'
+import type { SanityImageSource } from '@sanity/image-url/lib/types/types'
+import { sanityFetch } from '@/sanity/lib/live'
+import { aboutPageQuery } from '@/sanity/queries'
+import { urlFor } from '@/sanity/lib/image'
 import styles from './page.module.css'
 
 export const metadata: Metadata = {
@@ -7,7 +13,32 @@ export const metadata: Metadata = {
   description: 'Meet Tynnell Hollins — New Mexico photographer specializing in weddings, engagements, portraits, and family sessions.',
 }
 
-export default function AboutPage() {
+type AboutPage = {
+  headshot?: SanityImageSource
+  headshotAlt?: string
+  tagline?: string
+  bio?: unknown[]
+  values?: string[]
+}
+
+const DEFAULT_SPECIALTIES = [
+  'Weddings',
+  'Engagements',
+  'Portraits',
+  'Family Sessions',
+  'Maternity',
+  'Events',
+]
+
+export default async function AboutPage() {
+  const { data: about } = await sanityFetch({ query: aboutPageQuery }) as { data: AboutPage | null }
+
+  const headshotUrl = about?.headshot
+    ? urlFor(about.headshot).width(800).height(1000).fit('crop').auto('format').url()
+    : null
+
+  const specialties = about?.values?.length ? about.values : DEFAULT_SPECIALTIES
+
   return (
     <main className={styles.main}>
 
@@ -22,24 +53,42 @@ export default function AboutPage() {
       {/* ── Story ────────────────────────────────────────────── */}
       <section className={styles.story}>
         <div className={styles.storyImage}>
-          <span className={styles.placeholderLabel}>Photographer portrait</span>
+          {headshotUrl ? (
+            <Image
+              src={headshotUrl}
+              alt={about?.headshotAlt ?? 'Tynnell Hollins'}
+              fill
+              sizes="(max-width: 768px) 100vw, 50vw"
+              className={styles.headshotImg}
+            />
+          ) : (
+            <span className={styles.placeholderLabel}>Photographer portrait</span>
+          )}
         </div>
         <div className={styles.storyContent}>
           <p className={styles.sectionEyebrow}>My Story</p>
           <h2 className={styles.sectionHeading}>Where It All Began</h2>
-          <p className={styles.bodyText}>
-            Based in New Mexico, Tynnell Hollins has spent years learning to
-            see the world the way a camera does — not just the posed, polished
-            moments, but the ones in between. The glance across the aisle.
-            The way a parent holds their child like they never want to let go.
-          </p>
-          <p className={styles.bodyText}>
-            Photography found Tynnell before she found it. What started as a
-            curiosity became a calling — a way to slow time down and give
-            people something permanent to hold onto. Every session is
-            approached with the same quiet intention: to be present, to
-            listen, and to let the moment lead.
-          </p>
+          {about?.bio ? (
+            <div className={styles.bioBody}>
+              <PortableText value={about.bio} />
+            </div>
+          ) : (
+            <>
+              <p className={styles.bodyText}>
+                Based in New Mexico, Tynnell Hollins has spent years learning to
+                see the world the way a camera does. Not just the posed, polished
+                moments, but the ones in between. The glance across the aisle.
+                The way a parent holds their child like they never want to let go.
+              </p>
+              <p className={styles.bodyText}>
+                Photography found Tynnell before she found it. What started as a
+                curiosity became a calling. A way to slow time down and give
+                people something permanent to hold onto. Every session is
+                approached with the same quiet intention: to be present, to
+                listen, and to let the moment lead.
+              </p>
+            </>
+          )}
         </div>
       </section>
 
@@ -47,15 +96,11 @@ export default function AboutPage() {
       <section className={styles.philosophy}>
         <p className={styles.sectionEyebrow}>My Approach</p>
         <blockquote className={styles.philosophyQuote}>
-          I don&apos;t just take photographs. I preserve the in-between
-          moments &mdash; the laugh before the kiss, the tear that falls
-          before you even know it&apos;s there.
+          {about?.tagline ??
+            "I don\u2019t just take photographs. I preserve the in-between moments. The laugh before the kiss. The tear that falls before you even know it\u2019s there."}
         </blockquote>
         <p className={styles.philosophyBody}>
-          Whether it&apos;s a wedding of three hundred or an intimate session
-          for two, the goal is always the same: images that feel like a
-          memory rather than a photograph. Warm, honest, and undeniably
-          yours.
+          {"Whether it\u2019s a wedding of three hundred or an intimate session for two, the goal is always the same: images that feel like a memory rather than a photograph. Warm, honest, and undeniably yours."}
         </p>
       </section>
 
@@ -63,17 +108,10 @@ export default function AboutPage() {
       <section className={styles.specialties}>
         <p className={styles.sectionEyebrow}>What I Shoot</p>
         <h2 className={styles.sectionHeading}>
-          Capturing Life&apos;s Most<br />Meaningful Moments
+          {"Capturing Life\u2019s Most"}<br />Meaningful Moments
         </h2>
         <ul className={styles.specialtyList}>
-          {[
-            'Weddings',
-            'Engagements',
-            'Portraits',
-            'Family Sessions',
-            'Maternity',
-            'Events',
-          ].map((item) => (
+          {specialties.map((item) => (
             <li key={item} className={styles.specialtyItem}>
               <span className={styles.specialtyDot} aria-hidden="true" />
               {item}
@@ -84,13 +122,12 @@ export default function AboutPage() {
 
       {/* ── CTA ──────────────────────────────────────────────── */}
       <section className={styles.cta}>
-        <p className={styles.sectionEyebrow}>Let&apos;s Work Together</p>
+        <p className={styles.sectionEyebrow}>{"Let\u2019s Work Together"}</p>
         <h2 className={styles.ctaHeading}>
           Ready to Create<br />Something Beautiful?
         </h2>
         <p className={styles.ctaBody}>
-          I&apos;d love to hear about your story and how I can help you
-          preserve it.
+          {"I\u2019d love to hear about your story and how I can help you preserve it."}
         </p>
         <Link href="/contact" className={styles.ctaBtn}>Book a Session</Link>
       </section>

--- a/app/components/AboutPreview/AboutPreview.tsx
+++ b/app/components/AboutPreview/AboutPreview.tsx
@@ -39,7 +39,7 @@ export default function AboutPreview({ about }: Props) {
         <h2 className={styles.heading}>Every Moment Deserves to Last Forever</h2>
         <p className={styles.body}>
           {about?.previewBio ??
-            'Based in New Mexico, Tynnell Hollins is a photographer who believes the best images are the ones that feel like a memory — warm, honest, and full of life. From weddings to family portraits, she brings the same quiet attention to every shoot.'}
+            'Based in New Mexico, Tynnell Hollins is a photographer who believes the best images are the ones that feel like a memory. Warm, honest, and full of life. From weddings to family portraits, she brings the same quiet attention to every shoot.'}
         </p>
         <Link href="/about" className={styles.cta}>Meet Tynnell</Link>
       </div>


### PR DESCRIPTION
Wires about page to Sanity CMS. Headshot renders from Studio upload, bio renders as Portable Text with fallback copy, tagline drives philosophy quote, values array drives specialties list. Also fixes em dash in AboutPreview fallback copy.