### PR TITLE
TYN-19: Escape HTML in email templates to prevent injection

### DIFF
--- a/app/api/contact/route.ts
+++ b/app/api/contact/route.ts
@@ -1,5 +1,6 @@
 import { Resend } from 'resend'
 import { NextResponse } from 'next/server'
+import { escapeHtml } from '@/app/lib/validation'
 
 export const dynamic = 'force-dynamic'
 
@@ -17,55 +18,65 @@ export async function POST(request: Request) {
     return NextResponse.json({ error: 'Invalid email address' }, { status: 400 })
   }
 
+  const safeName              = escapeHtml(name)
+  const safeEmail             = escapeHtml(email)
+  const safePhone             = escapeHtml(phone)
+  const safeContactPreference = escapeHtml(contactPreference)
+  const safeSessionType       = escapeHtml(sessionType)
+  const safeDate              = escapeHtml(date)
+  const safeLocation          = escapeHtml(location)
+  const safeHowHeard          = escapeHtml(howHeard)
+  const safeMessage           = escapeHtml(message)
+
   try {
     await resend.emails.send({
       from: 'Tynnell Hollins Photography <hello@tynnellhollinsphotography.com>',
       to: process.env.CONTACT_TO_EMAIL!,
       replyTo: email,
-      subject: `New Inquiry: ${sessionType} — ${name}`,
+      subject: `New Inquiry: ${safeSessionType} - ${safeName}`,
       html: `
         <div style="font-family: sans-serif; max-width: 600px; margin: 0 auto; color: #333;">
           <h2 style="border-bottom: 1px solid #eee; padding-bottom: 1rem;">New Session Inquiry</h2>
           <table style="width: 100%; border-collapse: collapse;">
             <tr>
               <td style="padding: 8px 0; font-weight: bold; width: 160px;">Name</td>
-              <td style="padding: 8px 0;">${name}</td>
+              <td style="padding: 8px 0;">${safeName}</td>
             </tr>
             <tr>
               <td style="padding: 8px 0; font-weight: bold;">Email</td>
-              <td style="padding: 8px 0;"><a href="mailto:${email}">${email}</a></td>
+              <td style="padding: 8px 0;"><a href="mailto:${safeEmail}">${safeEmail}</a></td>
             </tr>
             <tr>
               <td style="padding: 8px 0; font-weight: bold;">Phone</td>
-              <td style="padding: 8px 0;">${phone}</td>
+              <td style="padding: 8px 0;">${safePhone}</td>
             </tr>
             <tr>
               <td style="padding: 8px 0; font-weight: bold;">Preferred Contact</td>
-              <td style="padding: 8px 0;">${contactPreference}</td>
+              <td style="padding: 8px 0;">${safeContactPreference}</td>
             </tr>
             <tr>
               <td style="padding: 8px 0; font-weight: bold;">Session Type</td>
-              <td style="padding: 8px 0;">${sessionType}</td>
+              <td style="padding: 8px 0;">${safeSessionType}</td>
             </tr>
             <tr>
               <td style="padding: 8px 0; font-weight: bold;">Desired Date</td>
-              <td style="padding: 8px 0;">${date}</td>
+              <td style="padding: 8px 0;">${safeDate}</td>
             </tr>
-            ${location ? `
+            ${safeLocation ? `
             <tr>
               <td style="padding: 8px 0; font-weight: bold;">Location / Venue</td>
-              <td style="padding: 8px 0;">${location}</td>
+              <td style="padding: 8px 0;">${safeLocation}</td>
             </tr>` : ''}
-            ${howHeard ? `
+            ${safeHowHeard ? `
             <tr>
               <td style="padding: 8px 0; font-weight: bold;">How They Found You</td>
-              <td style="padding: 8px 0;">${howHeard}</td>
+              <td style="padding: 8px 0;">${safeHowHeard}</td>
             </tr>` : ''}
           </table>
           <h3 style="margin-top: 1.5rem;">Message</h3>
-          <p style="white-space: pre-wrap; background: #f9f9f9; padding: 1rem; border-radius: 4px;">${message}</p>
+          <p style="white-space: pre-wrap; background: #f9f9f9; padding: 1rem; border-radius: 4px;">${safeMessage}</p>
           <p style="margin-top: 2rem; color: #999; font-size: 0.875rem;">
-            Reply directly to this email to respond to ${name}.
+            Reply directly to this email to respond to ${safeName}.
           </p>
         </div>
       `,

--- a/app/api/webhooks/stripe/route.ts
+++ b/app/api/webhooks/stripe/route.ts
@@ -1,6 +1,7 @@
 import Stripe from 'stripe'
 import { Resend } from 'resend'
 import { NextResponse } from 'next/server'
+import { escapeHtml } from '@/app/lib/validation'
 
 export const dynamic = 'force-dynamic'
 
@@ -34,16 +35,16 @@ export async function POST(request: Request) {
   if (event.type === 'checkout.session.completed') {
     const session = event.data.object as Stripe.Checkout.Session
 
-    const clientName = session.metadata?.clientName ?? 'Client'
-    const clientEmail = session.metadata?.clientEmail ?? session.customer_email ?? ''
-    const packageName = session.metadata?.packageName ?? 'Session'
-    const amountPaid = session.amount_total ? `$${(session.amount_total / 100).toFixed(0)}` : ''
+    const clientName  = escapeHtml(session.metadata?.clientName ?? 'Client')
+    const clientEmail = escapeHtml(session.metadata?.clientEmail ?? session.customer_email ?? '')
+    const packageName = escapeHtml(session.metadata?.packageName ?? 'Session')
+    const amountPaid  = session.amount_total ? `$${(session.amount_total / 100).toFixed(0)}` : ''
 
     // Email to Tynnell
     await resend.emails.send({
       from: 'Tynnell Hollins Photography <hello@tynnellhollinsphotography.com>',
       to: process.env.CONTACT_TO_EMAIL!,
-      subject: `New Booking Deposit: ${packageName} — ${clientName}`,
+      subject: `New Booking Deposit: ${packageName} - ${clientName}`,
       html: `
         <div style="font-family: sans-serif; max-width: 600px; margin: 0 auto; color: #333;">
           <h2 style="border-bottom: 1px solid #eee; padding-bottom: 1rem;">New Booking Deposit Received</h2>
@@ -70,13 +71,14 @@ export async function POST(request: Request) {
       `,
     })
 
-    // Confirmation email to client
-    if (clientEmail) {
+    // Confirmation email to client - use raw (unescaped) email as the To address
+    const rawClientEmail = session.metadata?.clientEmail ?? session.customer_email ?? ''
+    if (rawClientEmail) {
       await resend.emails.send({
         from: 'Tynnell Hollins Photography <hello@tynnellhollinsphotography.com>',
-        to: clientEmail,
+        to: rawClientEmail,
         replyTo: process.env.CONTACT_TO_EMAIL,
-        subject: `Your deposit is confirmed — ${packageName}`,
+        subject: `Your deposit is confirmed - ${packageName}`,
         html: `
           <div style="font-family: sans-serif; max-width: 600px; margin: 0 auto; color: #333;">
             <h2 style="border-bottom: 1px solid #eee; padding-bottom: 1rem;">You're officially on the calendar.</h2>

--- a/app/lib/validation.ts
+++ b/app/lib/validation.ts
@@ -1,0 +1,32 @@
+/**
+ * Validates an email address for use in API routes.
+ *
+ * Rejects:
+ * - Non-string values
+ * - Addresses longer than 255 characters (RFC 5321 limit)
+ * - Any string containing \r or \n (blocks email header injection)
+ * - Strings that don't match basic address format
+ */
+const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
+
+export function isValidEmail(email: unknown): email is string {
+  if (typeof email !== 'string') return false
+  if (email.length > 255) return false
+  if (/[\r\n]/.test(email)) return false
+  return EMAIL_REGEX.test(email)
+}
+
+/**
+ * Escapes user-supplied strings before embedding them in HTML email templates.
+ * Prevents HTML injection attacks where an attacker crafts input containing
+ * tags, scripts, or malicious links that render inside the email.
+ */
+export function escapeHtml(value: unknown): string {
+  if (typeof value !== 'string') return ''
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#039;')
+}

--- a/dev.ps1
+++ b/dev.ps1
@@ -1,0 +1,1 @@
+op run --env-file ".env.local" -- npm run dev

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
+    "dev:secure": "op run --env-file \".env.local\" -- next dev",
     "build": "next build",
     "start": "next start",
     "lint": "next lint"


### PR DESCRIPTION
## Summary
- Added `escapeHtml` utility to `app/lib/validation.ts` - encodes `&`, `<`, `>`, `"`, and `'` into safe HTML entities
- Applied to every user-supplied value in the contact route email template
- Applied to `clientName`, `clientEmail`, `packageName` in the Stripe webhook email templates
- Raw email address preserved separately for use as the `to:` field

## Test plan
- [x] POST to /api/contact with `name: "<a href='https://evil.com'>Click me</a>"` returns 200
- [ ] Email received by Tynnell shows escaped text, not a clickable link (blocked pending domain restoration)
- [ ] Happy path contact form submission delivers correctly formatted email