### PR TITLE
feat(admin): group nav into My Portfolio, Content, Services & Booking, Site Settings

### DIFF
--- a/collections/Galleries.ts
+++ b/collections/Galleries.ts
@@ -27,6 +27,7 @@ export const Galleries: CollectionConfig = {
     beforeValidate: [autoSlugFromTitle],
   },
   admin: {
+    group: 'My Portfolio',
     useAsTitle: 'title',
     description:
       'Curated collections of photos shown on your Portfolio page. Each gallery has a category, a cover photo, and a set of photos.',

--- a/collections/Photos.ts
+++ b/collections/Photos.ts
@@ -55,6 +55,7 @@ export const Photos: CollectionConfig = {
     mimeTypes: ['image/*'],
   },
   admin: {
+    group: 'My Portfolio',
     useAsTitle: 'title',
     description:
       'Your photo library. Drop images here and they upload instantly — title and alt text are filled in automatically from the filename so you can bulk-upload without stopping. Edit any photo afterwards to update the details.',

--- a/collections/Posts.ts
+++ b/collections/Posts.ts
@@ -31,6 +31,7 @@ export const Posts: CollectionConfig = {
     beforeValidate: [autoPopulate],
   },
   admin: {
+    group: 'Content',
     useAsTitle: 'title',
     description: 'Your blog posts, shown on the Blog page and individual post pages.',
     defaultColumns: ['coverImage', 'title', 'status', 'publishedAt', 'updatedAt'],

--- a/collections/Services.ts
+++ b/collections/Services.ts
@@ -7,6 +7,7 @@ export const Services: CollectionConfig = {
     plural: 'Services',
   },
   admin: {
+    group: 'Services & Booking',
     useAsTitle: 'title',
     description:
       'Your photography services, shown on the Services page. Services with a booking deposit set also appear on the Book a Session page.',

--- a/collections/Testimonials.ts
+++ b/collections/Testimonials.ts
@@ -7,6 +7,7 @@ export const Testimonials: CollectionConfig = {
     plural: 'Testimonials',
   },
   admin: {
+    group: 'Content',
     useAsTitle: 'clientName',
     description:
       'Reviews and quotes from your clients, shown on your homepage and testimonials page.',

--- a/globals/AboutPage.ts
+++ b/globals/AboutPage.ts
@@ -5,6 +5,7 @@ export const AboutPage: GlobalConfig = {
   slug: 'about-page',
   label: 'About Page',
   admin: {
+    group: 'Site Settings',
     description: 'Content for your About page and the about preview section on your homepage.',
   },
   fields: [

--- a/globals/Availability.ts
+++ b/globals/Availability.ts
@@ -4,7 +4,7 @@ export const Availability: GlobalConfig = {
   slug: 'availability',
   label: 'Availability',
   admin: {
-    group: 'Availability',
+    group: 'Services & Booking',
     description:
       'Block out dates when you are unavailable — vacations, personal time, recovery periods. Clients requesting sessions during these windows will see your custom message.',
   },

--- a/globals/BookingSettings.ts
+++ b/globals/BookingSettings.ts
@@ -4,7 +4,7 @@ export const BookingSettings: GlobalConfig = {
   slug: 'booking-settings',
   label: 'Booking Settings',
   admin: {
-    group: 'Availability',
+    group: 'Services & Booking',
     description:
       'Controls how far in advance clients can request sessions. Changes take effect immediately — no code change needed.',
   },

--- a/globals/HeroSlides.ts
+++ b/globals/HeroSlides.ts
@@ -4,6 +4,7 @@ export const HeroSlides: GlobalConfig = {
   slug: 'hero-slides',
   label: 'Hero Slides',
   admin: {
+    group: 'Site Settings',
     description:
       'The full-screen photo carousel on your homepage. Add, remove, or reorder slides here.',
   },

--- a/globals/SiteConfig.ts
+++ b/globals/SiteConfig.ts
@@ -4,6 +4,7 @@ export const SiteConfig: GlobalConfig = {
   slug: 'site-config',
   label: 'Site Settings',
   admin: {
+    group: 'Site Settings',
     description:
       'Global settings for your website — business name, contact info, and social media links.',
   },


### PR DESCRIPTION
## Summary

Adds `admin.group` to all 5 collections and all 5 globals so the Payload admin sidebar shows four clearly labelled sections instead of an undifferentiated alphabetical list.

| Group | Items |
|---|---|
| My Portfolio | Photos, Galleries |
| Content | Blog Posts, Testimonials |
| Services & Booking | Services, Booking Settings, Availability |
| Site Settings | Site Config, Hero Slides, About Page |

No schema changes, no migration needed.

## Test plan

- [ ] Open `/admin` sidebar — four group headings visible, items nested under each
- [ ] All links still navigate to the correct collection/global
- [ ] TypeScript passes: `npx tsc --noEmit`