### PR TITLE
TYN-17: Fix open redirect via untrusted Origin header in checkout API

### DIFF
--- a/app/api/checkout/route.ts
+++ b/app/api/checkout/route.ts
@@ -7,6 +7,9 @@ const ALLOWED_ORIGINS = [
   'https://tynnellhollinsphotography.com',
   'https://www.tynnellhollinsphotography.com',
   process.env.NEXT_PUBLIC_SITE_URL,
+  ...(process.env.NODE_ENV === 'development'
+    ? ['http://localhost:3000', 'http://localhost:3001']
+    : []),
 ].filter(Boolean) as string[]
 
 const SITE_ORIGIN = 'https://tynnellhollinsphotography.com'

--- a/app/api/checkout/route.ts
+++ b/app/api/checkout/route.ts
@@ -3,7 +3,21 @@ import { NextResponse } from 'next/server'
 
 export const dynamic = 'force-dynamic'
 
+const ALLOWED_ORIGINS = [
+  'https://tynnellhollinsphotography.com',
+  'https://www.tynnellhollinsphotography.com',
+  process.env.NEXT_PUBLIC_SITE_URL,
+].filter(Boolean) as string[]
+
+const SITE_ORIGIN = 'https://tynnellhollinsphotography.com'
+
 export async function POST(request: Request) {
+  const origin = request.headers.get('origin')
+
+  if (!origin || !ALLOWED_ORIGINS.includes(origin)) {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+  }
+
   const stripe = new Stripe(process.env.STRIPE_SECRET_KEY!)
 
   const body = await request.json()
@@ -16,8 +30,6 @@ export async function POST(request: Request) {
   if (typeof depositAmount !== 'number' || depositAmount <= 0) {
     return NextResponse.json({ error: 'Invalid deposit amount' }, { status: 400 })
   }
-
-  const origin = request.headers.get('origin') ?? process.env.NEXT_PUBLIC_SITE_URL ?? 'https://tynnellhollinsphotography.com'
 
   try {
     const session = await stripe.checkout.sessions.create({
@@ -41,8 +53,8 @@ export async function POST(request: Request) {
         clientEmail,
         packageName,
       },
-      success_url: `${origin}/book/success?session_id={CHECKOUT_SESSION_ID}`,
-      cancel_url: `${origin}/book/cancel`,
+      success_url: `${SITE_ORIGIN}/book/success?session_id={CHECKOUT_SESSION_ID}`,
+      cancel_url: `${SITE_ORIGIN}/book/cancel`,
     })
 
     return NextResponse.json({ url: session.url })

--- a/dev.ps1
+++ b/dev.ps1
@@ -1,0 +1,1 @@
+op run --env-file ".env.local" -- npm run dev

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
+    "dev:secure": "op run --env-file \".env.local\" -- next dev",
     "build": "next build",
     "start": "next start",
     "lint": "next lint"


### PR DESCRIPTION
## Summary
- Replaced dynamic `origin` from the request's Origin header with a hardcoded ALLOWED_ORIGINS allowlist
- Requests from any origin not on the list are immediately rejected with 403
- `success_url` and `cancel_url` now resolve against a fixed SITE_ORIGIN constant, not attacker-controlled input

## Security impact
Previously an attacker could POST to /api/checkout with Origin: https://evil.com and the Stripe Checkout session's redirect URLs would point to their domain, enabling phishing after a real payment.

## Test plan
- [ ] Booking flow from production domain works (success/cancel redirect correctly)
- [ ] POST from a non-allowlisted origin returns 403
- [ ] Local dev works if NEXT_PUBLIC_SITE_URL is set in .env.local