### PR TITLE
TYN-18: Add strict email validation to checkout and contact APIs

### DIFF
--- a/app/api/checkout/route.ts
+++ b/app/api/checkout/route.ts
@@ -1,5 +1,6 @@
 import Stripe from 'stripe'
 import { NextResponse } from 'next/server'
+import { isValidEmail } from '@/app/lib/validation'
 
 export const dynamic = 'force-dynamic'
 
@@ -15,6 +16,10 @@ export async function POST(request: Request) {
 
   if (typeof depositAmount !== 'number' || depositAmount <= 0) {
     return NextResponse.json({ error: 'Invalid deposit amount' }, { status: 400 })
+  }
+
+  if (!isValidEmail(clientEmail)) {
+    return NextResponse.json({ error: 'Invalid email address' }, { status: 400 })
   }
 
   const origin = request.headers.get('origin') ?? process.env.NEXT_PUBLIC_SITE_URL ?? 'https://tynnellhollinsphotography.com'

--- a/app/api/contact/route.ts
+++ b/app/api/contact/route.ts
@@ -1,5 +1,6 @@
 import { Resend } from 'resend'
 import { NextResponse } from 'next/server'
+import { isValidEmail } from '@/app/lib/validation'
 
 export const dynamic = 'force-dynamic'
 
@@ -12,8 +13,7 @@ export async function POST(request: Request) {
     return NextResponse.json({ error: 'Missing required fields' }, { status: 400 })
   }
 
-  const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
-  if (!emailRegex.test(email)) {
+  if (!isValidEmail(email)) {
     return NextResponse.json({ error: 'Invalid email address' }, { status: 400 })
   }
 

--- a/app/lib/validation.ts
+++ b/app/lib/validation.ts
@@ -1,0 +1,17 @@
+/**
+ * Validates an email address for use in API routes.
+ *
+ * Rejects:
+ * - Non-string values
+ * - Addresses longer than 255 characters (RFC 5321 limit)
+ * - Any string containing \r or \n (blocks email header injection)
+ * - Strings that don't match basic address format
+ */
+const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
+
+export function isValidEmail(email: unknown): email is string {
+  if (typeof email !== 'string') return false
+  if (email.length > 255) return false
+  if (/[\r\n]/.test(email)) return false
+  return EMAIL_REGEX.test(email)
+}


### PR DESCRIPTION
## Summary
- Created shared `isValidEmail` utility at `app/lib/validation.ts` that explicitly rejects non-strings, addresses over 255 chars, and any `\r`/`\n` characters (blocks header injection)
- Added email validation to `app/api/checkout/route.ts` where none existed
- Replaced the loose inline regex in `app/api/contact/route.ts` with the shared validator

## Test plan
- [x] POST to /api/checkout with `clientEmail: "notanemail"` returns 400
- [x] POST to /api/checkout with a valid email returns 200 + Stripe URL
- [ ] POST to /api/contact with a valid email submits successfully