### PR TITLE
feat(TYN-14): restructure Studio sidebar with Upload Photos parent section

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,4 +1,13 @@
 /** @type {import('next').NextConfig} */
-const nextConfig = {};
+const nextConfig = {
+  images: {
+    remotePatterns: [
+      {
+        protocol: 'https',
+        hostname: 'cdn.sanity.io',
+      },
+    ],
+  },
+};
 
 export default nextConfig;

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "react-dom": "^18",
         "resend": "^6.9.3",
         "sanity": "^4.22.0",
+        "sanity-plugin-media": "^4.2.0",
         "stripe": "^20.4.1",
         "styled-components": "^6.3.11",
         "swiper": "^12.1.2"
@@ -2357,6 +2358,71 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@emotion/babel-plugin": {
+      "version": "11.13.5",
+      "resolved": "https://registry.npmjs.org/@emotion/babel-plugin/-/babel-plugin-11.13.5.tgz",
+      "integrity": "sha512-pxHCpT2ex+0q+HH91/zsdHkw/lXd468DIN2zvfvLtPKLLMo6gQj7oLObq8PhkrxOZb/gGCq03S3Z7PDhS8pduQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.16.7",
+        "@babel/runtime": "^7.18.3",
+        "@emotion/hash": "^0.9.2",
+        "@emotion/memoize": "^0.9.0",
+        "@emotion/serialize": "^1.3.3",
+        "babel-plugin-macros": "^3.1.0",
+        "convert-source-map": "^1.5.0",
+        "escape-string-regexp": "^4.0.0",
+        "find-root": "^1.1.0",
+        "source-map": "^0.5.7",
+        "stylis": "4.2.0"
+      }
+    },
+    "node_modules/@emotion/babel-plugin/node_modules/convert-source-map": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.9.0.tgz",
+      "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==",
+      "license": "MIT"
+    },
+    "node_modules/@emotion/babel-plugin/node_modules/source-map": {
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+      "integrity": "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/@emotion/babel-plugin/node_modules/stylis": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.2.0.tgz",
+      "integrity": "sha512-Orov6g6BB1sDfYgzWfTHDOxamtX1bE/zo104Dh9e6fqJ3PooipYyfJ0pUmrZO2wAvO8YbEyeFrkV91XTsGMSrw==",
+      "license": "MIT"
+    },
+    "node_modules/@emotion/cache": {
+      "version": "11.14.0",
+      "resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-11.14.0.tgz",
+      "integrity": "sha512-L/B1lc/TViYk4DcpGxtAVbx0ZyiKM5ktoIyafGkH6zg/tj+mA+NE//aPYKG0k8kCHSHVJrpLpcAlOBEXQ3SavA==",
+      "license": "MIT",
+      "dependencies": {
+        "@emotion/memoize": "^0.9.0",
+        "@emotion/sheet": "^1.4.0",
+        "@emotion/utils": "^1.4.2",
+        "@emotion/weak-memoize": "^0.4.0",
+        "stylis": "4.2.0"
+      }
+    },
+    "node_modules/@emotion/cache/node_modules/stylis": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.2.0.tgz",
+      "integrity": "sha512-Orov6g6BB1sDfYgzWfTHDOxamtX1bE/zo104Dh9e6fqJ3PooipYyfJ0pUmrZO2wAvO8YbEyeFrkV91XTsGMSrw==",
+      "license": "MIT"
+    },
+    "node_modules/@emotion/hash": {
+      "version": "0.9.2",
+      "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.9.2.tgz",
+      "integrity": "sha512-MyqliTZGuOm3+5ZRSaaBGP3USLw6+EGykkwZns2EPC5g8jJ4z9OrdZY9apkl3+UP9+sdz76YYkwCKP5gh8iY3g==",
+      "license": "MIT"
+    },
     "node_modules/@emotion/is-prop-valid": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-1.4.0.tgz",
@@ -2372,10 +2438,74 @@
       "integrity": "sha512-30FAj7/EoJ5mwVPOWhAyCX+FPfMDrVecJAM+Iw9NRoSl4BBAQeqj4cApHHUXOVvIPgLVDsCFoz/hGD+5QQD1GQ==",
       "license": "MIT"
     },
+    "node_modules/@emotion/react": {
+      "version": "11.14.0",
+      "resolved": "https://registry.npmjs.org/@emotion/react/-/react-11.14.0.tgz",
+      "integrity": "sha512-O000MLDBDdk/EohJPFUqvnp4qnHeYkVP5B0xEG0D/L7cOKP9kefu2DXn8dj74cQfsEzUqh+sr1RzFqiL1o+PpA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.18.3",
+        "@emotion/babel-plugin": "^11.13.5",
+        "@emotion/cache": "^11.14.0",
+        "@emotion/serialize": "^1.3.3",
+        "@emotion/use-insertion-effect-with-fallbacks": "^1.2.0",
+        "@emotion/utils": "^1.4.2",
+        "@emotion/weak-memoize": "^0.4.0",
+        "hoist-non-react-statics": "^3.3.1"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@emotion/serialize": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@emotion/serialize/-/serialize-1.3.3.tgz",
+      "integrity": "sha512-EISGqt7sSNWHGI76hC7x1CksiXPahbxEOrC5RjmFRJTqLyEK9/9hZvBbiYn70dw4wuwMKiEMCUlR6ZXTSWQqxA==",
+      "license": "MIT",
+      "dependencies": {
+        "@emotion/hash": "^0.9.2",
+        "@emotion/memoize": "^0.9.0",
+        "@emotion/unitless": "^0.10.0",
+        "@emotion/utils": "^1.4.2",
+        "csstype": "^3.0.2"
+      }
+    },
+    "node_modules/@emotion/sheet": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@emotion/sheet/-/sheet-1.4.0.tgz",
+      "integrity": "sha512-fTBW9/8r2w3dXWYM4HCB1Rdp8NLibOw2+XELH5m5+AkWiL/KqYX6dc0kKYlaYyKjrQ6ds33MCdMPEwgs2z1rqg==",
+      "license": "MIT"
+    },
     "node_modules/@emotion/unitless": {
       "version": "0.10.0",
       "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.10.0.tgz",
       "integrity": "sha512-dFoMUuQA20zvtVTuxZww6OHoJYgrzfKM1t52mVySDJnMSEa08ruEvdYQbhvyu6soU+NeLVd3yKfTfT0NeV6qGg==",
+      "license": "MIT"
+    },
+    "node_modules/@emotion/use-insertion-effect-with-fallbacks": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@emotion/use-insertion-effect-with-fallbacks/-/use-insertion-effect-with-fallbacks-1.2.0.tgz",
+      "integrity": "sha512-yJMtVdH59sxi/aVJBpk9FQq+OR8ll5GT8oWd57UpeaKEVGab41JWaCFA7FRLoMLloOZF/c/wsPoe+bfGmRKgDg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@emotion/utils": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-1.4.2.tgz",
+      "integrity": "sha512-3vLclRofFziIa3J2wDh9jjbkUz9qk5Vi3IZ/FSTKViB0k+ef0fPV7dYrUIugbgupYDx7v9ud/SjrtEP8Y4xLoA==",
+      "license": "MIT"
+    },
+    "node_modules/@emotion/weak-memoize": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@emotion/weak-memoize/-/weak-memoize-0.4.0.tgz",
+      "integrity": "sha512-snKqtPW01tN0ui7yu9rGv69aJXr/a/Ywvl11sUjNtEcRc+ng/mQriFL0wLXMef74iHa/EkftbDzU9F8iFbH+zg==",
       "license": "MIT"
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -2894,6 +3024,15 @@
       "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.11.tgz",
       "integrity": "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==",
       "license": "MIT"
+    },
+    "node_modules/@hookform/resolvers": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/@hookform/resolvers/-/resolvers-3.10.0.tgz",
+      "integrity": "sha512-79Dv+3mDF7i+2ajj7SkypSKHhl1cbln1OGavqrsF7p6mbUv11xpqpacPsGDCTRvCSjEEIez2ef1NveSVL3b0Ag==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react-hook-form": "^7.0.0"
+      }
     },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.13.0",
@@ -4299,6 +4438,32 @@
         "node": ">=20.19 <22 || >=22.12"
       }
     },
+    "node_modules/@reduxjs/toolkit": {
+      "version": "2.11.2",
+      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-2.11.2.tgz",
+      "integrity": "sha512-Kd6kAHTA6/nUpp8mySPqj3en3dm0tdMIgbttnQ1xFMVpufoj+ADi8pXLBsd4xzTRHQa7t/Jv8W5UnCuW4kuWMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.0.0",
+        "@standard-schema/utils": "^0.3.0",
+        "immer": "^11.0.0",
+        "redux": "^5.0.1",
+        "redux-thunk": "^3.1.0",
+        "reselect": "^5.1.0"
+      },
+      "peerDependencies": {
+        "react": "^16.9.0 || ^17.0.0 || ^18 || ^19",
+        "react-redux": "^7.2.1 || ^8.1.3 || ^9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-redux": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@rexxars/react-json-inspector": {
       "version": "9.0.1",
       "resolved": "https://registry.npmjs.org/@rexxars/react-json-inspector/-/react-json-inspector-9.0.1.tgz",
@@ -5129,6 +5294,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@sanity/incompatible-plugin": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@sanity/incompatible-plugin/-/incompatible-plugin-1.0.5.tgz",
+      "integrity": "sha512-9JGAacbElUPy9Chghd+sllIiM3jAcraZdD65bWYWUVKkghOsf1L/+jFLz1rcAuvrA9o2s7Y+T75BNcXuLwRcvw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.9 || ^17 || ^18 || ^19",
+        "react-dom": "^16.9 || ^17 || ^18 || ^19"
       }
     },
     "node_modules/@sanity/insert-menu": {
@@ -6167,6 +6342,18 @@
       "integrity": "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==",
       "license": "MIT"
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/utils": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
+      "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
+      "license": "MIT"
+    },
     "node_modules/@swc/counter": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/@swc/counter/-/counter-0.1.3.tgz",
@@ -6181,6 +6368,20 @@
       "dependencies": {
         "@swc/counter": "^0.1.3",
         "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tanem/react-nprogress": {
+      "version": "5.0.63",
+      "resolved": "https://registry.npmjs.org/@tanem/react-nprogress/-/react-nprogress-5.0.63.tgz",
+      "integrity": "sha512-bWkOhMBvwAe8GlqgkXdAyAeUDtWv7NknoDnlZXdVJb8M/1tP+JcsHq/xc3zUTQ0jcT3AT0uSB7Hlt27lJMHtDQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.28.6",
+        "hoist-non-react-statics": "^3.3.2"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/@tanstack/react-table": {
@@ -6359,6 +6560,12 @@
       "integrity": "sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==",
       "license": "MIT"
     },
+    "node_modules/@types/parse-json": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.2.tgz",
+      "integrity": "sha512-dISoDXWWQwUquiKsyZ4Ng+HX2KsPL7LyHKHQwgGFEA3IaKac4Obd+h2a/a6waisAoepJlBcx9paWqjA8/HVjCw==",
+      "license": "MIT"
+    },
     "node_modules/@types/prismjs": {
       "version": "1.26.6",
       "resolved": "https://registry.npmjs.org/@types/prismjs/-/prismjs-1.26.6.tgz",
@@ -6397,6 +6604,15 @@
       "integrity": "sha512-NP2xtcjZfORsOa4g2JwdseyEnF+wUCx25fTdG/J/HIY6yKga6+NozRBg2xR2gyh7kKYyd6DXndbq0YbQuTJ7Ew==",
       "license": "MIT",
       "dependencies": {
+        "@types/react": "*"
+      }
+    },
+    "node_modules/@types/react-transition-group": {
+      "version": "4.4.12",
+      "resolved": "https://registry.npmjs.org/@types/react-transition-group/-/react-transition-group-4.4.12.tgz",
+      "integrity": "sha512-8TV6R3h2j7a91c+1DXdJi3Syo69zzIZbz7Lg5tORM5LEJG7X/E6a1V3drRyBRZq7/utz7A+c4OgYLiLcYGHG6w==",
+      "license": "MIT",
+      "peerDependencies": {
         "@types/react": "*"
       }
     },
@@ -7646,6 +7862,15 @@
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
       "license": "MIT"
     },
+    "node_modules/attr-accept": {
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/attr-accept/-/attr-accept-2.2.5.tgz",
+      "integrity": "sha512-0bDNnY/u6pPwHDMoF0FieU354oBi0a8rD9FcsLwzcGWbc8KS8KPIi7y+s13OlVY+gMWc/9xEMUgNE6Qm8ZllYQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/available-typed-arrays": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
@@ -7700,6 +7925,21 @@
         "react-native-b4a": {
           "optional": true
         }
+      }
+    },
+    "node_modules/babel-plugin-macros": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-macros/-/babel-plugin-macros-3.1.0.tgz",
+      "integrity": "sha512-Cg7TFGpIr01vOQNODXOOaGz2NpCU5gl8x1qJFbb6hbZxR7XrcE2vtbAsTAbJ7/xwJtUuJEw8K8Zr/AE0LHlesg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5",
+        "cosmiconfig": "^7.0.0",
+        "resolve": "^1.19.0"
+      },
+      "engines": {
+        "node": ">=10",
+        "npm": ">=6"
       }
     },
     "node_modules/babel-plugin-polyfill-corejs2": {
@@ -8462,6 +8702,12 @@
       "integrity": "sha512-zW190nQTIoXcGCaU08DvVNFTmQhUpnJfVuAKfWqUQkflXKpaDdpaYoM0iluLS9lgJNHyBF58KKA2FBEwkD7wog==",
       "license": "MIT"
     },
+    "node_modules/colord": {
+      "version": "2.9.3",
+      "resolved": "https://registry.npmjs.org/colord/-/colord-2.9.3.tgz",
+      "integrity": "sha512-jeC1axXpnb0/2nn/Y1LPuLdgXBLH7aDcHu4KEKfqw3CUhX7ZpfBSlPKyqXE6btIgEzfWtrX3/tyBCaCvXvMkOw==",
+      "license": "MIT"
+    },
     "node_modules/combined-stream": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
@@ -8623,6 +8869,15 @@
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "license": "MIT"
     },
+    "node_modules/copy-to-clipboard": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/copy-to-clipboard/-/copy-to-clipboard-3.3.3.tgz",
+      "integrity": "sha512-2KV8NhB5JqC3ky0r9PMCAZKbUHSwtEo4CwCs0KXgruG43gX5PMqDEBbVU4OUzw2MuAWUfsuFmWvEKG5QRfSnJA==",
+      "license": "MIT",
+      "dependencies": {
+        "toggle-selection": "^1.0.6"
+      }
+    },
     "node_modules/core-js-compat": {
       "version": "3.48.0",
       "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.48.0.tgz",
@@ -8641,6 +8896,31 @@
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
       "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
       "license": "MIT"
+    },
+    "node_modules/cosmiconfig": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.1.0.tgz",
+      "integrity": "sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/parse-json": "^4.0.0",
+        "import-fresh": "^3.2.1",
+        "parse-json": "^5.0.0",
+        "path-type": "^4.0.0",
+        "yaml": "^1.10.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/cosmiconfig/node_modules/yaml": {
+      "version": "1.10.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.3.tgz",
+      "integrity": "sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 6"
+      }
     },
     "node_modules/crc-32": {
       "version": "1.2.2",
@@ -9113,6 +9393,16 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/dom-helpers": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-5.2.1.tgz",
+      "integrity": "sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.8.7",
+        "csstype": "^3.0.2"
       }
     },
     "node_modules/dom-serializer": {
@@ -10243,6 +10533,18 @@
         "node": "^10.12.0 || >=12.0.0"
       }
     },
+    "node_modules/file-selector": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/file-selector/-/file-selector-0.4.0.tgz",
+      "integrity": "sha512-iACCiXeMYOvZqlF1kTiYINzgepRBymz1wwjiuup9u9nayhb6g4fSwiyJ/6adli+EPwrWtpgQAh2PoS7HukEGEg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
     "node_modules/file-uri-to-path": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
@@ -10286,6 +10588,15 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/filesize": {
+      "version": "9.0.11",
+      "resolved": "https://registry.npmjs.org/filesize/-/filesize-9.0.11.tgz",
+      "integrity": "sha512-gTAiTtI0STpKa5xesyTA9hA3LX4ga8sm2nWRcffEa1L/5vQwb4mj2MdzMkoHoGv4QzfDshQZuYscQSf8c4TKOA==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">= 0.4.0"
       }
     },
     "node_modules/fill-range": {
@@ -10386,6 +10697,12 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/find-root": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/find-root/-/find-root-1.1.0.tgz",
+      "integrity": "sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng==",
+      "license": "MIT"
     },
     "node_modules/find-up": {
       "version": "5.0.0",
@@ -11598,6 +11915,16 @@
       "license": "MIT",
       "engines": {
         "node": ">= 4"
+      }
+    },
+    "node_modules/immer": {
+      "version": "11.1.8",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-11.1.8.tgz",
+      "integrity": "sha512-/tbkHMW7y10Lx6i1crLjD4/OhNkRG+Fo7byZHtah0547nIeXYcpIXaUh0IAQY6gO5459qpGGYapcEOHtFXkIuA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
       }
     },
     "node_modules/import-fresh": {
@@ -13387,6 +13714,12 @@
       "integrity": "sha512-5SUElzGMYXA7bcyZBL1YzLTxH9Iyw1AeYNJxzByqbestrrtB0F3wfiWUr7aROpwodO4fwnxOt78Xjb3o3ONNQg==",
       "license": "MIT"
     },
+    "node_modules/memoize-one": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-6.0.0.tgz",
+      "integrity": "sha512-rkpe71W0N0c0Xz6QD0eJETuWAJGnJ9afsl1srmwPrI+yBCkge5EycXXbYRyvL29zZVUWQCY7InPRCv3GDXuZNw==",
+      "license": "MIT"
+    },
     "node_modules/mendoza": {
       "version": "3.0.8",
       "resolved": "https://registry.npmjs.org/mendoza/-/mendoza-3.0.8.tgz",
@@ -14662,6 +14995,15 @@
         "ce-la-react": "^0.3.0"
       }
     },
+    "node_modules/pluralize": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-8.0.0.tgz",
+      "integrity": "sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/pluralize-esm": {
       "version": "9.0.5",
       "resolved": "https://registry.npmjs.org/pluralize-esm/-/pluralize-esm-9.0.5.tgz",
@@ -15037,11 +15379,42 @@
         "react": "^18.3.1"
       }
     },
+    "node_modules/react-dropzone": {
+      "version": "11.7.1",
+      "resolved": "https://registry.npmjs.org/react-dropzone/-/react-dropzone-11.7.1.tgz",
+      "integrity": "sha512-zxCMwhfPy1olUEbw3FLNPLhAm/HnaYH5aELIEglRbqabizKAdHs0h+WuyOpmA+v1JXn0++fpQDdNfUagWt5hJQ==",
+      "license": "MIT",
+      "dependencies": {
+        "attr-accept": "^2.2.2",
+        "file-selector": "^0.4.0",
+        "prop-types": "^15.8.1"
+      },
+      "engines": {
+        "node": ">= 10.13"
+      },
+      "peerDependencies": {
+        "react": ">= 16.8"
+      }
+    },
     "node_modules/react-fast-compare": {
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-3.2.2.tgz",
       "integrity": "sha512-nsO+KSNgo1SbJqJEYRE9ERzo7YtYbou/OqjSQKxV7jcKox7+usiUVZOAC+XnDOABXggQTno0Y1CpVnuWEc1boQ==",
       "license": "MIT"
+    },
+    "node_modules/react-file-icon": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/react-file-icon/-/react-file-icon-1.6.0.tgz",
+      "integrity": "sha512-Ba4Qa2ya/kvhcCd4LJja77sV7JD7u1ZXcI1DUz+TII3nGmglG6QY+NZeHizThokgct3qI0glwb9eV8NqRGs5lw==",
+      "license": "MIT",
+      "dependencies": {
+        "colord": "^2.9.3",
+        "prop-types": "^15.7.2"
+      },
+      "peerDependencies": {
+        "react": "^19.0.0 || ^18.0.0 || ^17.0.0 || ^16.2.0",
+        "react-dom": "^19.0.0 || ^18.0.0 || ^17.0.0 || ^16.2.0"
+      }
     },
     "node_modules/react-focus-lock": {
       "version": "2.13.7",
@@ -15064,6 +15437,22 @@
         "@types/react": {
           "optional": true
         }
+      }
+    },
+    "node_modules/react-hook-form": {
+      "version": "7.75.0",
+      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.75.0.tgz",
+      "integrity": "sha512-Ovv94H+0p3sJ7B9B5QxPuCP1u8V/cHuVGyH55cSwodYDtoJwK+fqk3vjfIgSX59I2U/bU4z0nRJ9HMLpNiWEmw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/react-hook-form"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17 || ^18 || ^19"
       }
     },
     "node_modules/react-i18next": {
@@ -15096,6 +15485,35 @@
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "license": "MIT"
+    },
+    "node_modules/react-redux": {
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
+      "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/use-sync-external-store": "^0.0.6",
+        "use-sync-external-store": "^1.4.0"
+      },
+      "peerDependencies": {
+        "@types/react": "^18.2.25 || ^19",
+        "react": "^18.0 || ^19",
+        "redux": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "redux": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-redux/node_modules/@types/use-sync-external-store": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
+      "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
       "license": "MIT"
     },
     "node_modules/react-refractor": {
@@ -15137,6 +15555,53 @@
       "peerDependencies": {
         "react": "^18.3 || >=19.0.0-0",
         "rxjs": "^7"
+      }
+    },
+    "node_modules/react-select": {
+      "version": "5.10.2",
+      "resolved": "https://registry.npmjs.org/react-select/-/react-select-5.10.2.tgz",
+      "integrity": "sha512-Z33nHdEFWq9tfnfVXaiM12rbJmk+QjFEztWLtmXqQhz6Al4UZZ9xc0wiatmGtUOCCnHN0WizL3tCMYRENX4rVQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.0",
+        "@emotion/cache": "^11.4.0",
+        "@emotion/react": "^11.8.1",
+        "@floating-ui/dom": "^1.0.1",
+        "@types/react-transition-group": "^4.4.0",
+        "memoize-one": "^6.0.0",
+        "prop-types": "^15.6.0",
+        "react-transition-group": "^4.3.0",
+        "use-isomorphic-layout-effect": "^1.2.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/react-transition-group": {
+      "version": "4.4.5",
+      "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.4.5.tgz",
+      "integrity": "sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@babel/runtime": "^7.5.5",
+        "dom-helpers": "^5.0.1",
+        "loose-envify": "^1.4.0",
+        "prop-types": "^15.6.2"
+      },
+      "peerDependencies": {
+        "react": ">=16.6.0",
+        "react-dom": ">=16.6.0"
+      }
+    },
+    "node_modules/react-virtuoso": {
+      "version": "4.18.6",
+      "resolved": "https://registry.npmjs.org/react-virtuoso/-/react-virtuoso-4.18.6.tgz",
+      "integrity": "sha512-CrT3P6HyjJMHZVWSste2bG2q5aWGlHfW2QuySZjiFwB2Qok/xsvgy+k8Z2jeDP8PP5KsBip7zNrl/F0QoxeyKw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=16 || >=17 || >= 18 || >= 19",
+        "react-dom": ">=16 || >=17 || >= 18 || >=19"
       }
     },
     "node_modules/read-pkg": {
@@ -15382,6 +15847,31 @@
       "license": "MIT",
       "dependencies": {
         "esprima": "~4.0.0"
+      }
+    },
+    "node_modules/redux": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
+      "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
+      "license": "MIT"
+    },
+    "node_modules/redux-observable": {
+      "version": "3.0.0-rc.2",
+      "resolved": "https://registry.npmjs.org/redux-observable/-/redux-observable-3.0.0-rc.2.tgz",
+      "integrity": "sha512-gG/pWIKgSrcTyyavm2so5tc7tuyCQ47p3VdCAG6wt+CV0WGhDr50cMQHLcYKxFZSGgTm19a8ZmyfJGndmGDpYg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "redux": ">=5 <6",
+        "rxjs": ">=7 <8"
+      }
+    },
+    "node_modules/redux-thunk": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-3.1.0.tgz",
+      "integrity": "sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "redux": "^5.0.0"
       }
     },
     "node_modules/reflect.getprototypeof": {
@@ -16037,6 +16527,59 @@
         "react": "^18 || ^19",
         "react-dom": "^18 || ^19",
         "styled-components": "^6.1.15"
+      }
+    },
+    "node_modules/sanity-plugin-media": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/sanity-plugin-media/-/sanity-plugin-media-4.2.0.tgz",
+      "integrity": "sha512-xO06wge62/MG4gbaAk0Bsqco1dGAelYtIUpnr877ixPjGasxtofTL4HEUvdXR9OePK5C3RSn0+3sdNHOUj29lw==",
+      "license": "MIT",
+      "dependencies": {
+        "@hookform/resolvers": "^3.1.1",
+        "@reduxjs/toolkit": "^2.6.0",
+        "@sanity/client": "^7.13.2",
+        "@sanity/color": "^3.0.6",
+        "@sanity/icons": "^3.7.0",
+        "@sanity/incompatible-plugin": "^1.0.5",
+        "@sanity/ui": "^3.0.5",
+        "@sanity/uuid": "^3.0.1",
+        "@tanem/react-nprogress": "^5.0.55",
+        "copy-to-clipboard": "^3.3.1",
+        "date-fns": "^4.0.0",
+        "filesize": "^9.0.0",
+        "groq": "^3.0.0",
+        "is-hotkey-esm": "^1.0.0",
+        "nanoid": "^3.3.8",
+        "pluralize": "^8.0.0",
+        "react-dropzone": "^11.3.1",
+        "react-file-icon": "^1.6.0",
+        "react-hook-form": "^7.54.2",
+        "react-redux": "^9.2.0",
+        "react-select": "^5.10.1",
+        "react-virtuoso": "^4.12.5",
+        "redux": "^5.0.1",
+        "redux-observable": "3.0.0-rc.2",
+        "rxjs": "^7.8.1",
+        "zod": "^3.21.4"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "react": "^18.3 || ^19",
+        "react-dom": "^18.3 || ^19",
+        "react-is": "^18.3 || ^19",
+        "sanity": "^3.78 || ^4.0.0-0 || ^5",
+        "styled-components": "^6.1"
+      }
+    },
+    "node_modules/sanity-plugin-media/node_modules/groq": {
+      "version": "3.99.0",
+      "resolved": "https://registry.npmjs.org/groq/-/groq-3.99.0.tgz",
+      "integrity": "sha512-ZwKAWzvVCw51yjmIf5484KgsAzZAlGTM4uy9lki4PjAYxcEME2Xf93d31LhHzgUAr2JI79H+cNKoRjDHdv1BXQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/sanity/node_modules/@sanity/image-url": {
@@ -17226,6 +17769,12 @@
       "engines": {
         "node": ">=8.0"
       }
+    },
+    "node_modules/toggle-selection": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/toggle-selection/-/toggle-selection-1.0.6.tgz",
+      "integrity": "sha512-BiZS+C1OS8g/q2RRbJmy59xpyghNBqrr6k5L/uKBGRsTfxmu3ffiRnd8mlGPUVayg8pvfi5urfnu8TU7DVOkLQ==",
+      "license": "MIT"
     },
     "node_modules/tough-cookie": {
       "version": "5.1.2",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "react-dom": "^18",
     "resend": "^6.9.3",
     "sanity": "^4.22.0",
+    "sanity-plugin-media": "^4.2.0",
     "stripe": "^20.4.1",
     "styled-components": "^6.3.11",
     "swiper": "^12.1.2"

--- a/sanity.config.ts
+++ b/sanity.config.ts
@@ -2,6 +2,7 @@
 import {visionTool} from '@sanity/vision'
 import {defineConfig} from 'sanity'
 import {structureTool} from 'sanity/structure'
+import {media} from 'sanity-plugin-media'
 import {apiVersion, dataset, projectId} from './sanity/env'
 import {schemaTypes} from './sanity/schemaTypes'
 import {structure} from './sanity/structure'
@@ -14,5 +15,6 @@ export default defineConfig({
   plugins: [
     structureTool({structure}),
     visionTool({defaultApiVersion: apiVersion}),
+    media(),
   ],
 })

--- a/sanity/components/BulkUploadPane.tsx
+++ b/sanity/components/BulkUploadPane.tsx
@@ -1,0 +1,143 @@
+import { useCallback, useRef, useState } from 'react'
+import { useClient } from 'sanity'
+import { Badge, Button, Card, Flex, Stack, Text } from '@sanity/ui'
+import { UploadIcon } from '@sanity/icons'
+
+type UploadStatus = 'pending' | 'uploading' | 'done' | 'error'
+
+interface FileState {
+  name: string
+  status: UploadStatus
+  error?: string
+}
+
+export function BulkUploadPane() {
+  const client = useClient({ apiVersion: '2026-03-10' })
+  const fileInputRef = useRef<HTMLInputElement>(null)
+  const [files, setFiles] = useState<FileState[]>([])
+  const [running, setRunning] = useState(false)
+
+  const handleFiles = useCallback(
+    async (e: React.ChangeEvent<HTMLInputElement>) => {
+      const selected = Array.from(e.target.files ?? [])
+      if (!selected.length) return
+
+      setFiles(selected.map((f) => ({ name: f.name, status: 'pending' })))
+      setRunning(true)
+
+      for (let i = 0; i < selected.length; i++) {
+        const file = selected[i]
+        setFiles((prev) => prev.map((f, idx) => (idx === i ? { ...f, status: 'uploading' } : f)))
+        try {
+          const asset = await client.assets.upload('image', file, { filename: file.name })
+          await client.create({
+            _type: 'photo',
+            title: file.name.replace(/\.[^.]+$/, ''),
+            alt: '',
+            image: {
+              _type: 'image',
+              asset: { _type: 'reference', _ref: asset._id },
+            },
+            featured: false,
+          })
+          setFiles((prev) => prev.map((f, idx) => (idx === i ? { ...f, status: 'done' } : f)))
+        } catch (err) {
+          const msg = err instanceof Error ? err.message : 'Upload failed'
+          setFiles((prev) => prev.map((f, idx) => (idx === i ? { ...f, status: 'error', error: msg } : f)))
+        }
+      }
+
+      if (fileInputRef.current) fileInputRef.current.value = ''
+      setRunning(false)
+    },
+    [client],
+  )
+
+  const done = files.filter((f) => f.status === 'done').length
+  const errors = files.filter((f) => f.status === 'error').length
+
+  return (
+    <Card padding={5} height="fill">
+      <Stack space={5}>
+        <Stack space={2}>
+          <Text size={3} weight="semibold">Upload Multiple Photos</Text>
+          <Text size={1} muted>
+            Select multiple photos to upload them all at once. Each file becomes a separate Photo document.
+            Use Ctrl+click or Shift+click in the file picker to select multiple files.
+          </Text>
+        </Stack>
+
+        <Flex gap={3} align="center">
+          <input
+            ref={fileInputRef}
+            type="file"
+            accept="image/*"
+            multiple
+            style={{ display: 'none' }}
+            onChange={handleFiles}
+            id="bulk-upload-pane-input"
+            disabled={running}
+          />
+          <label htmlFor="bulk-upload-pane-input">
+            <Button
+              as="span"
+              icon={UploadIcon}
+              text={running ? `Uploading ${done} of ${files.length}...` : 'Choose photos'}
+              tone="primary"
+              disabled={running}
+              style={{ cursor: running ? 'not-allowed' : 'pointer' }}
+            />
+          </label>
+          {files.length > 0 && !running && (
+            <Button text="Clear" mode="ghost" onClick={() => setFiles([])} />
+          )}
+        </Flex>
+
+        {files.length > 0 && (
+          <Stack space={2}>
+            {files.map((f, i) => (
+              <Card
+                key={i}
+                padding={3}
+                radius={2}
+                tone={f.status === 'error' ? 'critical' : f.status === 'done' ? 'positive' : 'default'}
+              >
+                <Flex align="center" gap={3}>
+                  <Text size={1} style={{ flex: 1 }}>{f.name}</Text>
+                  <Badge
+                    tone={
+                      f.status === 'done'
+                        ? 'positive'
+                        : f.status === 'error'
+                          ? 'critical'
+                          : 'default'
+                    }
+                  >
+                    {f.status === 'pending'
+                      ? 'Waiting'
+                      : f.status === 'uploading'
+                        ? 'Uploading...'
+                        : f.status === 'done'
+                          ? 'Done'
+                          : 'Error'}
+                  </Badge>
+                </Flex>
+                {f.error && (
+                  <Text size={0} muted>
+                    {f.error}
+                  </Text>
+                )}
+              </Card>
+            ))}
+          </Stack>
+        )}
+
+        {!running && files.length > 0 && (
+          <Text size={1} muted>
+            {done} uploaded{errors > 0 ? `, ${errors} failed` : ''}. Go to Photo in the sidebar to edit titles, alt text, and categories.
+          </Text>
+        )}
+      </Stack>
+    </Card>
+  )
+}

--- a/sanity/components/BulkUploadPane.tsx
+++ b/sanity/components/BulkUploadPane.tsx
@@ -11,15 +11,32 @@ interface FileState {
   error?: string
 }
 
+const IMAGE_TYPES = ['.jpg', '.jpeg', '.png', '.webp', '.avif', '.heic', '.gif', '.tiff']
+
+async function pickFiles(): Promise<File[]> {
+  if ('showOpenFilePicker' in window) {
+    try {
+      const handles = await (window as any).showOpenFilePicker({
+        multiple: true,
+        startIn: 'pictures',
+        types: [{ description: 'Images', accept: { 'image/*': IMAGE_TYPES } }],
+      })
+      return Promise.all(handles.map((h: any) => h.getFile()))
+    } catch {
+      return []
+    }
+  }
+  return []
+}
+
 export function BulkUploadPane() {
   const client = useClient({ apiVersion: '2026-03-10' })
   const fileInputRef = useRef<HTMLInputElement>(null)
   const [files, setFiles] = useState<FileState[]>([])
   const [running, setRunning] = useState(false)
 
-  const handleFiles = useCallback(
-    async (e: React.ChangeEvent<HTMLInputElement>) => {
-      const selected = Array.from(e.target.files ?? [])
+  const processFiles = useCallback(
+    async (selected: File[]) => {
       if (!selected.length) return
 
       setFiles(selected.map((f) => ({ name: f.name, status: 'pending' })))
@@ -53,6 +70,23 @@ export function BulkUploadPane() {
     [client],
   )
 
+  const handleClick = useCallback(async () => {
+    if ('showOpenFilePicker' in window) {
+      const selected = await pickFiles()
+      if (selected.length) await processFiles(selected)
+    } else {
+      fileInputRef.current?.click()
+    }
+  }, [processFiles])
+
+  const handleInputChange = useCallback(
+    async (e: React.ChangeEvent<HTMLInputElement>) => {
+      const selected = Array.from(e.target.files ?? [])
+      await processFiles(selected)
+    },
+    [processFiles],
+  )
+
   const done = files.filter((f) => f.status === 'done').length
   const errors = files.filter((f) => f.status === 'error').length
 
@@ -74,20 +108,16 @@ export function BulkUploadPane() {
             accept="image/*"
             multiple
             style={{ display: 'none' }}
-            onChange={handleFiles}
-            id="bulk-upload-pane-input"
+            onChange={handleInputChange}
             disabled={running}
           />
-          <label htmlFor="bulk-upload-pane-input">
-            <Button
-              as="span"
-              icon={UploadIcon}
-              text={running ? `Uploading ${done} of ${files.length}...` : 'Choose photos'}
-              tone="primary"
-              disabled={running}
-              style={{ cursor: running ? 'not-allowed' : 'pointer' }}
-            />
-          </label>
+          <Button
+            icon={UploadIcon}
+            text={running ? `Uploading ${done} of ${files.length}...` : 'Choose photos'}
+            tone="primary"
+            disabled={running}
+            onClick={handleClick}
+          />
           {files.length > 0 && !running && (
             <Button text="Clear" mode="ghost" onClick={() => setFiles([])} />
           )}

--- a/sanity/components/PhotosArrayInput.tsx
+++ b/sanity/components/PhotosArrayInput.tsx
@@ -4,15 +4,32 @@ import { useClient } from 'sanity'
 import { Button, Stack, Text } from '@sanity/ui'
 import { UploadIcon } from '@sanity/icons'
 
+const IMAGE_TYPES = ['.jpg', '.jpeg', '.png', '.webp', '.avif', '.heic', '.gif', '.tiff']
+
+async function pickFiles(): Promise<File[]> {
+  if ('showOpenFilePicker' in window) {
+    try {
+      const handles = await (window as any).showOpenFilePicker({
+        multiple: true,
+        startIn: 'pictures',
+        types: [{ description: 'Images', accept: { 'image/*': IMAGE_TYPES } }],
+      })
+      return Promise.all(handles.map((h: any) => h.getFile()))
+    } catch {
+      return []
+    }
+  }
+  return []
+}
+
 export function PhotosArrayInput(props: ArrayOfObjectsInputProps) {
   const client = useClient({ apiVersion: '2026-03-10' })
   const fileInputRef = useRef<HTMLInputElement>(null)
   const [uploading, setUploading] = useState(false)
   const [progress, setProgress] = useState<{ done: number; total: number } | null>(null)
 
-  const handleFiles = useCallback(
-    async (e: React.ChangeEvent<HTMLInputElement>) => {
-      const files = Array.from(e.target.files ?? [])
+  const processFiles = useCallback(
+    async (files: File[]) => {
       if (!files.length) return
 
       setUploading(true)
@@ -44,6 +61,22 @@ export function PhotosArrayInput(props: ArrayOfObjectsInputProps) {
     [client, props],
   )
 
+  const handleClick = useCallback(async () => {
+    if ('showOpenFilePicker' in window) {
+      const selected = await pickFiles()
+      if (selected.length) await processFiles(selected)
+    } else {
+      fileInputRef.current?.click()
+    }
+  }, [processFiles])
+
+  const handleInputChange = useCallback(
+    async (e: React.ChangeEvent<HTMLInputElement>) => {
+      await processFiles(Array.from(e.target.files ?? []))
+    },
+    [processFiles],
+  )
+
   return (
     <Stack space={4}>
       <Stack space={3}>
@@ -53,24 +86,20 @@ export function PhotosArrayInput(props: ArrayOfObjectsInputProps) {
           accept="image/*"
           multiple
           style={{ display: 'none' }}
-          onChange={handleFiles}
-          id="photos-multi-upload"
+          onChange={handleInputChange}
           disabled={uploading}
         />
-        <label htmlFor="photos-multi-upload">
-          <Button
-            as="span"
-            icon={UploadIcon}
-            text={uploading ? `Uploading ${progress?.done ?? 0} of ${progress?.total ?? 0}…` : 'Upload photos'}
-            mode="ghost"
-            tone="primary"
-            disabled={uploading}
-            style={{ cursor: uploading ? 'not-allowed' : 'pointer' }}
-          />
-        </label>
+        <Button
+          icon={UploadIcon}
+          text={uploading ? `Uploading ${progress?.done ?? 0} of ${progress?.total ?? 0}...` : 'Upload photos'}
+          mode="ghost"
+          tone="primary"
+          disabled={uploading}
+          onClick={handleClick}
+        />
         {!uploading && (
           <Text size={1} muted>
-            Use Ctrl+click (Windows/Linux) or Cmd+click (Mac) to select multiple files. Shift+click for a range.
+            Use Ctrl+click or Shift+click to select multiple files.
           </Text>
         )}
       </Stack>

--- a/sanity/components/PhotosArrayInput.tsx
+++ b/sanity/components/PhotosArrayInput.tsx
@@ -1,0 +1,80 @@
+import { useCallback, useRef, useState } from 'react'
+import { ArrayOfObjectsInputProps, insert, setIfMissing } from 'sanity'
+import { useClient } from 'sanity'
+import { Button, Stack, Text } from '@sanity/ui'
+import { UploadIcon } from '@sanity/icons'
+
+export function PhotosArrayInput(props: ArrayOfObjectsInputProps) {
+  const client = useClient({ apiVersion: '2026-03-10' })
+  const fileInputRef = useRef<HTMLInputElement>(null)
+  const [uploading, setUploading] = useState(false)
+  const [progress, setProgress] = useState<{ done: number; total: number } | null>(null)
+
+  const handleFiles = useCallback(
+    async (e: React.ChangeEvent<HTMLInputElement>) => {
+      const files = Array.from(e.target.files ?? [])
+      if (!files.length) return
+
+      setUploading(true)
+      setProgress({ done: 0, total: files.length })
+
+      const newItems: object[] = []
+
+      for (const file of files) {
+        const asset = await client.assets.upload('image', file, { filename: file.name })
+        newItems.push({
+          _type: 'object',
+          _key: `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`,
+          image: {
+            _type: 'image',
+            asset: { _type: 'reference', _ref: asset._id },
+          },
+          alt: '',
+          caption: '',
+        })
+        setProgress((p) => p && { done: p.done + 1, total: p.total })
+      }
+
+      props.onChange([setIfMissing([]), insert(newItems, 'after', [-1])])
+
+      if (fileInputRef.current) fileInputRef.current.value = ''
+      setUploading(false)
+      setProgress(null)
+    },
+    [client, props],
+  )
+
+  return (
+    <Stack space={4}>
+      <Stack space={3}>
+        <input
+          ref={fileInputRef}
+          type="file"
+          accept="image/*"
+          multiple
+          style={{ display: 'none' }}
+          onChange={handleFiles}
+          id="photos-multi-upload"
+          disabled={uploading}
+        />
+        <label htmlFor="photos-multi-upload">
+          <Button
+            as="span"
+            icon={UploadIcon}
+            text={uploading ? `Uploading ${progress?.done ?? 0} of ${progress?.total ?? 0}…` : 'Upload photos'}
+            mode="ghost"
+            tone="primary"
+            disabled={uploading}
+            style={{ cursor: uploading ? 'not-allowed' : 'pointer' }}
+          />
+        </label>
+        {!uploading && (
+          <Text size={1} muted>
+            Use Ctrl+click (Windows/Linux) or Cmd+click (Mac) to select multiple files. Shift+click for a range.
+          </Text>
+        )}
+      </Stack>
+      {props.renderDefault(props)}
+    </Stack>
+  )
+}

--- a/sanity/queries.ts
+++ b/sanity/queries.ts
@@ -32,7 +32,7 @@ export const galleryBySlugQuery = groq`
   *[_type == "gallery" && slug.current == $slug][0] {
     _id, title, slug, category,
     coverImage->{ _id, image, alt },
-    photos[]->{ _id, title, alt, image, category }
+    photos[]{ _key, image, alt, caption }
   }
 `
 

--- a/sanity/schemaTypes/gallery.ts
+++ b/sanity/schemaTypes/gallery.ts
@@ -1,4 +1,5 @@
 import { defineField, defineType } from 'sanity'
+import { PhotosArrayInput } from '../components/PhotosArrayInput'
 
 export const gallery = defineType({
   name: 'gallery',
@@ -55,7 +56,8 @@ export const gallery = defineType({
           preview: { select: { media: 'image', title: 'alt' } },
         },
       ],
-      description: 'Drag and drop multiple photos at once using the Media Library.',
+      description: 'Use the "Upload photos" button above to select multiple files at once.',
+      components: { input: PhotosArrayInput },
     }),
     defineField({
       name: 'featured',

--- a/sanity/schemaTypes/gallery.ts
+++ b/sanity/schemaTypes/gallery.ts
@@ -44,7 +44,18 @@ export const gallery = defineType({
       name: 'photos',
       title: 'Photos',
       type: 'array',
-      of: [{ type: 'reference', to: [{ type: 'photo' }] }],
+      of: [
+        {
+          type: 'object',
+          fields: [
+            defineField({ name: 'image', title: 'Image', type: 'image', options: { hotspot: true }, validation: (Rule) => Rule.required() }),
+            defineField({ name: 'alt', title: 'Alt Text', type: 'string' }),
+            defineField({ name: 'caption', title: 'Caption', type: 'string' }),
+          ],
+          preview: { select: { media: 'image', title: 'alt' } },
+        },
+      ],
+      description: 'Drag and drop multiple photos at once using the Media Library.',
     }),
     defineField({
       name: 'featured',

--- a/sanity/structure.ts
+++ b/sanity/structure.ts
@@ -1,4 +1,5 @@
 import type { StructureResolver } from 'sanity/structure'
+import { BulkUploadPane } from './components/BulkUploadPane'
 
 export const structure: StructureResolver = (S) =>
   S.list()
@@ -34,13 +35,29 @@ export const structure: StructureResolver = (S) =>
 
       S.divider(),
 
-      // ── Portfolio ────────────────────────────────────────────
+      // ── Upload Photos ────────────────────────────────────────
       S.listItem()
-        .title('Photos')
-        .child(S.documentTypeList('photo').title('Photos')),
-      S.listItem()
-        .title('Galleries')
-        .child(S.documentTypeList('gallery').title('Galleries')),
+        .title('Upload Photos')
+        .id('uploadPhotos')
+        .child(
+          S.list()
+            .title('Upload Photos')
+            .items([
+              S.listItem()
+                .title('Galleries')
+                .child(S.documentTypeList('gallery').title('Galleries')),
+              S.listItem()
+                .title('Photo')
+                .child(S.documentTypeList('photo').title('Photo')),
+              S.listItem()
+                .title('Photos')
+                .id('bulkUpload')
+                .child(
+                  S.component(BulkUploadPane)
+                    .title('Upload Multiple Photos')
+                ),
+            ])
+        ),
 
       S.divider(),
 

--- a/sanity/structure.ts
+++ b/sanity/structure.ts
@@ -47,15 +47,15 @@ export const structure: StructureResolver = (S) =>
                 .title('Galleries')
                 .child(S.documentTypeList('gallery').title('Galleries')),
               S.listItem()
-                .title('Photo')
-                .child(S.documentTypeList('photo').title('Photo')),
-              S.listItem()
                 .title('Photos')
                 .id('bulkUpload')
                 .child(
                   S.component(BulkUploadPane)
                     .title('Upload Multiple Photos')
                 ),
+              S.listItem()
+                .title('Photo')
+                .child(S.documentTypeList('photo').title('Photo')),
             ])
         ),
 


### PR DESCRIPTION
## Summary

- Adds **Upload Photos** parent section to the Sanity Studio sidebar, replacing the flat top-level Photos and Galleries items
- Three children under Upload Photos: **Galleries**, **Photos** (bulk upload pane), **Photo** (single document list)
- Bulk upload pane creates one Photo document per file, with per-file progress and error reporting
- File picker defaults to the Pictures folder (via File System Access API, with hidden-input fallback for Firefox)
- Cherry-picks TYN-6 foundational changes: gallery inline objects schema, PhotosArrayInput, sanity-plugin-media, next.config CDN pattern

## Test plan

- [ ] Hard refresh Studio - sidebar shows Upload Photos instead of separate Photos/Galleries
- [ ] Click Upload Photos - expands to show Galleries, Photos, Photo
- [ ] Galleries opens gallery document list
- [ ] Photos opens bulk upload pane - file picker opens in Pictures folder
- [ ] Ctrl+click or Shift+click selects multiple files - each creates a Photo document
- [ ] Photo opens single photo document list
- [ ] No Bulk Upload tab in Studio top nav