### PR TITLE
feat(cms): gallery photos multi-select picker

### DIFF
--- a/app/(site)/portfolio/[slug]/page.tsx
+++ b/app/(site)/portfolio/[slug]/page.tsx
@@ -72,11 +72,8 @@ export default async function GalleryPage({ params, searchParams }: Props) {
     : null
   const coverUrl = cover?.sizes?.hero?.url ?? cover?.url ?? null
 
-  type GalleryPhotoRow = { photo: Photo | string | number; id?: string | null }
   const photos: Photo[] = Array.isArray(gallery.photos)
-    ? gallery.photos
-        .map((row: GalleryPhotoRow) => row.photo)
-        .filter((p): p is Photo => typeof p === 'object' && p !== null)
+    ? gallery.photos.filter((p): p is Photo => typeof p === 'object' && p !== null)
     : []
 
   const pageUrl = `https://tynnellhollinsphotography.com/portfolio/${gallery.slug}`

--- a/app/(site)/portfolio/page.tsx
+++ b/app/(site)/portfolio/page.tsx
@@ -36,10 +36,7 @@ export default async function PortfolioPage() {
     const previewUrls: string[] = Array.isArray(g.photos)
       ? g.photos
           .slice(0, 4)
-          .map(row => {
-            const p = typeof row.photo === 'object' && row.photo !== null ? row.photo as Photo : null
-            return p?.sizes?.card?.url ?? p?.url ?? null
-          })
+          .map(p => typeof p === 'object' && p !== null ? (p as Photo).sizes?.card?.url ?? (p as Photo).url ?? null : null)
           .filter((url): url is string => url !== null)
       : []
 

--- a/collections/Galleries.ts
+++ b/collections/Galleries.ts
@@ -86,21 +86,14 @@ export const Galleries: CollectionConfig = {
     },
     {
       name: 'photos',
-      type: 'array',
+      type: 'relationship',
       label: 'Photos in This Gallery',
+      relationTo: 'photos',
+      hasMany: true,
       admin: {
         description:
-          'Select photos to include in this gallery. Click "Add Row" to add each photo. Drag the handle on the left of each row to reorder them.',
+          'Type a filename or title to search, then click photos to select them. You can select as many as you need before saving — no need to add them one at a time.',
       },
-      fields: [
-        {
-          name: 'photo',
-          type: 'relationship',
-          label: 'Photo',
-          relationTo: 'photos',
-          required: true,
-        },
-      ],
     },
     {
       name: 'featured',

--- a/payload-types.ts
+++ b/payload-types.ts
@@ -260,14 +260,9 @@ export interface Gallery {
    */
   coverPhoto: number | Photo;
   /**
-   * Select photos to include in this gallery. Drag the handle on the left of each row to reorder them.
+   * Type a filename or title to search, then click photos to select them. You can select as many as you need before saving.
    */
-  photos?:
-    | {
-        photo: number | Photo;
-        id?: string | null;
-      }[]
-    | null;
+  photos?: (number | Photo)[] | null;
   /**
    * Turn this on to feature this gallery on your homepage.
    */
@@ -582,12 +577,7 @@ export interface GalleriesSelect<T extends boolean = true> {
   slug?: T;
   category?: T;
   coverPhoto?: T;
-  photos?:
-    | T
-    | {
-        photo?: T;
-        id?: T;
-      };
+  photos?: T;
   featured?: T;
   displayOrder?: T;
   updatedAt?: T;

--- a/scripts/migrate-db.mjs
+++ b/scripts/migrate-db.mjs
@@ -156,6 +156,61 @@ async function run() {
     `)
 
     console.log('✓ availability tables ready')
+
+    // ------------------------------------------------------------------
+    // Migration 20260608_100000: add galleries_rels table
+    // Required by reverting TYN-139: Gallery.photos changed back from
+    // array type to hasMany relationship so the admin shows a multi-select
+    // search picker instead of one-at-a-time row additions.
+    // Payload postgres adapter stores hasMany relationships in a _rels table.
+    // ------------------------------------------------------------------
+
+    await client.query(`
+      CREATE TABLE IF NOT EXISTS "galleries_rels" (
+        "id"        serial  PRIMARY KEY NOT NULL,
+        "order"     integer,
+        "parent_id" integer NOT NULL,
+        "path"      varchar NOT NULL,
+        "photos_id" integer
+      )
+    `)
+
+    await client.query(`
+      DO $$ BEGIN
+        ALTER TABLE "galleries_rels"
+          ADD CONSTRAINT "galleries_rels_parent_id_fk"
+          FOREIGN KEY ("parent_id")
+          REFERENCES "galleries"("id")
+          ON DELETE CASCADE ON UPDATE NO ACTION;
+      EXCEPTION WHEN duplicate_object THEN NULL;
+      END $$
+    `)
+
+    await client.query(`
+      DO $$ BEGIN
+        ALTER TABLE "galleries_rels"
+          ADD CONSTRAINT "galleries_rels_photos_id_fk"
+          FOREIGN KEY ("photos_id")
+          REFERENCES "photos"("id")
+          ON DELETE SET NULL ON UPDATE NO ACTION;
+      EXCEPTION WHEN duplicate_object THEN NULL;
+      END $$
+    `)
+
+    await client.query(`
+      CREATE INDEX IF NOT EXISTS "galleries_rels_order_idx"
+        ON "galleries_rels" USING btree ("order")
+    `)
+    await client.query(`
+      CREATE INDEX IF NOT EXISTS "galleries_rels_parent_id_idx"
+        ON "galleries_rels" USING btree ("parent_id")
+    `)
+    await client.query(`
+      CREATE INDEX IF NOT EXISTS "galleries_rels_photos_id_idx"
+        ON "galleries_rels" USING btree ("photos_id")
+    `)
+
+    console.log('✓ galleries_rels table ready')
   } finally {
     client.release()
     await pool.end()


### PR DESCRIPTION
## Summary

- Converts the gallery `photos` field from an array type back to a `hasMany` relationship, giving Tynnell a searchable multi-select picker in the admin instead of one-row-at-a-time additions
- Adds `galleries_rels` DB migration (Payload uses a `_rels` join table for hasMany relationships)
- Updates both portfolio pages to read the flat `(number | Photo)[]` format instead of the old `{ photo }` wrapper rows
- No visual change to the public site

## Test plan

- [ ] Open a gallery in the admin — Photos field should show a search box, not an Add Row button
- [ ] Search for photos by filename, select several at once, save — all should appear
- [ ] Visit `/portfolio` — gallery preview thumbnails still render
- [ ] Visit `/portfolio/[slug]` — photos grid still renders with correct count
- [ ] TypeScript passes: `npx tsc --noEmit`