### PR TITLE
fix(admin): CSS guard — load Payload base styles reliably

### DIFF
--- a/app/(payload)/admin/layout.tsx
+++ b/app/(payload)/admin/layout.tsx
@@ -2,6 +2,7 @@ import type { ServerFunctionClient } from 'payload'
 import { handleServerFunctions, RootLayout } from '@payloadcms/next/layouts'
 import React from 'react'
 import '../custom.css'
+import { PayloadCssGuard } from '../../../components/admin/PayloadCssGuard'
 
 import config from '@payload-config'
 import { importMap } from './importMap.js'
@@ -22,6 +23,7 @@ const serverFunction: ServerFunctionClient = async function (args) {
 export default async function Layout({ children }: Args) {
   return (
     <RootLayout config={config} importMap={importMap} serverFunction={serverFunction}>
+      <PayloadCssGuard />
       {children}
     </RootLayout>
   )

--- a/components/admin/PayloadCssGuard.tsx
+++ b/components/admin/PayloadCssGuard.tsx
@@ -1,0 +1,15 @@
+'use client'
+
+// This component exists solely to force Payload's base stylesheet into the
+// client bundle. CSS imported in a 'use client' module is extracted into a
+// static <link> tag by Next.js and is loaded independently of RSC streaming.
+// That means it survives React hydration failures — the admin never goes
+// fully unstyled even if error #418 causes a client-side re-render fallback.
+//
+// It renders nothing. Drop it anywhere in the admin layout tree.
+
+import '@payloadcms/next/css'
+
+export function PayloadCssGuard() {
+  return null
+}


### PR DESCRIPTION
## Summary

- `@payloadcms/next/css` (Payload's 300KB base stylesheet) was never imported in this project — the admin only had custom variable overrides, so all base Payload styles (nav, forms, buttons, tables) were missing
- Creates `components/admin/PayloadCssGuard.tsx`, a zero-render `'use client'` component that imports the stylesheet
- CSS imported in a client module is extracted into a static `<link>` tag by Next.js, loaded independently of RSC streaming — survives React hydration error #418 that previously left the admin unstyled

## Test plan

- [ ] Open `/admin` — nav, sidebar, form fields, buttons, and table rows should all have proper Payload styles
- [ ] Hard refresh several times — styles should be consistent every time
- [ ] TypeScript passes: `npx tsc --noEmit`