### PR TITLE
TYN-247: Site rebuild foundation - Pixieset-matching layout

### DIFF
--- a/app/(site)/about/page.module.css
+++ b/app/(site)/about/page.module.css
@@ -1,33 +1,71 @@
 .main {
   background: var(--color-bg);
-  padding-top: 5rem; /* navbar height */
 }
 
 /* ── Hero ─────────────────────────────────────────────────── */
 
 .hero {
-  padding: 6rem var(--padding-x) 5rem;
-  max-width: 1200px;
-  margin: 0 auto;
+  position: relative;
+  height: 100vh;
+  min-height: 600px;
+  display: flex;
+  align-items: flex-end;
+  overflow: hidden;
+}
+
+.heroImg {
+  object-fit: cover;
+  object-position: center top;
+}
+
+.heroOverlay {
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(
+    to top,
+    rgba(12, 12, 12, 0.88) 0%,
+    rgba(12, 12, 12, 0.25) 50%,
+    rgba(12, 12, 12, 0.1) 100%
+  );
+  z-index: 1;
+}
+
+.heroContent {
+  position: relative;
+  z-index: 2;
+  padding: 4rem var(--padding-x);
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
 }
 
 .eyebrow {
-  font-family: var(--font-mono);
+  font-family: var(--font-body);
   font-size: 0.7rem;
   font-weight: 400;
-  letter-spacing: 0.25em;
+  letter-spacing: 0.3em;
   text-transform: uppercase;
-  color: var(--color-detail);
-  margin: 0 0 1.25rem;
+  color: rgba(255, 255, 255, 0.55);
+  margin: 0;
 }
 
 .heroHeading {
   font-family: var(--font-display);
-  font-size: clamp(4rem, 8vw, 7rem);
+  font-size: clamp(5rem, 12vw, 10rem);
   font-weight: 400;
-  line-height: 1.05;
-  color: var(--color-heading);
+  line-height: 0.95;
+  color: #fff;
   margin: 0;
+  text-shadow: 0 2px 30px rgba(0, 0, 0, 0.4);
+}
+
+.heroSub {
+  font-family: var(--font-body);
+  font-size: 0.72rem;
+  letter-spacing: 0.28em;
+  text-transform: uppercase;
+  color: rgba(255, 255, 255, 0.65);
+  margin-top: 0.5rem;
 }
 
 /* ── Story ────────────────────────────────────────────────── */
@@ -35,7 +73,7 @@
 .story {
   max-width: 1200px;
   margin: 0 auto;
-  padding: 4rem var(--padding-x) 6rem;
+  padding: 6rem var(--padding-x) 6rem;
   display: grid;
   grid-template-columns: 1fr 1fr;
   gap: 6rem;

--- a/app/(site)/about/page.tsx
+++ b/app/(site)/about/page.tsx
@@ -55,6 +55,7 @@ export default async function AboutPage() {
   const headshotPhoto = typeof about?.headshot === 'object' && about.headshot !== null
     ? about.headshot as Photo
     : null
+  const headshotHeroUrl = headshotPhoto?.sizes?.hero?.url ?? headshotPhoto?.url ?? null
   const headshotUrl = headshotPhoto?.sizes?.card?.url ?? headshotPhoto?.url ?? null
 
   type RawValue = { heading?: string | null; body?: string | null }
@@ -90,10 +91,22 @@ export default async function AboutPage() {
 
       {/* Hero */}
       <section className={styles.hero}>
-        <p className={styles.eyebrow}>About Tynnell</p>
-        <h1 className={styles.heroHeading}>
-          The Woman<br />Behind the Lens
-        </h1>
+        {headshotHeroUrl && (
+          <Image
+            src={headshotHeroUrl}
+            alt="Tynnell Hollins"
+            fill
+            priority
+            sizes="100vw"
+            className={styles.heroImg}
+          />
+        )}
+        <div className={styles.heroOverlay} />
+        <div className={styles.heroContent}>
+          <p className={styles.eyebrow}>About</p>
+          <h1 className={styles.heroHeading}>Tynnell Hollins</h1>
+          <p className={styles.heroSub}>The Woman Behind the Lens</p>
+        </div>
       </section>
 
       {/* Story */}

--- a/app/(site)/blog/page.module.css
+++ b/app/(site)/blog/page.module.css
@@ -1,25 +1,33 @@
 .main {
   background: var(--color-bg);
   min-height: 100vh;
+  padding-top: 5.75rem; /* nav clearance (92px) */
 }
 
-/* ── Hero ─────────────────────────────────────────────────── */
+.srOnly {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+/* ── Cover image ──────────────────────────────────────────── */
 
 .hero {
   position: relative;
   width: 100%;
-  height: 70vh;
-  min-height: 480px;
+  height: clamp(280px, 48vh, 560px);
   overflow: hidden;
-  display: flex;
-  align-items: flex-end;
+  background: var(--color-bg-accent);
 }
 
-/* Dark panel fallback when no cover image exists */
 .heroFallback {
-  height: auto;
-  min-height: 0;
-  background: var(--color-bg-accent);
+  height: clamp(180px, 28vh, 320px);
   border-bottom: 1px solid var(--color-border-solid);
 }
 
@@ -41,131 +49,72 @@
 .heroOverlay {
   position: absolute;
   inset: 0;
-  background: linear-gradient(
-    to bottom,
-    rgba(12, 12, 12, 0.08) 0%,
-    rgba(12, 12, 12, 0.0) 25%,
-    rgba(12, 12, 12, 0.72) 100%
-  );
+  background: rgba(12, 12, 12, 0.22);
   z-index: 1;
+  pointer-events: none;
 }
 
-.heroFallback .heroOverlay {
-  display: none;
-}
-
-.heroContent {
-  position: relative;
+/* "BLOG" label — bottom-right corner of cover image */
+.blogLabel {
+  position: absolute;
+  bottom: 1.75rem;
+  right: 2rem;
   z-index: 2;
-  padding: 3rem var(--padding-x) 3.5rem;
-  display: flex;
-  flex-direction: column;
-  gap: 0.5rem;
-}
-
-/* Fallback panel needs nav clearance */
-.heroFallback .heroContent {
-  padding-top: 9rem;
-  padding-bottom: 4rem;
-}
-
-.heroEyebrow {
   font-family: var(--font-body);
-  font-size: 0.65rem;
-  letter-spacing: 0.3em;
+  font-size: 0.58rem;
+  letter-spacing: 0.45em;
   text-transform: uppercase;
-  color: rgba(255, 255, 255, 0.5);
-  margin: 0;
+  color: rgba(255, 255, 255, 0.55);
+  writing-mode: vertical-rl;
+  pointer-events: none;
 }
 
-.heroFallback .heroEyebrow {
+.heroFallback .blogLabel {
   color: var(--color-detail);
 }
 
-.heroTitle {
-  font-family: var(--font-display);
-  font-size: clamp(2.75rem, 5.5vw, 5.5rem);
-  font-weight: 400;
-  line-height: 1.05;
-  color: #fff;
-  margin: 0;
-  max-width: 820px;
-  text-shadow: 0 2px 24px rgba(0, 0, 0, 0.5);
-}
+/* ── Filter bar ───────────────────────────────────────────── */
 
-.heroFallback .heroTitle {
-  color: var(--color-heading);
-  text-shadow: none;
-}
-
-.heroTitleLink {
-  color: inherit;
-  text-decoration: none;
-  transition: opacity 0.2s ease;
-}
-
-.heroTitleLink:hover {
-  opacity: 0.82;
-}
-
-.heroMeta {
+.filterBar {
   display: flex;
-  align-items: center;
-  gap: 2rem;
-  margin-top: 0.5rem;
-}
-
-.heroDate {
-  font-family: var(--font-body);
-  font-size: 0.62rem;
-  letter-spacing: 0.15em;
-  text-transform: uppercase;
-  color: rgba(255, 255, 255, 0.48);
-}
-
-.heroCta {
-  font-family: var(--font-body);
-  font-size: 0.62rem;
-  letter-spacing: 0.15em;
-  text-transform: uppercase;
-  color: rgba(255, 255, 255, 0.88);
-  text-decoration: none;
-  border-bottom: 1px solid rgba(255, 255, 255, 0.32);
-  padding-bottom: 2px;
-  transition: color 0.2s ease, border-color 0.2s ease;
-}
-
-.heroCta:hover {
-  color: #fff;
-  border-bottom-color: rgba(255, 255, 255, 0.75);
-}
-
-/* ── Journal bar ──────────────────────────────────────────── */
-
-.journalBar {
-  max-width: 1200px;
-  margin: 0 auto;
-  padding: 1.5rem var(--padding-x);
-  display: flex;
-  align-items: center;
+  align-items: stretch;
   justify-content: space-between;
+  padding: 0 var(--padding-x);
   border-bottom: 1px solid var(--color-border-solid);
 }
 
-.journalLabel {
-  font-family: var(--font-body);
-  font-size: 0.62rem;
-  letter-spacing: 0.28em;
-  text-transform: uppercase;
-  color: var(--color-detail);
+.filterCats {
+  display: flex;
+  align-items: center;
+  gap: 2rem;
 }
 
-.journalCount {
+.filterCatActive {
   font-family: var(--font-body);
   font-size: 0.62rem;
-  letter-spacing: 0.1em;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+  color: var(--color-heading);
+  padding: 1.1rem 0;
+  border-bottom: 1px solid var(--color-heading);
+  margin-bottom: -1px;
+  display: block;
+}
+
+.filterSearchBtn {
+  background: none;
+  border: none;
+  padding: 0 0.25rem;
+  cursor: pointer;
   color: var(--color-detail);
-  opacity: 0.55;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: color 0.2s ease;
+}
+
+.filterSearchBtn:hover {
+  color: var(--color-heading);
 }
 
 /* ── Empty state ──────────────────────────────────────────── */
@@ -187,8 +136,8 @@
   margin: 0 auto;
   padding: 3.5rem var(--padding-x) 5rem;
   display: grid;
-  grid-template-columns: repeat(3, 1fr);
-  gap: 4rem 2rem;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 4rem 3rem;
 }
 
 /* ── Card ─────────────────────────────────────────────────── */
@@ -366,33 +315,13 @@
 
 /* ── Responsive ───────────────────────────────────────────── */
 
-@media (min-width: 769px) and (max-width: 1024px) {
-  .grid {
-    grid-template-columns: repeat(2, 1fr);
-    gap: 3rem 1.5rem;
-  }
-}
-
 @media (max-width: 768px) {
+  .main {
+    padding-top: 4.5rem;
+  }
+
   .hero {
-    height: 55vh;
-    min-height: 360px;
-  }
-
-  .heroFallback {
-    height: auto;
-    min-height: 0;
-  }
-
-  .heroTitle {
-    font-size: clamp(2rem, 8vw, 3rem);
-  }
-
-  .heroMeta {
-    flex-direction: column;
-    align-items: flex-start;
-    gap: 0.75rem;
-    margin-top: 0.25rem;
+    height: clamp(220px, 38vh, 380px);
   }
 
   .grid {

--- a/app/(site)/blog/page.module.css
+++ b/app/(site)/blog/page.module.css
@@ -27,8 +27,10 @@
 }
 
 .heroFallback {
-  height: clamp(180px, 28vh, 320px);
-  border-bottom: 1px solid var(--color-border-solid);
+  height: clamp(280px, 48vh, 560px);
+  background-image: url('/hero-background.jpg');
+  background-size: cover;
+  background-position: center;
 }
 
 .heroImageLink {

--- a/app/(site)/blog/page.module.css
+++ b/app/(site)/blog/page.module.css
@@ -1,265 +1,206 @@
 .main {
   background: var(--color-bg);
-  padding-top: 5rem;
   min-height: 100vh;
 }
 
 /* ── Hero ─────────────────────────────────────────────────── */
 
 .hero {
-  padding: 6rem var(--padding-x) 4rem;
-  max-width: 1200px;
-  margin: 0 auto;
-  border-bottom: 1px solid var(--color-border);
+  position: relative;
+  width: 100%;
+  height: 70vh;
+  min-height: 480px;
+  overflow: hidden;
+  display: flex;
+  align-items: flex-end;
 }
 
-.eyebrow {
-  font-family: var(--font-mono);
-  font-size: 0.7rem;
-  font-weight: 400;
-  letter-spacing: 0.25em;
+/* Dark panel fallback when no cover image exists */
+.heroFallback {
+  height: auto;
+  min-height: 0;
+  background: var(--color-bg-accent);
+  border-bottom: 1px solid var(--color-border-solid);
+}
+
+.heroImageLink {
+  position: absolute;
+  inset: 0;
+  display: block;
+}
+
+.heroPhoto {
+  object-fit: cover;
+  transition: transform 0.9s ease;
+}
+
+.hero:not(.heroFallback):hover .heroPhoto {
+  transform: scale(1.025);
+}
+
+.heroOverlay {
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(
+    to bottom,
+    rgba(12, 12, 12, 0.08) 0%,
+    rgba(12, 12, 12, 0.0) 25%,
+    rgba(12, 12, 12, 0.72) 100%
+  );
+  z-index: 1;
+}
+
+.heroFallback .heroOverlay {
+  display: none;
+}
+
+.heroContent {
+  position: relative;
+  z-index: 2;
+  padding: 3rem var(--padding-x) 3.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+/* Fallback panel needs nav clearance */
+.heroFallback .heroContent {
+  padding-top: 9rem;
+  padding-bottom: 4rem;
+}
+
+.heroEyebrow {
+  font-family: var(--font-body);
+  font-size: 0.65rem;
+  letter-spacing: 0.3em;
   text-transform: uppercase;
-  color: var(--color-detail);
-  margin: 0 0 1.25rem;
+  color: rgba(255, 255, 255, 0.5);
+  margin: 0;
 }
 
-.heroHeading {
+.heroFallback .heroEyebrow {
+  color: var(--color-detail);
+}
+
+.heroTitle {
   font-family: var(--font-display);
-  font-size: clamp(3.5rem, 7vw, 6rem);
+  font-size: clamp(2.75rem, 5.5vw, 5.5rem);
   font-weight: 400;
   line-height: 1.05;
-  color: var(--color-heading);
+  color: #fff;
   margin: 0;
+  max-width: 820px;
+  text-shadow: 0 2px 24px rgba(0, 0, 0, 0.5);
+}
+
+.heroFallback .heroTitle {
+  color: var(--color-heading);
+  text-shadow: none;
+}
+
+.heroTitleLink {
+  color: inherit;
+  text-decoration: none;
+  transition: opacity 0.2s ease;
+}
+
+.heroTitleLink:hover {
+  opacity: 0.82;
+}
+
+.heroMeta {
+  display: flex;
+  align-items: center;
+  gap: 2rem;
+  margin-top: 0.5rem;
+}
+
+.heroDate {
+  font-family: var(--font-body);
+  font-size: 0.62rem;
+  letter-spacing: 0.15em;
+  text-transform: uppercase;
+  color: rgba(255, 255, 255, 0.48);
+}
+
+.heroCta {
+  font-family: var(--font-body);
+  font-size: 0.62rem;
+  letter-spacing: 0.15em;
+  text-transform: uppercase;
+  color: rgba(255, 255, 255, 0.88);
+  text-decoration: none;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.32);
+  padding-bottom: 2px;
+  transition: color 0.2s ease, border-color 0.2s ease;
+}
+
+.heroCta:hover {
+  color: #fff;
+  border-bottom-color: rgba(255, 255, 255, 0.75);
+}
+
+/* ── Journal bar ──────────────────────────────────────────── */
+
+.journalBar {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 1.5rem var(--padding-x);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  border-bottom: 1px solid var(--color-border-solid);
+}
+
+.journalLabel {
+  font-family: var(--font-body);
+  font-size: 0.62rem;
+  letter-spacing: 0.28em;
+  text-transform: uppercase;
+  color: var(--color-detail);
+}
+
+.journalCount {
+  font-family: var(--font-body);
+  font-size: 0.62rem;
+  letter-spacing: 0.1em;
+  color: var(--color-detail);
+  opacity: 0.55;
 }
 
 /* ── Empty state ──────────────────────────────────────────── */
 
 .emptyState {
   max-width: 1200px;
-  margin: 4rem auto;
-  padding: 0 var(--padding-x);
-  font-family: var(--font-mono);
-  font-size: 0.8rem;
+  margin: 0 auto;
+  padding: 3.5rem var(--padding-x) 6rem;
+  font-family: var(--font-body);
+  font-size: 0.78rem;
   letter-spacing: 0.08em;
   color: var(--color-detail);
 }
 
-/* ── Featured post ────────────────────────────────────────── */
-
-.featured {
-  max-width: 1200px;
-  margin: 0 auto;
-  border-left: 1px solid var(--color-border);
-  border-right: 1px solid var(--color-border);
-  border-bottom: 1px solid var(--color-border);
-  overflow: hidden;
-  /* Default state when no cover image */
-  background: var(--color-bg-accent);
-}
-
-/* When a cover image is present, the article becomes relative so
-   featuredContent can be absolutely pinned to the bottom */
-.featured:has(.featuredImageLink) {
-  position: relative;
-  background: transparent;
-}
-
-.featuredImageLink {
-  display: block;
-}
-
-.featuredImage {
-  position: relative;
-  width: 100%;
-  height: clamp(380px, 60vh, 680px);
-  overflow: hidden;
-}
-
-.featuredPhoto {
-  object-fit: cover;
-  transition: transform 0.7s ease;
-}
-
-.featured:hover .featuredPhoto {
-  transform: scale(1.02);
-}
-
-.featuredOverlay {
-  position: absolute;
-  inset: 0;
-  background: linear-gradient(
-    to bottom,
-    rgba(12, 12, 12, 0.15) 0%,
-    rgba(12, 12, 12, 0.0) 35%,
-    rgba(12, 12, 12, 0.8) 100%
-  );
-}
-
-/* Content block: static by default (no image), absolute when image present */
-.featuredContent {
-  padding: 3.5rem var(--padding-x);
-}
-
-.featured:has(.featuredImageLink) .featuredContent {
-  position: absolute;
-  bottom: 0;
-  left: 0;
-  right: 0;
-  padding: 2.5rem 3rem;
-}
-
-/* Text colors - default (no image) */
-.featuredEyebrow {
-  font-family: var(--font-mono);
-  font-size: 0.65rem;
-  letter-spacing: 0.25em;
-  text-transform: uppercase;
-  color: var(--color-detail);
-  margin-bottom: 0.75rem;
-}
-
-.featuredTitle {
-  font-family: var(--font-display);
-  font-size: clamp(2.5rem, 5vw, 4.5rem);
-  font-weight: 400;
-  line-height: 1.05;
-  color: var(--color-heading);
-  margin-bottom: 1rem;
-}
-
-.featuredLink {
-  color: inherit;
-  text-decoration: none;
-}
-
-.featuredExcerpt {
-  font-family: var(--font-prose);
-  font-size: 0.9rem;
-  line-height: 1.75;
-  color: var(--color-body);
-  max-width: 640px;
-  margin-bottom: 1.5rem;
-}
-
-.featuredMeta {
-  display: flex;
-  align-items: center;
-  gap: 2rem;
-}
-
-.featuredDate {
-  font-family: var(--font-mono);
-  font-size: 0.65rem;
-  letter-spacing: 0.15em;
-  text-transform: uppercase;
-  color: var(--color-detail);
-}
-
-.featuredCta {
-  font-family: var(--font-mono);
-  font-size: 0.65rem;
-  letter-spacing: 0.15em;
-  text-transform: uppercase;
-  color: var(--color-heading);
-  text-decoration: none;
-  border-bottom: 1px solid rgba(214, 209, 206, 0.3);
-  padding-bottom: 2px;
-  transition: border-color 0.2s ease, color 0.2s ease;
-}
-
-.featuredCta:hover {
-  border-color: var(--color-heading);
-}
-
-/* Text colors - overlaid on cover image */
-.featured:has(.featuredImageLink) .featuredEyebrow {
-  color: rgba(255, 255, 255, 0.6);
-}
-
-.featured:has(.featuredImageLink) .featuredTitle {
-  color: #fff;
-}
-
-.featured:has(.featuredImageLink) .featuredExcerpt {
-  color: rgba(230, 225, 222, 0.85);
-}
-
-.featured:has(.featuredImageLink) .featuredDate {
-  color: rgba(255, 255, 255, 0.5);
-}
-
-.featured:has(.featuredImageLink) .featuredCta {
-  color: rgba(255, 255, 255, 0.9);
-  border-bottom-color: rgba(255, 255, 255, 0.3);
-}
-
-.featured:has(.featuredImageLink) .featuredCta:hover {
-  color: #fff;
-  border-bottom-color: rgba(255, 255, 255, 0.8);
-}
-
-/* ── More posts grid - taped polaroid style ────────────────── */
+/* ── Posts grid ───────────────────────────────────────────── */
 
 .grid {
   max-width: 1200px;
   margin: 0 auto;
-  padding: 3rem var(--padding-x) 4rem;
+  padding: 3.5rem var(--padding-x) 5rem;
   display: grid;
   grid-template-columns: repeat(3, 1fr);
-  gap: 4.5rem 2.5rem;
+  gap: 4rem 2rem;
 }
+
+/* ── Card ─────────────────────────────────────────────────── */
 
 .card {
   display: flex;
   flex-direction: column;
 }
 
-/* The image link wrapper becomes the cream polaroid mat */
 .cardImageLink {
   display: block;
-  position: relative;
-  background: var(--tape-mat);
-  padding: 0.6rem 0.6rem 2rem;
-  box-shadow: var(--tape-shadow);
-  transition: transform 0.3s ease, box-shadow 0.3s ease;
-}
-
-/* Washi-tape corners at the top of each polaroid */
-.cardImageLink::before,
-.cardImageLink::after {
-  content: '';
-  position: absolute;
-  top: -0.5rem;
-  width: 4rem;
-  height: 1.25rem;
-  background: var(--tape-color);
-  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.18);
-  z-index: 3;
-}
-
-.cardImageLink::before {
-  left: 0.8rem;
-  transform: rotate(-30deg);
-}
-
-.cardImageLink::after {
-  right: 0.8rem;
-  transform: rotate(30deg);
-}
-
-/* Alternating tilts so adjacent cards dont mirror each other */
-.card:nth-child(odd) .cardImageLink {
-  transform: rotate(-1.5deg);
-}
-
-.card:nth-child(even) .cardImageLink {
-  transform: rotate(1.2deg);
-}
-
-/* Hover: straighten, lift, and subtly zoom the photo */
-.card:hover .cardImageLink {
-  transform: rotate(0deg) scale(1.02);
-  box-shadow: 0 16px 48px rgba(0, 0, 0, 0.65);
+  overflow: hidden;
 }
 
 .cardImage {
@@ -271,24 +212,39 @@
 
 .cardPhoto {
   object-fit: cover;
-  transition: transform 0.5s ease;
+  transition: transform 0.6s ease;
 }
 
 .card:hover .cardPhoto {
-  transform: scale(1.03);
+  transform: scale(1.05);
+}
+
+.cardPlaceholder {
+  width: 100%;
+  height: 100%;
+  background: var(--color-bg-accent);
 }
 
 .cardBody {
-  padding: 1.5rem 0.25rem 2rem;
+  padding: 1.25rem 0 2rem;
   display: flex;
   flex-direction: column;
-  gap: 0.75rem;
+  gap: 0.6rem;
   flex: 1;
+}
+
+.cardDate {
+  font-family: var(--font-body);
+  font-size: 0.6rem;
+  letter-spacing: 0.15em;
+  text-transform: uppercase;
+  color: var(--color-detail);
+  opacity: 0.65;
 }
 
 .cardTitle {
   font-family: var(--font-display);
-  font-size: 1.75rem;
+  font-size: clamp(1.4rem, 2vw, 1.9rem);
   font-weight: 400;
   line-height: 1.15;
   color: var(--color-heading);
@@ -302,39 +258,33 @@
 }
 
 .cardLink:hover {
-  opacity: 0.7;
-}
-
-.cardDate {
-  font-family: var(--font-mono);
-  font-size: 0.65rem;
-  font-weight: 300;
-  color: var(--color-detail);
-  margin: 0;
+  opacity: 0.68;
 }
 
 .cardExcerpt {
   font-family: var(--font-prose);
   font-size: 0.875rem;
-  font-weight: 400;
   line-height: 1.75;
   color: var(--color-body);
   margin: 0;
   flex: 1;
+  display: -webkit-box;
+  -webkit-line-clamp: 3;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
 }
 
 .readMore {
-  font-family: var(--font-mono);
-  font-size: 0.65rem;
-  font-weight: 400;
+  font-family: var(--font-body);
+  font-size: 0.6rem;
   letter-spacing: 0.15em;
   text-transform: uppercase;
   color: var(--color-detail);
   text-decoration: none;
   margin-top: auto;
   padding-top: 0.5rem;
-  transition: color 0.2s ease;
   align-self: flex-start;
+  transition: color 0.2s ease;
 }
 
 .readMore:hover {
@@ -344,19 +294,22 @@
 /* ── CTA ──────────────────────────────────────────────────── */
 
 .cta {
-  text-align: center;
-  padding: var(--padding-block) var(--padding-x);
   background: var(--color-bg-accent);
-  border-top: 1px solid rgba(255,255,255,0.05);
+  border-top: 1px solid var(--color-border-solid);
+  padding: var(--padding-block) var(--padding-x);
+  text-align: center;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1.25rem;
 }
 
 .ctaEyebrow {
   font-family: var(--font-body);
-  font-size: 0.68rem;
+  font-size: 0.65rem;
   letter-spacing: 0.25em;
   text-transform: uppercase;
   color: var(--color-detail);
-  margin-bottom: 1rem;
 }
 
 .ctaHeading {
@@ -365,7 +318,7 @@
   font-weight: 400;
   color: var(--color-heading);
   line-height: 1.1;
-  margin-bottom: 2rem;
+  margin: 0;
 }
 
 .ctaActions {
@@ -373,41 +326,42 @@
   gap: 1rem;
   justify-content: center;
   flex-wrap: wrap;
+  margin-top: 0.5rem;
 }
 
 .ctaBtn {
   display: inline-block;
   font-family: var(--font-body);
-  font-size: 0.75rem;
+  font-size: 0.7rem;
   letter-spacing: 0.15em;
   text-transform: uppercase;
-  color: var(--color-bg);
+  color: var(--color-btn-text);
   background: var(--color-btn-bg);
   text-decoration: none;
-  padding: 0.875rem 2rem;
-  transition: opacity 0.2s ease;
+  padding: 0.9rem 2.5rem;
+  transition: background 0.2s ease;
 }
 
 .ctaBtn:hover {
-  opacity: 0.85;
+  background: var(--color-btn-hover);
 }
 
 .ctaBtnSecondary {
   display: inline-block;
   font-family: var(--font-body);
-  font-size: 0.75rem;
+  font-size: 0.7rem;
   letter-spacing: 0.15em;
   text-transform: uppercase;
   color: var(--color-detail);
   text-decoration: none;
-  padding: 0.875rem 2rem;
-  border: 1px solid rgba(155,154,154,0.3);
+  padding: 0.9rem 2.5rem;
+  border: 1px solid rgba(155, 154, 154, 0.3);
   transition: color 0.2s ease, border-color 0.2s ease;
 }
 
 .ctaBtnSecondary:hover {
   color: var(--color-heading);
-  border-color: rgba(155,154,154,0.6);
+  border-color: rgba(155, 154, 154, 0.6);
 }
 
 /* ── Responsive ───────────────────────────────────────────── */
@@ -415,44 +369,35 @@
 @media (min-width: 769px) and (max-width: 1024px) {
   .grid {
     grid-template-columns: repeat(2, 1fr);
-    gap: 4rem 2rem;
-  }
-
-  .featured:has(.featuredImageLink) .featuredContent {
-    padding: 2rem var(--padding-x);
+    gap: 3rem 1.5rem;
   }
 }
 
 @media (max-width: 768px) {
   .hero {
-    padding: 4rem var(--padding-x) 3rem;
+    height: 55vh;
+    min-height: 360px;
   }
 
-  .featuredImage {
-    height: clamp(280px, 50vh, 420px);
+  .heroFallback {
+    height: auto;
+    min-height: 0;
   }
 
-  .featured:has(.featuredImageLink) .featuredContent {
-    padding: 1.5rem var(--padding-x);
+  .heroTitle {
+    font-size: clamp(2rem, 8vw, 3rem);
   }
 
-  .featuredContent {
-    padding: 2.5rem var(--padding-x);
-  }
-
-  .featuredMeta {
+  .heroMeta {
     flex-direction: column;
     align-items: flex-start;
     gap: 0.75rem;
+    margin-top: 0.25rem;
   }
 
   .grid {
     grid-template-columns: 1fr;
     padding: 2.5rem var(--padding-x) 4rem;
-    gap: 4rem;
-  }
-
-  .cardBody {
-    padding: 1.25rem 0.25rem 1.5rem;
+    gap: 3rem;
   }
 }

--- a/app/(site)/blog/page.tsx
+++ b/app/(site)/blog/page.tsx
@@ -7,7 +7,6 @@ import type { Photo } from '@/payload-types'
 import JsonLd from '@/app/components/JsonLd/JsonLd'
 import styles from './page.module.css'
 
-// Blog listing - posts are published infrequently, revalidate every 2 minutes
 export const revalidate = 120
 
 export const metadata: Metadata = {
@@ -26,16 +25,13 @@ export default async function BlogPage() {
   })
 
   const featuredPost = posts[0] ?? null
-  const remainingPosts = posts.slice(1)
-
-  // Pre-compute featured post data outside JSX to keep template readable
   const featuredCover =
     featuredPost && typeof featuredPost.coverImage === 'object' && featuredPost.coverImage !== null
       ? (featuredPost.coverImage as Photo)
       : null
   const featuredCoverUrl = featuredCover?.sizes?.hero?.url ?? featuredCover?.url ?? null
   const featuredSlug = featuredPost
-    ? typeof featuredPost.slug === 'string' ? featuredPost.slug : ''
+    ? (typeof featuredPost.slug === 'string' ? featuredPost.slug : '')
     : ''
 
   const blogSchema = posts.length > 0 ? {
@@ -58,124 +54,128 @@ export default async function BlogPage() {
     <main className={styles.main}>
       {blogSchema && <JsonLd data={blogSchema} />}
 
-      {/* Hero */}
-      <section className={styles.hero}>
-        <p className={styles.eyebrow}>Journal</p>
-        <h1 className={styles.heroHeading}>Stories from<br />Behind the Lens</h1>
+      {/* Hero - featured post cover fills the viewport width */}
+      <section
+        className={`${styles.hero} ${!featuredCoverUrl ? styles.heroFallback : ''}`}
+        aria-label="Journal"
+      >
+        {featuredCoverUrl && featuredPost && (
+          <Link
+            href={`/blog/${featuredSlug}`}
+            className={styles.heroImageLink}
+            tabIndex={-1}
+            aria-hidden="true"
+          >
+            <Image
+              src={featuredCoverUrl}
+              alt={featuredCover?.alt ?? featuredPost.title}
+              fill
+              priority
+              sizes="100vw"
+              className={styles.heroPhoto}
+            />
+          </Link>
+        )}
+        <div className={styles.heroOverlay} />
+        <div className={styles.heroContent}>
+          <p className={styles.heroEyebrow}>Journal</p>
+          {featuredPost ? (
+            <>
+              <h1 className={styles.heroTitle}>
+                <Link href={`/blog/${featuredSlug}`} className={styles.heroTitleLink}>
+                  {featuredPost.title}
+                </Link>
+              </h1>
+              <div className={styles.heroMeta}>
+                {featuredPost.publishedAt && (
+                  <time className={styles.heroDate} dateTime={featuredPost.publishedAt}>
+                    {new Date(featuredPost.publishedAt).toLocaleDateString('en-US', {
+                      year: 'numeric', month: 'long', day: 'numeric',
+                    })}
+                  </time>
+                )}
+                <Link href={`/blog/${featuredSlug}`} className={styles.heroCta}>
+                  Read Article
+                </Link>
+              </div>
+            </>
+          ) : (
+            <h1 className={styles.heroTitle}>{"Stories from Behind the Lens"}</h1>
+          )}
+        </div>
       </section>
 
+      {/* Journal bar */}
+      <div className={styles.journalBar}>
+        <span className={styles.journalLabel}>The Journal</span>
+        {posts.length > 0 && (
+          <span className={styles.journalCount}>
+            {posts.length} {posts.length === 1 ? 'post' : 'posts'}
+          </span>
+        )}
+      </div>
+
+      {/* Posts grid */}
       {posts.length === 0 ? (
         <p className={styles.emptyState}>New posts are on their way. Check back soon.</p>
       ) : (
-        <>
-          {/* Featured post - most recent, full width with cover hero */}
-          {featuredPost && (
-            <article className={styles.featured}>
-              {featuredCoverUrl && (
+        <section className={styles.grid} aria-label="All posts">
+          {posts.map((post) => {
+            const cover =
+              typeof post.coverImage === 'object' && post.coverImage !== null
+                ? (post.coverImage as Photo)
+                : null
+            const coverUrl = cover?.sizes?.card?.url ?? cover?.url ?? null
+            const slug = typeof post.slug === 'string' ? post.slug : ''
+
+            return (
+              <article key={post.id} className={styles.card}>
                 <Link
-                  href={`/blog/${featuredSlug}`}
-                  className={styles.featuredImageLink}
+                  href={`/blog/${slug}`}
+                  className={styles.cardImageLink}
                   tabIndex={-1}
                   aria-hidden="true"
                 >
-                  <div className={styles.featuredImage}>
-                    <Image
-                      src={featuredCoverUrl}
-                      alt={featuredCover?.alt ?? featuredPost.title}
-                      fill
-                      priority
-                      sizes="100vw"
-                      className={styles.featuredPhoto}
-                    />
-                    <div className={styles.featuredOverlay} />
+                  <div className={styles.cardImage}>
+                    {coverUrl ? (
+                      <Image
+                        src={coverUrl}
+                        alt={cover?.alt ?? post.title}
+                        fill
+                        sizes="(max-width: 768px) 100vw, (max-width: 1024px) 50vw, 33vw"
+                        className={styles.cardPhoto}
+                      />
+                    ) : (
+                      <div className={styles.cardPlaceholder} />
+                    )}
                   </div>
                 </Link>
-              )}
-              <div className={styles.featuredContent}>
-                <p className={styles.featuredEyebrow}>Latest Post</p>
-                <h2 className={styles.featuredTitle}>
-                  <Link href={`/blog/${featuredSlug}`} className={styles.featuredLink}>
-                    {featuredPost.title}
-                  </Link>
-                </h2>
-                {featuredPost.excerpt && (
-                  <p className={styles.featuredExcerpt}>{featuredPost.excerpt}</p>
-                )}
-                <div className={styles.featuredMeta}>
-                  {featuredPost.publishedAt && (
-                    <time className={styles.featuredDate} dateTime={featuredPost.publishedAt}>
-                      {new Date(featuredPost.publishedAt).toLocaleDateString('en-US', {
+                <div className={styles.cardBody}>
+                  {post.publishedAt && (
+                    <time className={styles.cardDate} dateTime={post.publishedAt}>
+                      {new Date(post.publishedAt).toLocaleDateString('en-US', {
                         year: 'numeric', month: 'long', day: 'numeric',
                       })}
                     </time>
                   )}
-                  <Link href={`/blog/${featuredSlug}`} className={styles.featuredCta}>
-                    Read Article
+                  <h2 className={styles.cardTitle}>
+                    <Link href={`/blog/${slug}`} className={styles.cardLink}>
+                      {post.title}
+                    </Link>
+                  </h2>
+                  {post.excerpt && <p className={styles.cardExcerpt}>{post.excerpt}</p>}
+                  <Link
+                    href={`/blog/${slug}`}
+                    className={styles.readMore}
+                    aria-label={`Read: ${post.title}`}
+                  >
+                    Read More
                   </Link>
                 </div>
-              </div>
-            </article>
-          )}
-
-          {/* Remaining posts grid */}
-          {remainingPosts.length > 0 && (
-            <section className={styles.grid} aria-label="More posts">
-              {remainingPosts.map((post) => {
-                const cover =
-                  typeof post.coverImage === 'object' && post.coverImage !== null
-                    ? (post.coverImage as Photo)
-                    : null
-                const coverUrl = cover?.sizes?.card?.url ?? cover?.url ?? null
-                const slug = typeof post.slug === 'string' ? post.slug : ''
-
-                return (
-                  <article key={post.id} className={styles.card}>
-                    {coverUrl && (
-                      <Link
-                        href={`/blog/${slug}`}
-                        className={styles.cardImageLink}
-                        tabIndex={-1}
-                        aria-hidden="true"
-                      >
-                        <div className={styles.cardImage}>
-                          <Image
-                            src={coverUrl}
-                            alt={cover?.alt ?? post.title}
-                            fill
-                            sizes="(max-width: 768px) 100vw, 33vw"
-                            className={styles.cardPhoto}
-                          />
-                        </div>
-                      </Link>
-                    )}
-                    <div className={styles.cardBody}>
-                      {post.publishedAt && (
-                        <time className={styles.cardDate} dateTime={post.publishedAt}>
-                          {new Date(post.publishedAt).toLocaleDateString('en-US', {
-                            year: 'numeric', month: 'long', day: 'numeric',
-                          })}
-                        </time>
-                      )}
-                      <h2 className={styles.cardTitle}>
-                        <Link href={`/blog/${slug}`} className={styles.cardLink}>
-                          {post.title}
-                        </Link>
-                      </h2>
-                      {post.excerpt && <p className={styles.cardExcerpt}>{post.excerpt}</p>}
-                      <Link
-                        href={`/blog/${slug}`}
-                        className={styles.readMore}
-                        aria-label={`Read: ${post.title}`}
-                      >
-                        Read More
-                      </Link>
-                    </div>
-                  </article>
-                )
-              })}
-            </section>
-          )}
-        </>
+              </article>
+            )
+          })}
+        </section>
       )}
 
       {/* CTA */}
@@ -187,7 +187,6 @@ export default async function BlogPage() {
           <Link href="/portfolio" className={styles.ctaBtnSecondary}>View Portfolio</Link>
         </div>
       </section>
-
     </main>
   )
 }

--- a/app/(site)/blog/page.tsx
+++ b/app/(site)/blog/page.tsx
@@ -140,15 +140,6 @@ export default async function BlogPage() {
         </section>
       )}
 
-      {/* CTA */}
-      <section className={styles.cta}>
-        <p className={styles.ctaEyebrow}>{"Let's work together"}</p>
-        <h2 className={styles.ctaHeading}>{"Ready to book"}<br />{"your session?"}</h2>
-        <div className={styles.ctaActions}>
-          <Link href="/book" className={styles.ctaBtn}>Book a Session</Link>
-          <Link href="/portfolio" className={styles.ctaBtnSecondary}>View Portfolio</Link>
-        </div>
-      </section>
     </main>
   )
 }

--- a/app/(site)/blog/page.tsx
+++ b/app/(site)/blog/page.tsx
@@ -53,19 +53,12 @@ export default async function BlogPage() {
   return (
     <main className={styles.main}>
       {blogSchema && <JsonLd data={blogSchema} />}
+      <h1 className={styles.srOnly}>The Journal</h1>
 
-      {/* Hero - featured post cover fills the viewport width */}
-      <section
-        className={`${styles.hero} ${!featuredCoverUrl ? styles.heroFallback : ''}`}
-        aria-label="Journal"
-      >
+      {/* Cover image - sits below the fixed nav */}
+      <section className={`${styles.hero} ${!featuredCoverUrl ? styles.heroFallback : ''}`} aria-label="Journal">
         {featuredCoverUrl && featuredPost && (
-          <Link
-            href={`/blog/${featuredSlug}`}
-            className={styles.heroImageLink}
-            tabIndex={-1}
-            aria-hidden="true"
-          >
+          <Link href={`/blog/${featuredSlug}`} className={styles.heroImageLink} tabIndex={-1} aria-hidden="true">
             <Image
               src={featuredCoverUrl}
               alt={featuredCover?.alt ?? featuredPost.title}
@@ -76,43 +69,21 @@ export default async function BlogPage() {
             />
           </Link>
         )}
-        <div className={styles.heroOverlay} />
-        <div className={styles.heroContent}>
-          <p className={styles.heroEyebrow}>Journal</p>
-          {featuredPost ? (
-            <>
-              <h1 className={styles.heroTitle}>
-                <Link href={`/blog/${featuredSlug}`} className={styles.heroTitleLink}>
-                  {featuredPost.title}
-                </Link>
-              </h1>
-              <div className={styles.heroMeta}>
-                {featuredPost.publishedAt && (
-                  <time className={styles.heroDate} dateTime={featuredPost.publishedAt}>
-                    {new Date(featuredPost.publishedAt).toLocaleDateString('en-US', {
-                      year: 'numeric', month: 'long', day: 'numeric',
-                    })}
-                  </time>
-                )}
-                <Link href={`/blog/${featuredSlug}`} className={styles.heroCta}>
-                  Read Article
-                </Link>
-              </div>
-            </>
-          ) : (
-            <h1 className={styles.heroTitle}>{"Stories from Behind the Lens"}</h1>
-          )}
-        </div>
+        {featuredCoverUrl && <div className={styles.heroOverlay} />}
+        <span className={styles.blogLabel} aria-hidden="true">Blog</span>
       </section>
 
-      {/* Journal bar */}
-      <div className={styles.journalBar}>
-        <span className={styles.journalLabel}>The Journal</span>
-        {posts.length > 0 && (
-          <span className={styles.journalCount}>
-            {posts.length} {posts.length === 1 ? 'post' : 'posts'}
-          </span>
-        )}
+      {/* Filter bar */}
+      <div className={styles.filterBar}>
+        <div className={styles.filterCats}>
+          <span className={styles.filterCatActive}>All</span>
+        </div>
+        <button className={styles.filterSearchBtn} aria-label="Search posts">
+          <svg width="16" height="16" viewBox="0 0 16 16" fill="none" aria-hidden="true">
+            <circle cx="6.5" cy="6.5" r="5" stroke="currentColor" strokeWidth="1.25" />
+            <path d="M10.5 10.5L14 14" stroke="currentColor" strokeWidth="1.25" strokeLinecap="round" />
+          </svg>
+        </button>
       </div>
 
       {/* Posts grid */}
@@ -130,19 +101,14 @@ export default async function BlogPage() {
 
             return (
               <article key={post.id} className={styles.card}>
-                <Link
-                  href={`/blog/${slug}`}
-                  className={styles.cardImageLink}
-                  tabIndex={-1}
-                  aria-hidden="true"
-                >
+                <Link href={`/blog/${slug}`} className={styles.cardImageLink} tabIndex={-1} aria-hidden="true">
                   <div className={styles.cardImage}>
                     {coverUrl ? (
                       <Image
                         src={coverUrl}
                         alt={cover?.alt ?? post.title}
                         fill
-                        sizes="(max-width: 768px) 100vw, (max-width: 1024px) 50vw, 33vw"
+                        sizes="(max-width: 768px) 100vw, 50vw"
                         className={styles.cardPhoto}
                       />
                     ) : (
@@ -164,11 +130,7 @@ export default async function BlogPage() {
                     </Link>
                   </h2>
                   {post.excerpt && <p className={styles.cardExcerpt}>{post.excerpt}</p>}
-                  <Link
-                    href={`/blog/${slug}`}
-                    className={styles.readMore}
-                    aria-label={`Read: ${post.title}`}
-                  >
+                  <Link href={`/blog/${slug}`} className={styles.readMore} aria-label={`Read: ${post.title}`}>
                     Read More
                   </Link>
                 </div>

--- a/app/(site)/layout.tsx
+++ b/app/(site)/layout.tsx
@@ -1,5 +1,5 @@
 import type { Metadata, Viewport } from 'next'
-import { Tangerine, Archivo, Roboto_Mono } from 'next/font/google'
+import { Tangerine, Archivo, Roboto_Mono, Abril_Fatface } from 'next/font/google'
 import './globals.css'
 import './styles/tokens.css'
 import Navbar from '../components/Navbar/Navbar'
@@ -16,9 +16,16 @@ const tangerine = Tangerine({
 })
 
 const archivo = Archivo({
-  weight: ['400', '500', '600'],
+  weight: ['400', '500', '600', '700', '800'],
   subsets: ['latin'],
   variable: '--font-heading',
+  display: 'swap',
+})
+
+const abrialFatface = Abril_Fatface({
+  weight: ['400'],
+  subsets: ['latin'],
+  variable: '--font-display-bold',
   display: 'swap',
 })
 
@@ -65,7 +72,7 @@ export default async function RootLayout({
   const builderLinks = await getBuilderNavLinks()
 
   return (
-    <html lang="en" className={`${tangerine.variable} ${archivo.variable} ${robotoMono.variable}`}>
+    <html lang="en" className={`${tangerine.variable} ${archivo.variable} ${robotoMono.variable} ${abrialFatface.variable}`}>
       <body suppressHydrationWarning>
         <a href="#main-content" className="skipLink">Skip to content</a>
         <Navbar builderLinks={builderLinks} />

--- a/app/(site)/portfolio/_components/CategoryPage.module.css
+++ b/app/(site)/portfolio/_components/CategoryPage.module.css
@@ -1,0 +1,112 @@
+.hero {
+  position: relative;
+  height: 85vh;
+  min-height: 520px;
+  overflow: hidden;
+}
+
+.heroImg {
+  object-fit: cover;
+  object-position: center;
+}
+
+.heroOverlay {
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(to top, rgba(0,0,0,0.55) 0%, transparent 50%);
+  pointer-events: none;
+}
+
+.heroContent {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  padding: 2.5rem var(--padding-x);
+  gap: 2rem;
+}
+
+.titleBox {
+  background: var(--color-bg-overlay);
+  padding: 1.25rem 2rem;
+  backdrop-filter: blur(8px);
+}
+
+.title {
+  font-family: var(--font-heading);
+  font-size: clamp(2.5rem, 6vw, 5rem);
+  font-weight: 700;
+  color: #fff;
+  letter-spacing: -0.01em;
+  line-height: 1;
+}
+
+.descBox {
+  background: var(--color-bg-overlay);
+  padding: 1.25rem 1.75rem;
+  backdrop-filter: blur(8px);
+  max-width: 400px;
+}
+
+.desc {
+  font-family: var(--font-body);
+  font-size: 0.75rem;
+  letter-spacing: 0.04em;
+  color: rgba(214, 209, 206, 0.9);
+  line-height: 1.8;
+}
+
+/* ── CTA ─────────────────────────────────────────────────── */
+
+.cta {
+  padding: 5rem var(--padding-x);
+  text-align: center;
+  border-top: 1px solid var(--color-border);
+}
+
+.ctaText {
+  font-family: var(--font-body);
+  font-size: 0.72rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--color-detail);
+  margin-bottom: 1.5rem;
+}
+
+.ctaBtn {
+  display: inline-block;
+  font-family: var(--font-body);
+  font-size: 0.7rem;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--color-heading);
+  text-decoration: none;
+  border: 1px solid var(--color-border);
+  padding: 0.9rem 2.5rem;
+  transition: background 0.2s ease, color 0.2s ease;
+}
+
+.ctaBtn:hover {
+  background: var(--color-heading);
+  color: var(--color-bg);
+}
+
+/* ── Responsive ──────────────────────────────────────────── */
+
+@media (max-width: 640px) {
+  .hero { height: 65vh; }
+
+  .heroContent {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.75rem;
+    padding: 1.5rem var(--padding-x);
+  }
+
+  .descBox {
+    max-width: 100%;
+  }
+}

--- a/app/(site)/portfolio/_components/CategoryPhotoGrid.module.css
+++ b/app/(site)/portfolio/_components/CategoryPhotoGrid.module.css
@@ -1,0 +1,37 @@
+.grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 0;
+}
+
+.cell {
+  position: relative;
+  aspect-ratio: 4 / 3;
+  overflow: hidden;
+  cursor: zoom-in;
+  background: var(--color-bg-card);
+}
+
+.img {
+  object-fit: cover;
+  transition: transform 0.5s ease;
+}
+
+.cell:hover .img {
+  transform: scale(1.03);
+}
+
+.empty {
+  font-family: var(--font-body);
+  font-size: 0.8rem;
+  letter-spacing: 0.08em;
+  color: var(--color-detail);
+  padding: 4rem var(--padding-x);
+  text-align: center;
+}
+
+@media (max-width: 640px) {
+  .grid {
+    grid-template-columns: 1fr;
+  }
+}

--- a/app/(site)/portfolio/_components/CategoryPhotoGrid.tsx
+++ b/app/(site)/portfolio/_components/CategoryPhotoGrid.tsx
@@ -1,0 +1,163 @@
+'use client'
+import { useState, useCallback, useEffect, useRef } from 'react'
+import { ProtectedImage } from '@/app/components/ProtectedImage/ProtectedImage'
+import styles from './CategoryPhotoGrid.module.css'
+
+export type CategoryPhoto = {
+  id: string
+  title?: string | null
+  alt?: string | null
+  imageUrl: string | null
+  fullUrl: string | null
+}
+
+const NAV_BTN: React.CSSProperties = {
+  position: 'absolute',
+  top: '50%',
+  transform: 'translateY(-50%)',
+  background: 'rgba(255,255,255,0.07)',
+  border: '1px solid rgba(255,255,255,0.14)',
+  color: '#d6d1ce',
+  width: 48,
+  height: 48,
+  borderRadius: '50%',
+  cursor: 'pointer',
+  fontSize: '1.1rem',
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  backdropFilter: 'blur(4px)',
+}
+
+export default function CategoryPhotoGrid({ photos }: { photos: CategoryPhoto[] }) {
+  const [lightboxIdx, setLightboxIdx] = useState<number | null>(null)
+  const [imgLoading, setImgLoading] = useState(false)
+  const touchStartX = useRef<number | null>(null)
+  const previousFocusRef = useRef<HTMLElement | null>(null)
+  const closeBtnRef = useRef<HTMLButtonElement>(null)
+
+  const closeLightbox = useCallback(() => setLightboxIdx(null), [])
+  const prevPhoto = useCallback(() => { setImgLoading(true); setLightboxIdx(i => i !== null ? (i - 1 + photos.length) % photos.length : null) }, [photos.length])
+  const nextPhoto = useCallback(() => { setImgLoading(true); setLightboxIdx(i => i !== null ? (i + 1) % photos.length : null) }, [photos.length])
+
+  const openPhoto = useCallback((i: number) => {
+    previousFocusRef.current = document.activeElement as HTMLElement
+    setImgLoading(true)
+    setLightboxIdx(i)
+  }, [])
+
+  useEffect(() => {
+    if (lightboxIdx !== null) closeBtnRef.current?.focus()
+    else previousFocusRef.current?.focus()
+  }, [lightboxIdx])
+
+  useEffect(() => {
+    if (lightboxIdx === null) return
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') closeLightbox()
+      else if (e.key === 'ArrowLeft') prevPhoto()
+      else if (e.key === 'ArrowRight') nextPhoto()
+    }
+    window.addEventListener('keydown', handler)
+    document.body.style.overflow = 'hidden'
+    return () => { window.removeEventListener('keydown', handler); document.body.style.overflow = '' }
+  }, [lightboxIdx, closeLightbox, prevPhoto, nextPhoto])
+
+  useEffect(() => {
+    if (lightboxIdx === null || photos.length < 2) return
+    const adjacentIdxs = [(lightboxIdx + 1) % photos.length, (lightboxIdx - 1 + photos.length) % photos.length]
+    adjacentIdxs.forEach(i => {
+      const url = photos[i]?.fullUrl ?? photos[i]?.imageUrl
+      if (url) { const img = new window.Image(); img.src = url }
+    })
+  }, [lightboxIdx, photos])
+
+  const currentPhoto = lightboxIdx !== null ? photos[lightboxIdx] : null
+
+  if (!photos.length) {
+    return <p className={styles.empty}>No photos in this category yet.</p>
+  }
+
+  return (
+    <>
+      <div className={styles.grid}>
+        {photos.map((photo, i) =>
+          photo.imageUrl ? (
+            <div
+              key={photo.id}
+              className={styles.cell}
+              role="button"
+              tabIndex={0}
+              aria-label={`View photo${photo.alt ? `: ${photo.alt}` : photo.title ? `: ${photo.title}` : ''}`}
+              onClick={() => openPhoto(i)}
+              onKeyDown={e => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); openPhoto(i) } }}
+            >
+              <ProtectedImage
+                src={photo.imageUrl}
+                alt={photo.alt ?? photo.title ?? ''}
+                fill
+                sizes="(max-width: 640px) 100vw, 50vw"
+                className={styles.img}
+              />
+            </div>
+          ) : null
+        )}
+      </div>
+
+      {currentPhoto !== null && lightboxIdx !== null && (
+        <div
+          role="dialog"
+          aria-modal="true"
+          aria-label={`Photo ${lightboxIdx + 1} of ${photos.length}`}
+          style={{ position: 'fixed', inset: 0, zIndex: 9999, background: 'rgba(0,0,0,0.96)', display: 'flex', alignItems: 'center', justifyContent: 'center' }}
+          onClick={closeLightbox}
+          onTouchStart={e => { touchStartX.current = e.touches[0].clientX }}
+          onTouchEnd={e => {
+            if (touchStartX.current === null) return
+            const delta = e.changedTouches[0].clientX - touchStartX.current
+            touchStartX.current = null
+            if (Math.abs(delta) < 50) return
+            e.stopPropagation()
+            if (delta < 0) nextPhoto(); else prevPhoto()
+          }}
+        >
+          {photos.length > 1 && (
+            <button type="button" onClick={e => { e.stopPropagation(); prevPhoto() }} aria-label="Previous photo" style={{ ...NAV_BTN, left: '1rem' }}>&#8592;</button>
+          )}
+          {imgLoading && (
+            <div aria-label="Loading image" style={{ position: 'absolute', pointerEvents: 'none' }}>
+              <div style={{ width: 32, height: 32, border: '2px solid rgba(214,209,206,0.2)', borderTopColor: '#d6d1ce', borderRadius: '50%', animation: 'spin 0.7s linear infinite' }} />
+              <style>{`@keyframes spin { to { transform: rotate(360deg) } }`}</style>
+            </div>
+          )}
+          <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', maxWidth: '90vw', maxHeight: '90vh' }} onClick={e => e.stopPropagation()}>
+            {/* eslint-disable-next-line @next/next/no-img-element */}
+            <img
+              src={currentPhoto.fullUrl ?? currentPhoto.imageUrl ?? ''}
+              alt={currentPhoto.alt ?? currentPhoto.title ?? ''}
+              draggable={false}
+              onLoad={() => setImgLoading(false)}
+              onContextMenu={e => e.preventDefault()}
+              style={{ maxWidth: '90vw', maxHeight: '85vh', objectFit: 'contain', display: 'block', userSelect: 'none', opacity: imgLoading ? 0 : 1, transition: 'opacity 0.2s' }}
+            />
+          </div>
+          {photos.length > 1 && (
+            <button type="button" onClick={e => { e.stopPropagation(); nextPhoto() }} aria-label="Next photo" style={{ ...NAV_BTN, right: '1rem' }}>&#8594;</button>
+          )}
+          <button
+            ref={closeBtnRef}
+            type="button"
+            onClick={closeLightbox}
+            aria-label="Close lightbox"
+            style={{ position: 'absolute', top: '1rem', right: '1rem', background: 'rgba(255,255,255,0.07)', border: '1px solid rgba(255,255,255,0.14)', color: '#d6d1ce', width: 40, height: 40, borderRadius: '50%', cursor: 'pointer', fontSize: '1.4rem', display: 'flex', alignItems: 'center', justifyContent: 'center', backdropFilter: 'blur(4px)' }}
+          >
+            &times;
+          </button>
+          <p style={{ position: 'absolute', bottom: '1.5rem', left: '50%', transform: 'translateX(-50%)', color: 'rgba(155,154,154,0.6)', fontFamily: 'var(--font-body)', fontSize: '0.62rem', letterSpacing: '0.14em', textTransform: 'uppercase', margin: 0, whiteSpace: 'nowrap' }}>
+            {lightboxIdx + 1} / {photos.length}
+          </p>
+        </div>
+      )}
+    </>
+  )
+}

--- a/app/(site)/portfolio/family/page.tsx
+++ b/app/(site)/portfolio/family/page.tsx
@@ -1,0 +1,78 @@
+import type { Metadata } from 'next'
+import Image from 'next/image'
+import Link from 'next/link'
+import { getPayload } from 'payload'
+import config from '@payload-config'
+import type { Photo } from '@/payload-types'
+import CategoryPhotoGrid, { type CategoryPhoto } from '../_components/CategoryPhotoGrid'
+import styles from '../_components/CategoryPage.module.css'
+
+export const revalidate = 120
+
+export const metadata: Metadata = {
+  title: 'Family',
+  description: 'Family portrait photography in Albuquerque and Seattle. Real connection, real moments, real laughter.',
+}
+
+export default async function FamilyPage() {
+  const payload = await getPayload({ config })
+
+  const { docs: rawPhotos } = await payload.find({
+    collection: 'photos',
+    where: { category: { equals: 'families' } },
+    sort: 'displayOrder',
+    depth: 0,
+    limit: 500,
+  })
+
+  const photos: CategoryPhoto[] = rawPhotos
+    .filter(p => p.url)
+    .map(p => ({
+      id: String(p.id),
+      title: p.title,
+      alt: p.alt ?? undefined,
+      imageUrl: (p as Photo).sizes?.card?.url ?? p.url ?? null,
+      fullUrl: (p as Photo).sizes?.hero?.url ?? p.url ?? null,
+    }))
+
+  const heroPhoto = rawPhotos.find(p => p.featured && p.url) ?? rawPhotos.find(p => p.url)
+  const heroUrl = heroPhoto ? ((heroPhoto as Photo).sizes?.hero?.url ?? heroPhoto.url ?? null) : null
+
+  return (
+    <main>
+      {/* Hero */}
+      <section className={styles.hero}>
+        {heroUrl && (
+          <Image
+            src={heroUrl}
+            alt="Family photography by Tynnell Hollins"
+            fill
+            priority
+            className={styles.heroImg}
+            sizes="100vw"
+          />
+        )}
+        <div className={styles.heroOverlay} />
+        <div className={styles.heroContent}>
+          <div className={styles.titleBox}>
+            <h1 className={styles.title}>Family</h1>
+          </div>
+          <div className={styles.descBox}>
+            <p className={styles.desc}>
+              Family is a thousand small moments. This gallery celebrates real connection, easy laughter, and the bonds that make your story your own.
+            </p>
+          </div>
+        </div>
+      </section>
+
+      {/* Photo grid */}
+      <CategoryPhotoGrid photos={photos} />
+
+      {/* CTA */}
+      <section className={styles.cta}>
+        <p className={styles.ctaText}>Ready to tell your story?</p>
+        <Link href="/book" className={styles.ctaBtn}>Book a session</Link>
+      </section>
+    </main>
+  )
+}

--- a/app/(site)/portfolio/page.tsx
+++ b/app/(site)/portfolio/page.tsx
@@ -1,100 +1,108 @@
-import { Suspense } from 'react'
 import type { Metadata } from 'next'
+import Image from 'next/image'
 import Link from 'next/link'
 import { getPayload } from 'payload'
 import config from '@payload-config'
 import type { Photo } from '@/payload-types'
-import PortfolioGrid from './PortfolioGrid'
-import type { PortfolioPhoto, PortfolioGallery } from './PortfolioGrid'
 import JsonLd from '@/app/components/JsonLd/JsonLd'
-import styles from './page.module.css'
+import styles from './portfolio-landing.module.css'
 
-// Portfolio updates occasionally as photos are added - revalidate every 2 minutes
 export const revalidate = 120
 
 export const metadata: Metadata = {
   title: 'Portfolio',
-  description: 'Browse the full portfolio: weddings, portraits, families, couples, and more.',
+  description: 'Browse portraits, family sessions, and weddings by Tynnell Hollins Photography.',
 }
+
+const CATEGORIES = [
+  {
+    label: 'Portraits',
+    href: '/portfolio/portraits',
+    dbCategory: 'portraits',
+    description: 'Intimate portraits that capture who you really are.',
+  },
+  {
+    label: 'Family',
+    href: '/portfolio/family',
+    dbCategory: 'families',
+    description: 'Real connection, easy laughter, bonds that tell your story.',
+  },
+  {
+    label: 'Weddings',
+    href: '/portfolio/weddings',
+    dbCategory: 'weddings',
+    description: 'Every wedding is a love story all its own.',
+  },
+]
 
 export default async function PortfolioPage() {
   const payload = await getPayload({ config })
 
-  const [{ docs: rawPhotos }, { docs: rawGalleries }] = await Promise.all([
-    payload.find({ collection: 'photos', sort: 'displayOrder', depth: 0, limit: 1000 }),
-    payload.find({ collection: 'galleries', sort: 'displayOrder', depth: 1, limit: 200, where: { status: { not_equals: 'draft' } } }),
-  ])
+  const coverPhotos = await Promise.all(
+    CATEGORIES.map(async cat => {
+      const { docs } = await payload.find({
+        collection: 'photos',
+        where: {
+          and: [
+            { category: { equals: cat.dbCategory } },
+            { featured: { equals: true } },
+          ],
+        },
+        sort: '-updatedAt',
+        limit: 1,
+        depth: 0,
+      })
+      if (docs.length) return docs[0]
 
-  const photos: PortfolioPhoto[] = rawPhotos.map(p => ({
-    id: String(p.id),
-    title: p.title,
-    alt: p.alt ?? undefined,
-    imageUrl: p.sizes?.card?.url ?? p.url ?? null,
-    fullUrl: p.sizes?.hero?.url ?? p.url ?? null,
-    category: p.category ?? 'portraits',
-  }))
-
-  const galleries: PortfolioGallery[] = rawGalleries.map(g => {
-    const cover = typeof g.coverPhoto === 'object' && g.coverPhoto !== null
-      ? g.coverPhoto as Photo
-      : null
-
-    // gallery.photos is an ordered array of { photo: Photo | number } rows
-    const previewUrls: string[] = Array.isArray(g.photos)
-      ? g.photos
-          .slice(0, 4)
-          .map(item => {
-            const p = item.photo
-            return typeof p === 'object' && p !== null
-              ? (p as Photo).sizes?.card?.url ?? (p as Photo).url ?? null
-              : null
-          })
-          .filter((url): url is string => url !== null)
-      : []
-
-    return {
-      id: String(g.id),
-      title: g.title,
-      slug: typeof g.slug === 'string' ? g.slug : '',
-      category: g.category ?? 'weddings',
-      featured: g.featured ?? false,
-      coverImageUrl: cover?.sizes?.card?.url ?? cover?.url ?? null,
-      coverImageAlt: cover?.alt ?? undefined,
-      photoCount: Array.isArray(g.photos) ? g.photos.length : 0,
-      previewUrls,
-    }
-  })
+      const { docs: fallback } = await payload.find({
+        collection: 'photos',
+        where: { category: { equals: cat.dbCategory } },
+        sort: 'displayOrder',
+        limit: 1,
+        depth: 0,
+      })
+      return fallback[0] ?? null
+    })
+  )
 
   const portfolioSchema = {
     '@context': 'https://schema.org',
     '@type': 'CollectionPage',
     name: 'Portfolio',
-    description: 'Browse the full portfolio: weddings, portraits, families, couples, and more.',
+    description: 'Browse portraits, family sessions, and weddings by Tynnell Hollins Photography.',
     url: 'https://tynnellhollinsphotography.com/portfolio',
     author: { '@type': 'Person', name: 'Tynnell Hollins', url: 'https://tynnellhollinsphotography.com/about' },
   }
 
   return (
-    <main className={styles.main}>
+    <main>
       <JsonLd data={portfolioSchema} />
-      <div className={styles.inner}>
-        <div className={styles.header}>
-          <p className={styles.eyebrow}>The Work</p>
-          <h1 className={styles.heading}>Portfolio</h1>
-          <p className={styles.subheading}>Every story, every moment, every face</p>
-        </div>
-        <Suspense fallback={null}>
-          <PortfolioGrid photos={photos} galleries={galleries} />
-        </Suspense>
+      <div className={styles.tiles}>
+        {CATEGORIES.map((cat, i) => {
+          const photo = coverPhotos[i] as (Photo & { url?: string | null }) | null
+          const imgUrl = photo?.sizes?.hero?.url ?? photo?.url ?? null
+
+          return (
+            <Link key={cat.href} href={cat.href} className={styles.tile} aria-label={cat.label}>
+              {imgUrl && (
+                <Image
+                  src={imgUrl}
+                  alt={cat.label}
+                  fill
+                  sizes="(max-width: 768px) 100vw, 33vw"
+                  className={styles.tileImg}
+                  priority={i === 0}
+                />
+              )}
+              <div className={styles.tileOverlay} />
+              <div className={styles.tileContent}>
+                <h2 className={styles.tileTitle}>{cat.label}</h2>
+                <p className={styles.tileDesc}>{cat.description}</p>
+              </div>
+            </Link>
+          )
+        })}
       </div>
-      <section className={styles.cta}>
-        <p className={styles.ctaEyebrow}>{"Let's make something beautiful"}</p>
-        <h2 className={styles.ctaHeading}>{"Book your"}<br />{"session."}</h2>
-        <div className={styles.ctaActions}>
-          <Link href="/book" className={styles.ctaBtn}>Book a Session</Link>
-          <Link href="/contact" className={styles.ctaBtnSecondary}>Get in touch</Link>
-        </div>
-      </section>
     </main>
   )
 }

--- a/app/(site)/portfolio/portfolio-landing.module.css
+++ b/app/(site)/portfolio/portfolio-landing.module.css
@@ -1,0 +1,99 @@
+.tiles {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  min-height: 100vh;
+  padding-top: 0;
+}
+
+.tile {
+  position: relative;
+  overflow: hidden;
+  min-height: 100vh;
+  display: flex;
+  align-items: flex-end;
+  text-decoration: none;
+  color: inherit;
+}
+
+.tileImg {
+  object-fit: cover;
+  object-position: center;
+  transition: transform 0.7s ease;
+}
+
+.tile:hover .tileImg {
+  transform: scale(1.04);
+}
+
+.tileOverlay {
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(
+    to top,
+    rgba(0, 0, 0, 0.72) 0%,
+    rgba(0, 0, 0, 0.18) 40%,
+    transparent 70%
+  );
+  transition: background 0.4s ease;
+}
+
+.tile:hover .tileOverlay {
+  background: linear-gradient(
+    to top,
+    rgba(0, 0, 0, 0.8) 0%,
+    rgba(0, 0, 0, 0.28) 45%,
+    transparent 70%
+  );
+}
+
+.tileContent {
+  position: relative;
+  z-index: 1;
+  padding: 2.5rem var(--padding-x);
+  width: 100%;
+}
+
+.tileTitle {
+  font-family: var(--font-heading);
+  font-size: clamp(2rem, 3.5vw, 3.5rem);
+  font-weight: 700;
+  color: #fff;
+  letter-spacing: -0.01em;
+  line-height: 1;
+  margin-bottom: 0.75rem;
+}
+
+.tileDesc {
+  font-family: var(--font-body);
+  font-size: 0.7rem;
+  letter-spacing: 0.08em;
+  color: rgba(255, 255, 255, 0.75);
+  line-height: 1.7;
+  max-width: 260px;
+  opacity: 0;
+  transform: translateY(6px);
+  transition: opacity 0.35s ease, transform 0.35s ease;
+}
+
+.tile:hover .tileDesc {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+/* ── Responsive ──────────────────────────────────────────── */
+
+@media (max-width: 900px) {
+  .tiles {
+    grid-template-columns: 1fr;
+    min-height: auto;
+  }
+
+  .tile {
+    min-height: 60vw;
+  }
+
+  .tileDesc {
+    opacity: 1;
+    transform: none;
+  }
+}

--- a/app/(site)/portfolio/portraits/page.tsx
+++ b/app/(site)/portfolio/portraits/page.tsx
@@ -1,0 +1,78 @@
+import type { Metadata } from 'next'
+import Image from 'next/image'
+import Link from 'next/link'
+import { getPayload } from 'payload'
+import config from '@payload-config'
+import type { Photo } from '@/payload-types'
+import CategoryPhotoGrid, { type CategoryPhoto } from '../_components/CategoryPhotoGrid'
+import styles from '../_components/CategoryPage.module.css'
+
+export const revalidate = 120
+
+export const metadata: Metadata = {
+  title: 'Portraits',
+  description: 'Intimate portrait photography in Albuquerque and Seattle. Tynnell Hollins captures the real you.',
+}
+
+export default async function PortraitsPage() {
+  const payload = await getPayload({ config })
+
+  const { docs: rawPhotos } = await payload.find({
+    collection: 'photos',
+    where: { category: { equals: 'portraits' } },
+    sort: 'displayOrder',
+    depth: 0,
+    limit: 500,
+  })
+
+  const photos: CategoryPhoto[] = rawPhotos
+    .filter(p => p.url)
+    .map(p => ({
+      id: String(p.id),
+      title: p.title,
+      alt: p.alt ?? undefined,
+      imageUrl: (p as Photo).sizes?.card?.url ?? p.url ?? null,
+      fullUrl: (p as Photo).sizes?.hero?.url ?? p.url ?? null,
+    }))
+
+  const heroPhoto = rawPhotos.find(p => p.featured && p.url) ?? rawPhotos.find(p => p.url)
+  const heroUrl = heroPhoto ? ((heroPhoto as Photo).sizes?.hero?.url ?? heroPhoto.url ?? null) : null
+
+  return (
+    <main>
+      {/* Hero */}
+      <section className={styles.hero}>
+        {heroUrl && (
+          <Image
+            src={heroUrl}
+            alt="Portrait photography by Tynnell Hollins"
+            fill
+            priority
+            className={styles.heroImg}
+            sizes="100vw"
+          />
+        )}
+        <div className={styles.heroOverlay} />
+        <div className={styles.heroContent}>
+          <div className={styles.titleBox}>
+            <h1 className={styles.title}>Portraits</h1>
+          </div>
+          <div className={styles.descBox}>
+            <p className={styles.desc}>
+              Intimate portraits that capture who you really are. Not just how you look, but how you feel.
+            </p>
+          </div>
+        </div>
+      </section>
+
+      {/* Photo grid */}
+      <CategoryPhotoGrid photos={photos} />
+
+      {/* CTA */}
+      <section className={styles.cta}>
+        <p className={styles.ctaText}>Ready to tell your story?</p>
+        <Link href="/book" className={styles.ctaBtn}>Book a session</Link>
+      </section>
+    </main>
+  )
+}

--- a/app/(site)/portfolio/weddings/page.tsx
+++ b/app/(site)/portfolio/weddings/page.tsx
@@ -1,0 +1,132 @@
+import type { Metadata } from 'next'
+import Image from 'next/image'
+import Link from 'next/link'
+import { getPayload } from 'payload'
+import config from '@payload-config'
+import type { Photo } from '@/payload-types'
+import CategoryPhotoGrid, { type CategoryPhoto } from '../_components/CategoryPhotoGrid'
+import styles from '../_components/CategoryPage.module.css'
+import albumStyles from './weddings.module.css'
+import { ProtectedImage } from '@/app/components/ProtectedImage/ProtectedImage'
+
+export const revalidate = 120
+
+export const metadata: Metadata = {
+  title: 'Weddings',
+  description: 'Wedding photography in New Mexico and Seattle. Every wedding is a love story all its own.',
+}
+
+export default async function WeddingsPage() {
+  const payload = await getPayload({ config })
+
+  const [{ docs: rawPhotos }, { docs: rawGalleries }] = await Promise.all([
+    payload.find({
+      collection: 'photos',
+      where: { category: { equals: 'weddings' } },
+      sort: 'displayOrder',
+      depth: 0,
+      limit: 500,
+    }),
+    payload.find({
+      collection: 'galleries',
+      where: {
+        and: [
+          { category: { equals: 'weddings' } },
+          { status: { not_equals: 'draft' } },
+        ],
+      },
+      sort: 'displayOrder',
+      depth: 1,
+      limit: 100,
+    }),
+  ])
+
+  const photos: CategoryPhoto[] = rawPhotos
+    .filter(p => p.url)
+    .map(p => ({
+      id: String(p.id),
+      title: p.title,
+      alt: p.alt ?? undefined,
+      imageUrl: (p as Photo).sizes?.card?.url ?? p.url ?? null,
+      fullUrl: (p as Photo).sizes?.hero?.url ?? p.url ?? null,
+    }))
+
+  const heroPhoto = rawPhotos.find(p => p.featured && p.url) ?? rawPhotos.find(p => p.url)
+  const heroUrl = heroPhoto ? ((heroPhoto as Photo).sizes?.hero?.url ?? heroPhoto.url ?? null) : null
+
+  return (
+    <main>
+      {/* Hero */}
+      <section className={styles.hero}>
+        {heroUrl && (
+          <Image
+            src={heroUrl}
+            alt="Wedding photography by Tynnell Hollins"
+            fill
+            priority
+            className={styles.heroImg}
+            sizes="100vw"
+          />
+        )}
+        <div className={styles.heroOverlay} />
+        <div className={styles.heroContent}>
+          <div className={styles.titleBox}>
+            <h1 className={styles.title}>Weddings</h1>
+          </div>
+          <div className={styles.descBox}>
+            <p className={styles.desc}>
+              Every wedding is a love story all its own. I photograph the glances, the laughter, and the quiet moments in between.
+            </p>
+          </div>
+        </div>
+      </section>
+
+      {/* Wedding albums */}
+      {rawGalleries.length > 0 && (
+        <section className={albumStyles.albums}>
+          <h2 className={albumStyles.albumsHeading}>Albums</h2>
+          <div className={albumStyles.albumGrid}>
+            {rawGalleries.map(gallery => {
+              const cover = typeof gallery.coverPhoto === 'object' && gallery.coverPhoto !== null
+                ? gallery.coverPhoto as Photo
+                : null
+              const coverUrl = cover?.sizes?.card?.url ?? cover?.url ?? null
+              const photoCount = Array.isArray(gallery.photos) ? gallery.photos.length : 0
+
+              return (
+                <Link key={gallery.id} href={`/portfolio/${gallery.slug}`} className={albumStyles.albumCard}>
+                  <div className={albumStyles.albumCover}>
+                    {coverUrl ? (
+                      <ProtectedImage
+                        src={coverUrl}
+                        alt={cover?.alt ?? gallery.title}
+                        fill
+                        sizes="(max-width: 640px) 100vw, (max-width: 1024px) 50vw, 33vw"
+                        className={albumStyles.albumImg}
+                      />
+                    ) : (
+                      <div className={albumStyles.noCover} />
+                    )}
+                  </div>
+                  <div className={albumStyles.albumFooter}>
+                    <span className={albumStyles.albumTitle}>{gallery.title}</span>
+                    <span className={albumStyles.albumMeta}>{photoCount} photos</span>
+                  </div>
+                </Link>
+              )
+            })}
+          </div>
+        </section>
+      )}
+
+      {/* Individual wedding photos */}
+      {photos.length > 0 && <CategoryPhotoGrid photos={photos} />}
+
+      {/* CTA */}
+      <section className={styles.cta}>
+        <p className={styles.ctaText}>{"Let's capture your day"}</p>
+        <Link href="/book" className={styles.ctaBtn}>Book a consultation</Link>
+      </section>
+    </main>
+  )
+}

--- a/app/(site)/portfolio/weddings/weddings.module.css
+++ b/app/(site)/portfolio/weddings/weddings.module.css
@@ -1,0 +1,84 @@
+.albums {
+  padding: 4rem var(--padding-x);
+  border-bottom: 1px solid var(--color-border);
+}
+
+.albumsHeading {
+  font-family: var(--font-body);
+  font-size: 0.65rem;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+  color: var(--color-detail);
+  margin-bottom: 2rem;
+}
+
+.albumGrid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 1.5rem;
+}
+
+.albumCard {
+  display: block;
+  text-decoration: none;
+  color: inherit;
+}
+
+.albumCard:hover .albumImg {
+  transform: scale(1.03);
+}
+
+.albumCover {
+  position: relative;
+  aspect-ratio: 3 / 2;
+  overflow: hidden;
+  background: var(--color-bg-card);
+  margin-bottom: 0.75rem;
+}
+
+.albumImg {
+  object-fit: cover;
+  transition: transform 0.5s ease;
+}
+
+.noCover {
+  width: 100%;
+  height: 100%;
+  background: var(--color-bg-card);
+}
+
+.albumFooter {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.albumTitle {
+  font-family: var(--font-heading);
+  font-size: 0.9rem;
+  font-weight: 500;
+  color: var(--color-heading);
+  letter-spacing: 0.02em;
+}
+
+.albumMeta {
+  font-family: var(--font-body);
+  font-size: 0.62rem;
+  letter-spacing: 0.1em;
+  color: var(--color-detail);
+  white-space: nowrap;
+}
+
+@media (max-width: 768px) {
+  .albumGrid {
+    grid-template-columns: repeat(2, 1fr);
+    gap: 1rem;
+  }
+}
+
+@media (max-width: 480px) {
+  .albumGrid {
+    grid-template-columns: 1fr;
+  }
+}

--- a/app/(site)/services/page.module.css
+++ b/app/(site)/services/page.module.css
@@ -40,6 +40,83 @@
   margin: 0 auto;
 }
 
+/* ── How It Works ────────────────────────────────────────── */
+
+.process {
+  max-width: 1100px;
+  margin: 0 auto;
+  padding: 6rem var(--padding-x);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 3.5rem;
+}
+
+.processEyebrow {
+  font-family: var(--font-body);
+  font-size: 0.7rem;
+  letter-spacing: 0.28em;
+  text-transform: uppercase;
+  color: var(--color-detail);
+}
+
+.steps {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 0;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  width: 100%;
+  border-top: 1px solid var(--color-border-solid);
+}
+
+.step {
+  padding: 2.5rem 2rem 2.5rem 0;
+  border-right: 1px solid var(--color-border-solid);
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.step:first-child {
+  padding-left: 0;
+}
+
+.step:last-child {
+  border-right: none;
+  padding-right: 0;
+  padding-left: 2rem;
+}
+
+.step:not(:first-child):not(:last-child) {
+  padding-left: 2rem;
+}
+
+.stepNum {
+  font-family: var(--font-heading);
+  font-size: 0.65rem;
+  letter-spacing: 0.2em;
+  color: var(--color-detail);
+}
+
+.stepHeading {
+  font-family: var(--font-display);
+  font-size: clamp(1.5rem, 2.5vw, 2rem);
+  font-weight: 400;
+  color: var(--color-heading);
+  line-height: 1.1;
+  margin: 0;
+}
+
+.stepBody {
+  font-family: var(--font-prose);
+  font-size: 0.875rem;
+  line-height: 1.75;
+  color: var(--color-body);
+  margin: 0;
+}
+
 /* ── Grid ────────────────────────────────────────────────── */
 
 .grid {
@@ -285,6 +362,28 @@
 @media (max-width: 768px) {
   .hero {
     padding-bottom: 3.5rem;
+  }
+
+  .process {
+    padding: 4rem var(--padding-x);
+    gap: 2.5rem;
+  }
+
+  .steps {
+    grid-template-columns: 1fr;
+  }
+
+  .step,
+  .step:first-child,
+  .step:last-child,
+  .step:not(:first-child):not(:last-child) {
+    padding: 2rem 0;
+    border-right: none;
+    border-bottom: 1px solid var(--color-border-solid);
+  }
+
+  .step:last-child {
+    border-bottom: none;
   }
 
   .grid {

--- a/app/(site)/services/page.tsx
+++ b/app/(site)/services/page.tsx
@@ -52,10 +52,32 @@ export default async function ServicesPage() {
       {/* Hero */}
       <section className={styles.hero}>
         <p className={styles.eyebrow}>Services</p>
-        <h1 className={styles.heroHeading}>{"Let's Create"}<br />{"Something Beautiful"}</h1>
+        <h1 className={styles.heroHeading}>{"Every Session,"}<br />{"Crafted for You"}</h1>
         <p className={styles.heroSub}>
-          {"Every package is crafted to give you images you'll treasure for a lifetime."}
+          {"Packages designed to give you images you'll treasure for a lifetime. Choose the experience that fits your story."}
         </p>
+      </section>
+
+      {/* How It Works */}
+      <section className={styles.process} aria-label="How it works">
+        <p className={styles.processEyebrow}>How It Works</p>
+        <ol className={styles.steps}>
+          <li className={styles.step}>
+            <span className={styles.stepNum}>01</span>
+            <h2 className={styles.stepHeading}>Connect</h2>
+            <p className={styles.stepBody}>Fill out the inquiry form or send a message. We talk through your vision, your people, and what this session means to you.</p>
+          </li>
+          <li className={styles.step}>
+            <span className={styles.stepNum}>02</span>
+            <h2 className={styles.stepHeading}>Plan Together</h2>
+            <p className={styles.stepBody}>Choose your date and package. We walk through every detail so you feel relaxed and ready before we ever pick up a camera.</p>
+          </li>
+          <li className={styles.step}>
+            <span className={styles.stepNum}>03</span>
+            <h2 className={styles.stepHeading}>Remember Forever</h2>
+            <p className={styles.stepBody}>Your gallery arrives beautifully edited and ready to keep, share, and print. These images belong to you. Always.</p>
+          </li>
+        </ol>
       </section>
 
       {/* Service cards */}

--- a/app/(site)/styles/tokens.css
+++ b/app/(site)/styles/tokens.css
@@ -39,21 +39,3 @@
   --padding-block:        4vmax;
 }
 
-@media (prefers-color-scheme: light) {
-  :root {
-    --color-bg:             #f4efe8;
-    --color-bg-accent:      #ede8de;
-    --color-bg-card:        #e4dfd6;
-    --color-bg-hover:       #ddd6cc;
-    --color-heading:        #1a1a1a;
-    --color-body:           #2a2a2a;
-    --color-detail:         #6b6a6a;
-    --color-btn-bg:         #6b6a6a;
-    --color-btn-text:       #f4efe8;
-    --color-btn-hover:      #4a4a4a;
-    --color-border:         rgba(26, 26, 26, 0.10);
-    --color-border-subtle:  rgba(26, 26, 26, 0.06);
-    --color-border-solid:   #ccc4ba;
-    --color-error:          #c0392b;
-  }
-}

--- a/app/(site)/styles/tokens.css
+++ b/app/(site)/styles/tokens.css
@@ -1,8 +1,10 @@
 :root {
-  /* Colors */
+  /* ── Colors: dark mode (default) ─────────────────────────── */
   --color-bg:             #0C0C0C;
   --color-bg-accent:      #131313;
   --color-bg-card:        #1a1a1a;
+  --color-bg-overlay:     rgba(12, 12, 12, 0.76);   /* dark boxes over photos - same in both modes */
+  --color-bg-hover:       #222222;
   --color-heading:        #D6D1CE;
   --color-body:           #E6E1DE;
   --color-detail:         #9B9A9A;
@@ -11,30 +13,47 @@
   --color-btn-hover:      #807F7F;
   --color-border:         rgba(214, 209, 206, 0.08);
   --color-border-subtle:  rgba(214, 209, 206, 0.06);
-  --color-border-solid:   #1e1e1e;  /* solid dividers/card borders on dark surfaces */
-  --color-bg-hover:       #222222;  /* hover highlight on dark card surfaces */
-  --color-error:          #c87171;  /* inline validation errors */
+  --color-border-solid:   #1e1e1e;
+  --color-error:          #c87171;
 
-  /* Taped-photo treatment (TYN-230). The cream-polaroid look's identity lives
-     here so it can be tuned in one place. Used by the gallery pages, the home
-     portfolio teaser, the About headshot, and the builder Photo Gallery block.
-     Per-surface tape geometry (size/offset/tilt) stays in each stylesheet since
-     it scales with context. */
+  /* ── Colors: light mode override ─────────────────────────── */
+  /* Overlay boxes (--color-bg-overlay) intentionally stay dark since they
+     sit on top of photos in both modes. */
+
+  /* ── Tape treatment ───────────────────────────────────────── */
   --tape-mat:             #f4efe8;
   --tape-color:           rgba(214, 209, 206, 0.42);
   --tape-shadow:          0 10px 26px rgba(0, 0, 0, 0.45);
 
-  /* Typography - values are overridden by next/font CSS variables on <html>.
-     Fallbacks here ensure nothing breaks if the variable is unset. */
-  --font-display:      'Tangerine', cursive;
-  --font-heading:      'Archivo', sans-serif;
-  --font-prose:        var(--font-heading); /* readable paragraphs and body copy - same Archivo family, inherits Next.js self-hosted font */
-  --font-body:         'Roboto Mono', monospace;
-  --font-mono:         var(--font-body); /* alias - resolves to Roboto Mono */
+  /* ── Typography ───────────────────────────────────────────── */
+  --font-display:         'Tangerine', cursive;
+  --font-display-bold:    'Abril Fatface', cursive;
+  --font-heading:         'Archivo', sans-serif;
+  --font-prose:           var(--font-heading);
+  --font-body:            'Roboto Mono', monospace;
+  --font-mono:            var(--font-body);
 
-  /* Spacing */
-  --max-width:         1680px;
-  /* min 1.25rem (20px) so small phones never get less than 20px side padding */
-  --padding-x:         max(1.25rem, 2.5vw);
-  --padding-block:     4vmax;
+  /* ── Spacing ──────────────────────────────────────────────── */
+  --max-width:            1680px;
+  --padding-x:            max(1.25rem, 2.5vw);
+  --padding-block:        4vmax;
+}
+
+@media (prefers-color-scheme: light) {
+  :root {
+    --color-bg:             #f4efe8;
+    --color-bg-accent:      #ede8de;
+    --color-bg-card:        #e4dfd6;
+    --color-bg-hover:       #ddd6cc;
+    --color-heading:        #1a1a1a;
+    --color-body:           #2a2a2a;
+    --color-detail:         #6b6a6a;
+    --color-btn-bg:         #6b6a6a;
+    --color-btn-text:       #f4efe8;
+    --color-btn-hover:      #4a4a4a;
+    --color-border:         rgba(26, 26, 26, 0.10);
+    --color-border-subtle:  rgba(26, 26, 26, 0.06);
+    --color-border-solid:   #ccc4ba;
+    --color-error:          #c0392b;
+  }
 }

--- a/app/builder/SiteEditorClient.tsx
+++ b/app/builder/SiteEditorClient.tsx
@@ -38,6 +38,7 @@ const SITE_NAV: NavItem[] = [
   { key: 'services',     label: 'Services',      href: '/services'      },
   { key: 'testimonials', label: 'Testimonials',  href: '/testimonials'  },
   { key: 'contact',      label: 'Contact',       href: '/contact'       },
+  { key: 'book',         label: 'Book',          href: '/book'          },
   { key: 'blog',         label: 'Blog',          href: '/blog'          },
 ]
 
@@ -504,6 +505,7 @@ export function SiteEditorClient({ initialPages }: { initialPages: SitePage[] })
   const handleSelect = (key: string, href: string) => {
     setSelectedKey(key)
     setPreviewHref(href)
+    if (key === 'portfolio') setPortfolioExpanded(true)
   }
 
   const deletePage = async (id: string | number) => {

--- a/app/builder/SiteEditorClient.tsx
+++ b/app/builder/SiteEditorClient.tsx
@@ -1,8 +1,9 @@
 'use client'
 import { useState, useCallback, useRef, useEffect } from 'react'
 
-const ui = "var(--font-heading, Archivo, sans-serif)"
-const mono = "var(--font-body, 'Roboto Mono', monospace)"
+const ui = "'Archivo', system-ui, sans-serif"
+const mono = "'Roboto Mono', monospace"
+const teal = '#1db48e'
 
 export interface SitePage {
   id: number | string
@@ -19,85 +20,109 @@ export interface SitePage {
 // Icons
 // ---------------------------------------------------------------------------
 
-function PageIcon() {
+function IconPages() {
   return (
-    <svg width="15" height="15" viewBox="0 0 15 15" fill="none" aria-hidden="true">
-      <rect x="2" y="1" width="11" height="13" rx="1.5" stroke="currentColor" strokeWidth="1.2" />
-      <path d="M5 5h5M5 8h5M5 11h3" stroke="currentColor" strokeWidth="1.2" strokeLinecap="round" />
+    <svg width="18" height="18" viewBox="0 0 18 18" fill="none" aria-hidden="true">
+      <rect x="2" y="2" width="10" height="13" rx="1.5" stroke="currentColor" strokeWidth="1.4"/>
+      <rect x="6" y="4" width="10" height="13" rx="1.5" stroke="currentColor" strokeWidth="1.4" fill="none"/>
     </svg>
   )
 }
 
-function HomeIcon() {
+function IconBrush() {
   return (
-    <svg width="15" height="15" viewBox="0 0 15 15" fill="none" aria-hidden="true">
-      <path d="M1.5 7L7.5 1.5L13.5 7V13.5H10V9.5H5V13.5H1.5V7Z" stroke="currentColor" strokeWidth="1.2" strokeLinejoin="round" />
+    <svg width="18" height="18" viewBox="0 0 18 18" fill="none" aria-hidden="true">
+      <path d="M3 15c1.5 0 3-1.5 3-3S4.5 9 3 9c-.8 0-1.5.7-1.5 1.5S2 12 3 12" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round"/>
+      <path d="M6 12L14 4" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round"/>
+      <path d="M11.5 2.5l4 4" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round"/>
     </svg>
   )
 }
 
-function PlusIcon() {
+function IconPen() {
   return (
-    <svg width="13" height="13" viewBox="0 0 13 13" fill="none" aria-hidden="true">
-      <path d="M6.5 2v9M2 6.5h9" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
+    <svg width="18" height="18" viewBox="0 0 18 18" fill="none" aria-hidden="true">
+      <path d="M3 13l9-9 3 3-9 9H3v-3z" stroke="currentColor" strokeWidth="1.4" strokeLinejoin="round"/>
+      <path d="M10.5 5.5l2 2" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round"/>
     </svg>
   )
 }
 
-function DotsIcon() {
+function IconSettings() {
+  return (
+    <svg width="18" height="18" viewBox="0 0 18 18" fill="none" aria-hidden="true">
+      <circle cx="9" cy="9" r="2.5" stroke="currentColor" strokeWidth="1.4"/>
+      <path d="M9 1.5v2M9 14.5v2M1.5 9h2M14.5 9h2M3.7 3.7l1.4 1.4M12.9 12.9l1.4 1.4M14.3 3.7l-1.4 1.4M5.1 12.9l-1.4 1.4" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round"/>
+    </svg>
+  )
+}
+
+function IconPage() {
   return (
     <svg width="14" height="14" viewBox="0 0 14 14" fill="none" aria-hidden="true">
-      <circle cx="3" cy="7" r="1.2" fill="currentColor" />
-      <circle cx="7" cy="7" r="1.2" fill="currentColor" />
-      <circle cx="11" cy="7" r="1.2" fill="currentColor" />
+      <rect x="2" y="1" width="10" height="12" rx="1.5" stroke="currentColor" strokeWidth="1.2"/>
+      <path d="M4.5 4.5h5M4.5 7h5M4.5 9.5h3" stroke="currentColor" strokeWidth="1.1" strokeLinecap="round"/>
     </svg>
   )
 }
 
-function ExternalIcon() {
+function IconHome() {
+  return (
+    <svg width="14" height="14" viewBox="0 0 14 14" fill="none" aria-hidden="true">
+      <path d="M1.5 6.5L7 1.5l5.5 5V13H9.5V9H4.5v4H1.5V6.5z" stroke="currentColor" strokeWidth="1.2" strokeLinejoin="round"/>
+    </svg>
+  )
+}
+
+function IconBlog() {
+  return (
+    <svg width="14" height="14" viewBox="0 0 14 14" fill="none" aria-hidden="true">
+      <path d="M2 10l7-7 2 2-7 7H2v-2z" stroke="currentColor" strokeWidth="1.2" strokeLinejoin="round"/>
+    </svg>
+  )
+}
+
+function IconDots() {
+  return (
+    <svg width="14" height="14" viewBox="0 0 14 14" fill="none" aria-hidden="true">
+      <circle cx="3" cy="7" r="1.2" fill="currentColor"/>
+      <circle cx="7" cy="7" r="1.2" fill="currentColor"/>
+      <circle cx="11" cy="7" r="1.2" fill="currentColor"/>
+    </svg>
+  )
+}
+
+function IconExternal() {
   return (
     <svg width="11" height="11" viewBox="0 0 11 11" fill="none" aria-hidden="true">
-      <path d="M2 9L9 2M9 2H5.5M9 2V5.5" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round" strokeLinejoin="round" />
+      <path d="M2 9L9 2M9 2H5.5M9 2V5.5" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round" strokeLinejoin="round"/>
     </svg>
   )
 }
 
-function GlobeIcon() {
+function IconChevronDown() {
   return (
-    <svg width="17" height="17" viewBox="0 0 17 17" fill="none" aria-hidden="true">
-      <circle cx="8.5" cy="8.5" r="7" stroke="currentColor" strokeWidth="1.3" />
-      <path d="M8.5 1.5C8.5 1.5 6 5 6 8.5s2.5 7 2.5 7M8.5 1.5C8.5 1.5 11 5 11 8.5s-2.5 7-2.5 7M1.5 8.5h14" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round" />
+    <svg width="12" height="12" viewBox="0 0 12 12" fill="none" aria-hidden="true">
+      <path d="M2.5 4.5L6 8l3.5-3.5" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round" strokeLinejoin="round"/>
     </svg>
   )
 }
 
-function StylesIcon() {
+function IconDashboard() {
   return (
-    <svg width="17" height="17" viewBox="0 0 17 17" fill="none" aria-hidden="true">
-      <circle cx="5" cy="5" r="3" stroke="currentColor" strokeWidth="1.3" />
-      <circle cx="12" cy="5" r="3" stroke="currentColor" strokeWidth="1.3" />
-      <circle cx="5" cy="12" r="3" stroke="currentColor" strokeWidth="1.3" />
-      <circle cx="12" cy="12" r="3" stroke="currentColor" strokeWidth="1.3" />
+    <svg width="13" height="13" viewBox="0 0 13 13" fill="none" aria-hidden="true">
+      <rect x="1" y="1" width="4.5" height="4.5" rx="1" stroke="currentColor" strokeWidth="1.2"/>
+      <rect x="7.5" y="1" width="4.5" height="4.5" rx="1" stroke="currentColor" strokeWidth="1.2"/>
+      <rect x="1" y="7.5" width="4.5" height="4.5" rx="1" stroke="currentColor" strokeWidth="1.2"/>
+      <rect x="7.5" y="7.5" width="4.5" height="4.5" rx="1" stroke="currentColor" strokeWidth="1.2"/>
     </svg>
   )
 }
 
-function SettingsIcon() {
+function IconPlus() {
   return (
-    <svg width="17" height="17" viewBox="0 0 17 17" fill="none" aria-hidden="true">
-      <circle cx="8.5" cy="8.5" r="2.5" stroke="currentColor" strokeWidth="1.3" />
-      <path d="M8.5 1v2M8.5 14v2M1 8.5h2M14 8.5h2M3.2 3.2l1.4 1.4M12.4 12.4l1.4 1.4M14.8 3.2l-1.4 1.4M5.6 12.4l-1.4 1.4" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round" />
-    </svg>
-  )
-}
-
-function DashboardIcon() {
-  return (
-    <svg width="15" height="15" viewBox="0 0 15 15" fill="none" aria-hidden="true">
-      <rect x="1" y="1" width="5.5" height="5.5" rx="1" stroke="currentColor" strokeWidth="1.2" />
-      <rect x="8.5" y="1" width="5.5" height="5.5" rx="1" stroke="currentColor" strokeWidth="1.2" />
-      <rect x="1" y="8.5" width="5.5" height="5.5" rx="1" stroke="currentColor" strokeWidth="1.2" />
-      <rect x="8.5" y="8.5" width="5.5" height="5.5" rx="1" stroke="currentColor" strokeWidth="1.2" />
+    <svg width="13" height="13" viewBox="0 0 13 13" fill="none" aria-hidden="true">
+      <path d="M6.5 2v9M2 6.5h9" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round"/>
     </svg>
   )
 }
@@ -122,26 +147,28 @@ function PageMenu({ page, onDelete, onToggleNav, onClose }: {
     return () => document.removeEventListener('mousedown', handler)
   }, [onClose])
 
+  const items = [
+    { label: 'Edit page', action: () => { window.location.href = `/builder/${page.slug ?? ''}` } },
+    { label: page.showInNav ? 'Remove from menu' : 'Add to menu', action: onToggleNav },
+    { label: 'Delete', action: onDelete, danger: true },
+  ]
+
   return (
     <div
       ref={ref}
       style={{
-        position: 'absolute', right: 0, top: '100%', zIndex: 100,
-        background: '#1e1e1e', border: '1px solid rgba(255,255,255,0.1)',
-        borderRadius: 7, padding: '0.3rem', minWidth: 160,
-        boxShadow: '0 8px 24px rgba(0,0,0,0.6)',
+        position: 'absolute', right: 4, top: '100%', zIndex: 200,
+        background: '#232323', border: '1px solid rgba(255,255,255,0.1)',
+        borderRadius: 8, padding: '0.3rem', minWidth: 170,
+        boxShadow: '0 8px 32px rgba(0,0,0,0.7)',
       }}
     >
-      {[
-        { label: 'Edit in Builder', action: () => { window.location.href = `/builder/${page.slug ?? ''}` } },
-        { label: page.showInNav ? 'Remove from menu' : 'Add to menu', action: onToggleNav },
-        { label: 'Delete', action: onDelete, danger: true },
-      ].map(item => (
+      {items.map(item => (
         <button
           key={item.label}
           type="button"
           onClick={() => { item.action(); onClose() }}
-          style={{ display: 'block', width: '100%', textAlign: 'left', padding: '0.45rem 0.65rem', background: 'none', border: 'none', borderRadius: 5, fontSize: '0.8rem', fontFamily: ui, color: item.danger ? '#f87171' : '#c4bfb9', cursor: 'pointer' }}
+          style={{ display: 'block', width: '100%', textAlign: 'left', padding: '0.5rem 0.7rem', background: 'none', border: 'none', borderRadius: 5, fontSize: '0.8rem', fontFamily: ui, color: item.danger ? '#f87171' : '#c4bfb9', cursor: 'pointer' }}
           onMouseEnter={e => { (e.currentTarget as HTMLElement).style.background = 'rgba(255,255,255,0.06)' }}
           onMouseLeave={e => { (e.currentTarget as HTMLElement).style.background = 'none' }}
         >
@@ -164,60 +191,58 @@ function PageRow({ page, onDelete, onToggleNav, onRefresh }: {
 }) {
   const [menuOpen, setMenuOpen] = useState(false)
   const [hovered, setHovered] = useState(false)
-
-  const isLive = Boolean(page.published)
   const isHome = Boolean(page.isHomepage)
+
+  const pageIcon = isHome ? <IconHome /> : (page.slug === 'blog' ? <IconBlog /> : <IconPage />)
 
   return (
     <div
-      style={{ position: 'relative', display: 'flex', alignItems: 'center', gap: '0.55rem', padding: '0.55rem 0.75rem', borderRadius: 7, cursor: 'pointer', background: hovered ? 'rgba(255,255,255,0.05)' : 'transparent', transition: 'background 0.1s' }}
+      style={{
+        position: 'relative', display: 'flex', alignItems: 'center', gap: '0.55rem',
+        padding: '0.5rem 0.75rem', borderRadius: 6, cursor: 'pointer',
+        background: hovered ? 'rgba(255,255,255,0.04)' : 'transparent',
+        transition: 'background 0.1s',
+      }}
       onMouseEnter={() => setHovered(true)}
-      onMouseLeave={() => { setHovered(false) }}
+      onMouseLeave={() => { if (!menuOpen) setHovered(false) }}
       onClick={() => { if (!menuOpen) window.location.href = `/builder/${page.slug ?? ''}` }}
     >
-      {/* Status dot */}
-      <span style={{ width: 7, height: 7, borderRadius: '50%', flexShrink: 0, background: isLive ? '#4ade80' : 'transparent', border: isLive ? 'none' : '1.5px solid #4a4a4a', display: 'inline-block' }} />
-
-      {/* Icon */}
-      <span style={{ color: '#4a4a4a', flexShrink: 0 }}>
-        {isHome ? <HomeIcon /> : <PageIcon />}
+      <span style={{ color: '#6b6b6b', flexShrink: 0, display: 'flex', alignItems: 'center' }}>
+        {pageIcon}
       </span>
 
-      {/* Title */}
-      <span style={{ flex: 1, fontSize: '0.85rem', fontFamily: ui, color: '#c4bfb9', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', minWidth: 0 }}>
+      <span style={{ flex: 1, fontSize: '0.85rem', fontFamily: ui, fontWeight: 400, color: '#d4d0cc', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', minWidth: 0 }}>
         {page.title ?? 'Untitled'}
       </span>
 
-      {/* External link for live pages */}
-      {isLive && page.slug && hovered && !menuOpen && (
+      {hovered && !menuOpen && page.published && page.slug && (
         <a
           href={`/${page.slug}`} target="_blank" rel="noopener noreferrer"
           onClick={e => e.stopPropagation()}
-          style={{ color: '#5a5a5a', flexShrink: 0, display: 'flex', alignItems: 'center', lineHeight: 1 }}
-          title="View live page"
+          style={{ color: '#6b6b6b', display: 'flex', alignItems: 'center', flexShrink: 0, lineHeight: 1 }}
+          title="View live"
         >
-          <ExternalIcon />
+          <IconExternal />
         </a>
       )}
 
-      {/* Dots menu button */}
       {hovered && (
         <button
           type="button"
           onClick={e => { e.stopPropagation(); setMenuOpen(o => !o) }}
-          style={{ background: 'none', border: 'none', color: '#5a5a5a', cursor: 'pointer', padding: '0.1rem', borderRadius: 4, display: 'flex', alignItems: 'center', flexShrink: 0, lineHeight: 1 }}
+          style={{ background: 'none', border: 'none', color: '#6b6b6b', cursor: 'pointer', padding: '0.1rem 0.2rem', borderRadius: 4, display: 'flex', alignItems: 'center', flexShrink: 0 }}
+          aria-label={`Options for ${page.title ?? 'page'}`}
         >
-          <DotsIcon />
+          <IconDots />
         </button>
       )}
 
-      {/* Context menu */}
       {menuOpen && (
         <PageMenu
           page={page}
-          onDelete={() => onDelete(page.id)}
-          onToggleNav={() => { onToggleNav(page.id, Boolean(page.showInNav)); onRefresh() }}
-          onClose={() => setMenuOpen(false)}
+          onDelete={() => { onDelete(page.id); setMenuOpen(false); setHovered(false) }}
+          onToggleNav={() => { onToggleNav(page.id, Boolean(page.showInNav)); onRefresh(); setMenuOpen(false) }}
+          onClose={() => { setMenuOpen(false); setHovered(false) }}
         />
       )}
     </div>
@@ -244,7 +269,7 @@ function NewPageModal({ onClose }: { onClose: () => void }) {
       const res = await fetch('/api/pages', {
         method: 'POST', credentials: 'include',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ title: title.trim(), slug, published: false, displayOrder: Date.now() }),
+        body: JSON.stringify({ title: title.trim(), slug, published: false, displayOrder: Date.now(), template }),
       })
       if (res.ok) {
         window.location.href = `/builder/${slug}`
@@ -258,27 +283,29 @@ function NewPageModal({ onClose }: { onClose: () => void }) {
   return (
     <div
       role="dialog" aria-modal="true" aria-labelledby="new-page-label"
-      style={{ position: 'fixed', inset: 0, background: 'rgba(0,0,0,0.75)', zIndex: 300, display: 'flex', alignItems: 'center', justifyContent: 'center' }}
+      style={{ position: 'fixed', inset: 0, background: 'rgba(0,0,0,0.65)', zIndex: 400, display: 'flex', alignItems: 'center', justifyContent: 'center' }}
       onClick={e => { if (e.target === e.currentTarget) onClose() }}
       onKeyDown={e => { if (e.key === 'Escape') onClose() }}
     >
-      <div style={{ background: '#1a1a1a', border: '1px solid rgba(255,255,255,0.1)', borderRadius: 10, padding: '1.75rem', width: 360, display: 'flex', flexDirection: 'column', gap: '1.1rem', boxShadow: '0 24px 64px rgba(0,0,0,0.7)' }}>
+      <div style={{ background: '#1c1c1c', border: '1px solid rgba(255,255,255,0.1)', borderRadius: 12, padding: '1.75rem', width: 380, display: 'flex', flexDirection: 'column', gap: '1.1rem', boxShadow: '0 24px 64px rgba(0,0,0,0.8)' }}>
         <h2 id="new-page-label" style={{ margin: 0, fontFamily: ui, fontSize: '1rem', fontWeight: 600, color: '#e6e1de' }}>New page</h2>
-        <label style={{ display: 'flex', flexDirection: 'column', gap: '0.35rem' }}>
-          <span style={{ fontFamily: mono, fontSize: '0.7rem', color: '#9b9a9a' }}>Page title</span>
+
+        <label style={{ display: 'flex', flexDirection: 'column', gap: '0.4rem' }}>
+          <span style={{ fontFamily: mono, fontSize: '0.68rem', color: '#7a7a7a', letterSpacing: '0.06em' }}>Page title</span>
           <input
             autoFocus type="text" value={title}
             onChange={e => setTitle(e.target.value)}
             onKeyDown={e => { if (e.key === 'Enter') void create() }}
             placeholder="e.g. About Me"
-            style={{ background: '#0c0c0c', border: '1px solid rgba(255,255,255,0.12)', borderRadius: 6, padding: '0.6rem 0.75rem', color: '#e6e1de', fontSize: '0.88rem', outline: 'none', fontFamily: ui }}
+            style={{ background: '#111', border: '1px solid rgba(255,255,255,0.12)', borderRadius: 7, padding: '0.6rem 0.75rem', color: '#e6e1de', fontSize: '0.88rem', outline: 'none', fontFamily: ui }}
           />
         </label>
-        <label style={{ display: 'flex', flexDirection: 'column', gap: '0.35rem' }}>
-          <span style={{ fontFamily: mono, fontSize: '0.7rem', color: '#9b9a9a' }}>Template</span>
+
+        <label style={{ display: 'flex', flexDirection: 'column', gap: '0.4rem' }}>
+          <span style={{ fontFamily: mono, fontSize: '0.68rem', color: '#7a7a7a', letterSpacing: '0.06em' }}>Template</span>
           <select
             value={template} onChange={e => setTemplate(e.target.value)}
-            style={{ background: '#0c0c0c', border: '1px solid rgba(255,255,255,0.12)', borderRadius: 6, padding: '0.6rem 0.75rem', color: '#e6e1de', fontSize: '0.85rem', outline: 'none', fontFamily: ui }}
+            style={{ background: '#111', border: '1px solid rgba(255,255,255,0.12)', borderRadius: 7, padding: '0.6rem 0.75rem', color: '#e6e1de', fontSize: '0.85rem', outline: 'none', fontFamily: ui }}
           >
             <option value="blank">Blank</option>
             <option value="landing">Landing Page</option>
@@ -286,12 +313,16 @@ function NewPageModal({ onClose }: { onClose: () => void }) {
             <option value="gallery">Gallery Showcase</option>
           </select>
         </label>
+
         {error && <p role="alert" style={{ margin: 0, fontFamily: mono, fontSize: '0.75rem', color: '#f87171' }}>{error}</p>}
+
         <div style={{ display: 'flex', gap: '0.6rem', justifyContent: 'flex-end' }}>
-          <button type="button" onClick={onClose} style={{ background: 'none', border: '1px solid rgba(255,255,255,0.15)', color: '#9b9a9a', borderRadius: 6, padding: '0.45rem 1rem', fontSize: '0.82rem', fontFamily: ui, cursor: 'pointer' }}>Cancel</button>
+          <button type="button" onClick={onClose} style={{ background: 'none', border: '1px solid rgba(255,255,255,0.15)', color: '#9b9a9a', borderRadius: 7, padding: '0.5rem 1rem', fontSize: '0.82rem', fontFamily: ui, cursor: 'pointer' }}>
+            Cancel
+          </button>
           <button
             type="button" onClick={() => void create()} disabled={!title.trim() || creating} aria-busy={creating}
-            style={{ background: '#2563eb', border: 'none', color: '#fff', borderRadius: 6, padding: '0.45rem 1.2rem', fontSize: '0.82rem', fontWeight: 600, fontFamily: ui, cursor: !title.trim() || creating ? 'not-allowed' : 'pointer', opacity: !title.trim() || creating ? 0.5 : 1 }}
+            style={{ background: teal, border: 'none', color: '#fff', borderRadius: 7, padding: '0.5rem 1.2rem', fontSize: '0.82rem', fontWeight: 600, fontFamily: ui, cursor: !title.trim() || creating ? 'not-allowed' : 'pointer', opacity: !title.trim() || creating ? 0.5 : 1 }}
           >
             {creating ? 'Creating...' : 'Create page'}
           </button>
@@ -305,10 +336,81 @@ function NewPageModal({ onClose }: { onClose: () => void }) {
 // Main
 // ---------------------------------------------------------------------------
 
+type Tab = 'pages' | 'design' | 'blog' | 'settings'
+
+const SWITCHER_ITEMS = [
+  { label: 'Portfolio', desc: 'Galleries and photos', href: '/gallery-editor', color: '#0d9488' },
+  { label: 'Website', desc: 'Pages and content', href: '/builder', color: '#2563eb', active: true },
+  { label: 'Blog', desc: 'Posts and articles', href: '/admin/collections/posts', color: '#7c3aed' },
+  { label: 'Bookings', desc: 'Services and availability', href: '/admin/globals/booking-settings', color: '#b45309' },
+  { label: 'Testimonials', desc: 'Client reviews', href: '/admin/collections/testimonials', color: '#059669' },
+  { label: 'Studio', desc: 'Site settings', href: '/admin', color: '#475569' },
+]
+
+function ProductSwitcher({ onClose, anchorRef }: { onClose: () => void; anchorRef: React.RefObject<HTMLButtonElement | null> }) {
+  const ref = useRef<HTMLDivElement>(null)
+  const [pos, setPos] = useState({ top: 52, left: 12 })
+
+  useEffect(() => {
+    if (anchorRef.current) {
+      const r = anchorRef.current.getBoundingClientRect()
+      setPos({ top: r.bottom + 6, left: r.left })
+    }
+    const handler = (e: MouseEvent) => {
+      if (ref.current && !ref.current.contains(e.target as Node) &&
+          anchorRef.current && !anchorRef.current.contains(e.target as Node)) {
+        onClose()
+      }
+    }
+    document.addEventListener('mousedown', handler)
+    return () => document.removeEventListener('mousedown', handler)
+  }, [onClose, anchorRef])
+
+  return (
+    <div
+      ref={ref}
+      style={{
+        position: 'fixed', top: pos.top, left: pos.left, zIndex: 500,
+        background: '#1c1c1c', border: '1px solid rgba(255,255,255,0.1)',
+        borderRadius: 10, padding: '0.5rem', width: 240,
+        boxShadow: '0 12px 40px rgba(0,0,0,0.7)',
+      }}
+    >
+      {SWITCHER_ITEMS.map(item => (
+        // eslint-disable-next-line @next/next/no-html-link-for-pages
+        <a
+          key={item.label}
+          href={item.href}
+          onClick={onClose}
+          style={{
+            display: 'flex', alignItems: 'center', gap: '0.75rem',
+            padding: '0.6rem 0.75rem', borderRadius: 7, textDecoration: 'none',
+            background: item.active ? 'rgba(255,255,255,0.06)' : 'none',
+            transition: 'background 0.1s',
+          }}
+          onMouseEnter={e => { (e.currentTarget as HTMLElement).style.background = 'rgba(255,255,255,0.07)' }}
+          onMouseLeave={e => { (e.currentTarget as HTMLElement).style.background = item.active ? 'rgba(255,255,255,0.06)' : 'none' }}
+        >
+          <span style={{ width: 28, height: 28, borderRadius: 7, background: item.color, flexShrink: 0, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+            <span style={{ width: 12, height: 12, background: 'rgba(255,255,255,0.8)', borderRadius: 2, display: 'block' }} />
+          </span>
+          <span>
+            <span style={{ display: 'block', fontFamily: ui, fontSize: '0.82rem', fontWeight: item.active ? 600 : 400, color: item.active ? '#e6e1de' : '#c4bfb9' }}>{item.label}</span>
+            <span style={{ display: 'block', fontFamily: mono, fontSize: '0.68rem', color: '#5a5a5a', marginTop: 1 }}>{item.desc}</span>
+          </span>
+        </a>
+      ))}
+    </div>
+  )
+}
+
 export function SiteEditorClient({ initialPages }: { initialPages: SitePage[] }) {
   const [pages, setPages] = useState<SitePage[]>(initialPages)
-  const [activeTab, setActiveTab] = useState<'pages' | 'styles' | 'settings'>('pages')
+  const [activeTab, setActiveTab] = useState<Tab>('pages')
   const [showModal, setShowModal] = useState(false)
+  const [publishing, setPublishing] = useState(false)
+  const [showSwitcher, setShowSwitcher] = useState(false)
+  const switcherBtnRef = useRef<HTMLButtonElement>(null)
 
   const reload = useCallback(() => {
     fetch('/api/pages?sort=displayOrder&limit=100&depth=0', { credentials: 'include' })
@@ -332,145 +434,239 @@ export function SiteEditorClient({ initialPages }: { initialPages: SitePage[] })
     reload()
   }
 
+  const publishAll = async () => {
+    setPublishing(true)
+    await Promise.all(
+      pages.filter(p => !p.published).map(p =>
+        fetch(`/api/pages/${p.id}`, {
+          method: 'PATCH', credentials: 'include',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ published: true }),
+        })
+      )
+    )
+    reload()
+    setPublishing(false)
+  }
+
   const inMenu = pages.filter(p => p.showInNav)
   const notInMenu = pages.filter(p => !p.showInNav)
 
-  const tabs: { id: 'pages' | 'styles' | 'settings'; icon: React.ReactNode; label: string }[] = [
-    { id: 'pages', icon: <GlobeIcon />, label: 'Pages' },
-    { id: 'styles', icon: <StylesIcon />, label: 'Styles' },
-    { id: 'settings', icon: <SettingsIcon />, label: 'Settings' },
+  const tabs: { id: Tab; icon: React.ReactNode; label: string }[] = [
+    { id: 'pages', icon: <IconPages />, label: 'Pages' },
+    { id: 'design', icon: <IconBrush />, label: 'Design' },
+    { id: 'blog', icon: <IconPen />, label: 'Blog' },
+    { id: 'settings', icon: <IconSettings />, label: 'Settings' },
   ]
 
   return (
-    <div style={{ display: 'flex', height: '100vh', background: '#0e0e0e', color: '#e6e1de' }}>
+    <div style={{ display: 'flex', flexDirection: 'column', height: '100vh', background: '#141414', color: '#d4d0cc', fontFamily: ui }}>
 
       {showModal && <NewPageModal onClose={() => setShowModal(false)} />}
+      {showSwitcher && <ProductSwitcher onClose={() => setShowSwitcher(false)} anchorRef={switcherBtnRef} />}
 
-      {/* ---- Left sidebar ---- */}
-      <div style={{ width: 260, flexShrink: 0, background: '#111', borderRight: '1px solid rgba(255,255,255,0.07)', display: 'flex', flexDirection: 'column', height: '100vh' }}>
+      {/* ---- Top bar ---- */}
+      <div style={{ height: 52, flexShrink: 0, display: 'flex', alignItems: 'center', justifyContent: 'space-between', padding: '0 1.25rem', borderBottom: '1px solid rgba(255,255,255,0.07)', background: '#141414' }}>
+        {/* Left: product switcher */}
+        <button
+          ref={switcherBtnRef}
+          type="button"
+          onClick={() => setShowSwitcher(s => !s)}
+          aria-expanded={showSwitcher}
+          style={{ display: 'flex', alignItems: 'center', gap: '0.35rem', background: showSwitcher ? 'rgba(255,255,255,0.06)' : 'none', border: 'none', cursor: 'pointer', color: '#d4d0cc', fontFamily: ui, fontSize: '0.9rem', fontWeight: 500, padding: '0.3rem 0.5rem', borderRadius: 6 }}
+          onMouseEnter={e => { (e.currentTarget as HTMLElement).style.background = 'rgba(255,255,255,0.06)' }}
+          onMouseLeave={e => { if (!showSwitcher) (e.currentTarget as HTMLElement).style.background = 'none' }}
+        >
+          Website <IconChevronDown />
+        </button>
 
-        {/* Brand header */}
-        <div style={{ padding: '1rem 1rem 0.75rem', borderBottom: '1px solid rgba(255,255,255,0.06)' }}>
-          <p style={{ margin: 0, fontFamily: ui, fontSize: '0.72rem', fontWeight: 600, color: '#3a3a3a', letterSpacing: '0.14em', textTransform: 'uppercase' }}>Tynnell Hollins</p>
-          <p style={{ margin: '0.2rem 0 0', fontFamily: ui, fontSize: '0.8rem', fontWeight: 500, color: '#9b9a9a' }}>Website Editor</p>
-        </div>
-
-        {/* Tab icons */}
-        <div style={{ display: 'flex', borderBottom: '1px solid rgba(255,255,255,0.06)', padding: '0 0.5rem' }}>
-          {tabs.map(t => (
-            <button
-              key={t.id}
-              type="button"
-              onClick={() => setActiveTab(t.id)}
-              aria-pressed={activeTab === t.id}
-              title={t.label}
-              style={{ flex: 1, display: 'flex', alignItems: 'center', justifyContent: 'center', padding: '0.7rem 0.5rem', background: 'none', border: 'none', cursor: 'pointer', color: activeTab === t.id ? '#e6e1de' : '#3a3a3a', borderBottom: `2px solid ${activeTab === t.id ? '#e6e1de' : 'transparent'}`, transition: 'color 0.12s, border-color 0.12s' }}
-            >
-              {t.icon}
-            </button>
-          ))}
-        </div>
-
-        {/* Pages tab content */}
-        {activeTab === 'pages' && (
-          <div style={{ flex: 1, overflowY: 'auto', padding: '0.75rem 0.5rem' }}>
-
-            {/* Add Page button */}
-            <button
-              type="button"
-              onClick={() => setShowModal(true)}
-              style={{ display: 'flex', alignItems: 'center', gap: '0.5rem', width: '100%', padding: '0.5rem 0.75rem', background: 'none', border: '1px dashed rgba(255,255,255,0.12)', borderRadius: 7, color: '#5a5a5a', fontSize: '0.8rem', fontFamily: ui, cursor: 'pointer', marginBottom: '1rem', transition: 'border-color 0.12s, color 0.12s' }}
-              onMouseEnter={e => { (e.currentTarget as HTMLElement).style.borderColor = 'rgba(255,255,255,0.25)'; (e.currentTarget as HTMLElement).style.color = '#9b9a9a' }}
-              onMouseLeave={e => { (e.currentTarget as HTMLElement).style.borderColor = 'rgba(255,255,255,0.12)'; (e.currentTarget as HTMLElement).style.color = '#5a5a5a' }}
-            >
-              <PlusIcon /> Add Page
-            </button>
-
-            {/* SITE MENU */}
-            <p style={{ margin: '0 0 0.4rem 0.75rem', fontFamily: mono, fontSize: '0.6rem', letterSpacing: '0.14em', color: '#3a3a3a', textTransform: 'uppercase' }}>Site Menu</p>
-            {inMenu.length > 0
-              ? inMenu.map(p => (
-                  <PageRow key={String(p.id)} page={p} onDelete={deletePage} onToggleNav={toggleNav} onRefresh={reload} />
-                ))
-              : <p style={{ margin: '0 0 0.75rem 0.75rem', fontFamily: mono, fontSize: '0.72rem', color: '#2a2a2a' }}>No pages in menu</p>
-            }
-
-            {/* NOT IN MENU */}
-            {notInMenu.length > 0 && (
-              <>
-                <p style={{ margin: '1rem 0 0.4rem 0.75rem', fontFamily: mono, fontSize: '0.6rem', letterSpacing: '0.14em', color: '#3a3a3a', textTransform: 'uppercase' }}>Not in Menu</p>
-                {notInMenu.map(p => (
-                  <PageRow key={String(p.id)} page={p} onDelete={deletePage} onToggleNav={toggleNav} onRefresh={reload} />
-                ))}
-              </>
-            )}
-
-            {pages.length === 0 && (
-              <p style={{ fontFamily: mono, fontSize: '0.75rem', color: '#2a2a2a', padding: '0 0.75rem' }}>No pages yet. Click &quot;Add Page&quot; to create one.</p>
-            )}
-          </div>
-        )}
-
-        {/* Styles tab */}
-        {activeTab === 'styles' && (
-          <div style={{ flex: 1, padding: '1.25rem 1rem', display: 'flex', flexDirection: 'column', gap: '0.5rem' }}>
-            <p style={{ margin: 0, fontFamily: ui, fontSize: '0.85rem', color: '#9b9a9a' }}>Design tokens and global styles are managed in code.</p>
-            {/* eslint-disable-next-line @next/next/no-html-link-for-pages */}
-            <a href="/admin/globals/site-config" style={{ color: '#2563eb', fontSize: '0.8rem', fontFamily: ui }}>Open Site Config</a>
-          </div>
-        )}
-
-        {/* Settings tab */}
-        {activeTab === 'settings' && (
-          <div style={{ flex: 1, padding: '1.25rem 1rem', display: 'flex', flexDirection: 'column', gap: '0.75rem' }}>
-            {/* eslint-disable @next/next/no-html-link-for-pages */}
-            <a href="/admin/globals/site-config" style={{ color: '#c4bfb9', textDecoration: 'none', fontFamily: ui, fontSize: '0.85rem', padding: '0.5rem 0', borderBottom: '1px solid rgba(255,255,255,0.06)' }}>Site Config</a>
-            <a href="/admin/globals/hero-slides" style={{ color: '#c4bfb9', textDecoration: 'none', fontFamily: ui, fontSize: '0.85rem', padding: '0.5rem 0', borderBottom: '1px solid rgba(255,255,255,0.06)' }}>Hero Slides</a>
-            <a href="/admin/globals/about-page" style={{ color: '#c4bfb9', textDecoration: 'none', fontFamily: ui, fontSize: '0.85rem', padding: '0.5rem 0' }}>About Page</a>
-            {/* eslint-enable @next/next/no-html-link-for-pages */}
-          </div>
-        )}
-
-        {/* Bottom: Preview + Publish + Back */}
-        <div style={{ borderTop: '1px solid rgba(255,255,255,0.06)', padding: '0.75rem 0.75rem' }}>
-          <div style={{ display: 'flex', gap: '0.5rem', marginBottom: '0.5rem' }}>
-            <a
-              href="https://tynnellhollinsphotography.com" target="_blank" rel="noopener noreferrer"
-              style={{ flex: 1, display: 'flex', alignItems: 'center', justifyContent: 'center', gap: '0.35rem', padding: '0.5rem', background: 'none', border: '1px solid rgba(255,255,255,0.12)', borderRadius: 6, color: '#9b9a9a', fontSize: '0.78rem', fontFamily: ui, textDecoration: 'none', transition: 'border-color 0.12s' }}
-              onMouseEnter={e => { (e.currentTarget as HTMLElement).style.borderColor = 'rgba(255,255,255,0.25)' }}
-              onMouseLeave={e => { (e.currentTarget as HTMLElement).style.borderColor = 'rgba(255,255,255,0.12)' }}
-            >
-              Preview <ExternalIcon />
-            </a>
-          </div>
+        {/* Right: nav icons + avatar */}
+        <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
           {/* eslint-disable-next-line @next/next/no-html-link-for-pages */}
           <a
             href="/admin"
-            style={{ display: 'flex', alignItems: 'center', gap: '0.45rem', padding: '0.4rem 0.5rem', color: '#2e2e2e', fontSize: '0.75rem', fontFamily: ui, textDecoration: 'none', borderRadius: 6, transition: 'color 0.12s' }}
-            onMouseEnter={e => { (e.currentTarget as HTMLElement).style.color = '#5a5a5a' }}
-            onMouseLeave={e => { (e.currentTarget as HTMLElement).style.color = '#2e2e2e' }}
+            title="Back to dashboard"
+            style={{ display: 'flex', alignItems: 'center', gap: '0.35rem', padding: '0.35rem 0.6rem', background: 'rgba(255,255,255,0.05)', border: '1px solid rgba(255,255,255,0.1)', borderRadius: 6, color: '#9b9a9a', fontSize: '0.75rem', fontFamily: ui, textDecoration: 'none' }}
+            onMouseEnter={e => { (e.currentTarget as HTMLElement).style.background = 'rgba(255,255,255,0.09)' }}
+            onMouseLeave={e => { (e.currentTarget as HTMLElement).style.background = 'rgba(255,255,255,0.05)' }}
           >
-            <DashboardIcon /> Back to Dashboard
+            <IconDashboard /> Dashboard
           </a>
+          <div style={{ width: 30, height: 30, borderRadius: '50%', background: teal, display: 'flex', alignItems: 'center', justifyContent: 'center', fontSize: '0.75rem', fontWeight: 700, color: '#fff', fontFamily: ui, flexShrink: 0 }}>
+            T
+          </div>
         </div>
       </div>
 
-      {/* ---- Right: main content ---- */}
-      <div style={{ flex: 1, display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', padding: '3rem', background: '#0a0a0a' }}>
-        <div style={{ maxWidth: 480, textAlign: 'center' }}>
-          <div style={{ width: 56, height: 56, borderRadius: '50%', background: '#2563eb', display: 'flex', alignItems: 'center', justifyContent: 'center', margin: '0 auto 1.5rem' }}>
-            <GlobeIcon />
+      {/* ---- Body (sidebar + preview) ---- */}
+      <div style={{ flex: 1, display: 'flex', overflow: 'hidden' }}>
+
+        {/* ---- Sidebar ---- */}
+        <div style={{ width: 300, flexShrink: 0, background: '#141414', borderRight: '1px solid rgba(255,255,255,0.07)', display: 'flex', flexDirection: 'column', height: '100%' }}>
+
+          {/* Tab icon row */}
+          <div style={{ display: 'flex', borderBottom: '1px solid rgba(255,255,255,0.07)' }}>
+            {tabs.map(t => (
+              <button
+                key={t.id}
+                type="button"
+                onClick={() => setActiveTab(t.id)}
+                aria-pressed={activeTab === t.id}
+                title={t.label}
+                style={{
+                  flex: 1, display: 'flex', alignItems: 'center', justifyContent: 'center',
+                  padding: '0.85rem 0.5rem', background: 'none', border: 'none', cursor: 'pointer',
+                  color: activeTab === t.id ? teal : '#4a4a4a',
+                  borderBottom: `2px solid ${activeTab === t.id ? teal : 'transparent'}`,
+                  transition: 'color 0.12s, border-color 0.12s',
+                }}
+                onMouseEnter={e => { if (activeTab !== t.id) (e.currentTarget as HTMLElement).style.color = '#9b9a9a' }}
+                onMouseLeave={e => { if (activeTab !== t.id) (e.currentTarget as HTMLElement).style.color = '#4a4a4a' }}
+              >
+                {t.icon}
+              </button>
+            ))}
           </div>
-          <h1 style={{ fontFamily: ui, fontSize: '1.4rem', fontWeight: 600, color: '#d6d1ce', margin: '0 0 0.75rem' }}>Website Editor</h1>
-          <p style={{ fontFamily: mono, fontSize: '0.78rem', color: '#4a4a4a', margin: '0 0 2rem', lineHeight: 1.7 }}>
-            Select a page from the sidebar to open it in the visual builder, or click &quot;Add Page&quot; to create a new one.
-          </p>
-          <button
-            type="button" onClick={() => setShowModal(true)}
-            style={{ display: 'inline-flex', alignItems: 'center', gap: '0.5rem', background: '#2563eb', border: 'none', color: '#fff', borderRadius: 7, padding: '0.65rem 1.4rem', fontSize: '0.85rem', fontWeight: 600, fontFamily: ui, cursor: 'pointer' }}
-          >
-            <PlusIcon /> Add Page
-          </button>
+
+          {/* Pages tab */}
+          {activeTab === 'pages' && (
+            <>
+              {/* Pages heading + Add Page */}
+              <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', padding: '1rem 1rem 0.5rem' }}>
+                <span style={{ fontFamily: ui, fontSize: '0.88rem', fontWeight: 600, color: '#d4d0cc' }}>Pages</span>
+                <button
+                  type="button"
+                  onClick={() => setShowModal(true)}
+                  style={{ display: 'flex', alignItems: 'center', gap: '0.3rem', background: 'none', border: 'none', cursor: 'pointer', color: teal, fontSize: '0.8rem', fontFamily: ui, fontWeight: 500, padding: '0.25rem 0.4rem', borderRadius: 5 }}
+                  onMouseEnter={e => { (e.currentTarget as HTMLElement).style.background = 'rgba(29,180,142,0.08)' }}
+                  onMouseLeave={e => { (e.currentTarget as HTMLElement).style.background = 'none' }}
+                >
+                  <IconPlus /> Add Page
+                </button>
+              </div>
+
+              {/* Page list */}
+              <div style={{ flex: 1, overflowY: 'auto', padding: '0.25rem 0.5rem' }}>
+                {/* SITE MENU */}
+                <p style={{ margin: '0.5rem 0 0.3rem 0.75rem', fontFamily: mono, fontSize: '0.58rem', letterSpacing: '0.12em', color: '#4a4a4a', textTransform: 'uppercase' }}>Site Menu</p>
+                {inMenu.length > 0
+                  ? inMenu.map(p => (
+                      <PageRow key={String(p.id)} page={p} onDelete={deletePage} onToggleNav={toggleNav} onRefresh={reload} />
+                    ))
+                  : <p style={{ margin: '0 0 0.5rem 0.75rem', fontFamily: mono, fontSize: '0.72rem', color: '#3a3a3a' }}>No pages in menu</p>
+                }
+
+                {/* NOT IN MENU */}
+                {notInMenu.length > 0 && (
+                  <>
+                    <p style={{ margin: '1rem 0 0.3rem 0.75rem', fontFamily: mono, fontSize: '0.58rem', letterSpacing: '0.12em', color: '#4a4a4a', textTransform: 'uppercase' }}>Not in Menu</p>
+                    {notInMenu.map(p => (
+                      <PageRow key={String(p.id)} page={p} onDelete={deletePage} onToggleNav={toggleNav} onRefresh={reload} />
+                    ))}
+                  </>
+                )}
+
+                {pages.length === 0 && (
+                  <p style={{ fontFamily: mono, fontSize: '0.75rem', color: '#3a3a3a', padding: '0.5rem 0.75rem' }}>
+                    No pages yet. Click &quot;Add Page&quot; to create one.
+                  </p>
+                )}
+              </div>
+            </>
+          )}
+
+          {/* Design tab */}
+          {activeTab === 'design' && (
+            <div style={{ flex: 1, padding: '1.25rem 1rem', display: 'flex', flexDirection: 'column', gap: '0.75rem' }}>
+              <p style={{ margin: 0, fontFamily: ui, fontSize: '0.82rem', color: '#6b6b6b', lineHeight: 1.6 }}>
+                Global design tokens are managed in code at <code style={{ color: '#9b9a9a', fontSize: '0.78rem' }}>tokens.css</code>.
+              </p>
+              {/* eslint-disable-next-line @next/next/no-html-link-for-pages */}
+              <a href="/admin/globals/site-config" style={{ color: teal, fontSize: '0.8rem', fontFamily: ui, textDecoration: 'none' }}
+                onMouseEnter={e => { (e.currentTarget as HTMLElement).style.textDecoration = 'underline' }}
+                onMouseLeave={e => { (e.currentTarget as HTMLElement).style.textDecoration = 'none' }}
+              >
+                Open Site Config
+              </a>
+            </div>
+          )}
+
+          {/* Blog tab */}
+          {activeTab === 'blog' && (
+            <div style={{ flex: 1, padding: '1.25rem 1rem', display: 'flex', flexDirection: 'column', gap: '0.5rem' }}>
+              <p style={{ margin: '0 0 0.75rem', fontFamily: ui, fontSize: '0.88rem', fontWeight: 600, color: '#d4d0cc' }}>Blog</p>
+              {/* eslint-disable-next-line @next/next/no-html-link-for-pages */}
+              <a href="/admin/collections/posts" style={{ display: 'block', padding: '0.55rem 0.75rem', background: 'rgba(255,255,255,0.03)', border: '1px solid rgba(255,255,255,0.07)', borderRadius: 7, color: '#c4bfb9', textDecoration: 'none', fontFamily: ui, fontSize: '0.83rem' }}
+                onMouseEnter={e => { (e.currentTarget as HTMLElement).style.background = 'rgba(255,255,255,0.06)' }}
+                onMouseLeave={e => { (e.currentTarget as HTMLElement).style.background = 'rgba(255,255,255,0.03)' }}
+              >
+                All Posts
+              </a>
+              {/* eslint-disable-next-line @next/next/no-html-link-for-pages */}
+              <a href="/admin/collections/posts/create" style={{ display: 'block', padding: '0.55rem 0.75rem', background: 'rgba(255,255,255,0.03)', border: '1px solid rgba(255,255,255,0.07)', borderRadius: 7, color: '#c4bfb9', textDecoration: 'none', fontFamily: ui, fontSize: '0.83rem' }}
+                onMouseEnter={e => { (e.currentTarget as HTMLElement).style.background = 'rgba(255,255,255,0.06)' }}
+                onMouseLeave={e => { (e.currentTarget as HTMLElement).style.background = 'rgba(255,255,255,0.03)' }}
+              >
+                New Post
+              </a>
+            </div>
+          )}
+
+          {/* Settings tab */}
+          {activeTab === 'settings' && (
+            <div style={{ flex: 1, padding: '1.25rem 1rem', display: 'flex', flexDirection: 'column', gap: '0.5rem' }}>
+              <p style={{ margin: '0 0 0.75rem', fontFamily: ui, fontSize: '0.88rem', fontWeight: 600, color: '#d4d0cc' }}>Settings</p>
+              {/* eslint-disable @next/next/no-html-link-for-pages */}
+              {[
+                { label: 'Site Config', href: '/admin/globals/site-config' },
+                { label: 'Hero Slides', href: '/admin/globals/hero-slides' },
+                { label: 'About Page', href: '/admin/globals/about-page' },
+              ].map(item => (
+                <a
+                  key={item.href}
+                  href={item.href}
+                  style={{ display: 'block', padding: '0.55rem 0.75rem', background: 'rgba(255,255,255,0.03)', border: '1px solid rgba(255,255,255,0.07)', borderRadius: 7, color: '#c4bfb9', textDecoration: 'none', fontFamily: ui, fontSize: '0.83rem' }}
+                  onMouseEnter={e => { (e.currentTarget as HTMLElement).style.background = 'rgba(255,255,255,0.06)' }}
+                  onMouseLeave={e => { (e.currentTarget as HTMLElement).style.background = 'rgba(255,255,255,0.03)' }}
+                >
+                  {item.label}
+                </a>
+              ))}
+              {/* eslint-enable @next/next/no-html-link-for-pages */}
+            </div>
+          )}
+
+          {/* ---- Bottom: Preview + Publish ---- */}
+          <div style={{ borderTop: '1px solid rgba(255,255,255,0.07)', padding: '0.75rem', display: 'flex', gap: '0.5rem' }}>
+            <a
+              href="https://tynnellhollinsphotography.com" target="_blank" rel="noopener noreferrer"
+              style={{ flex: 1, display: 'flex', alignItems: 'center', justifyContent: 'center', padding: '0.6rem', background: 'none', border: '1px solid rgba(255,255,255,0.14)', borderRadius: 7, color: '#9b9a9a', fontSize: '0.82rem', fontFamily: ui, textDecoration: 'none', fontWeight: 500, transition: 'border-color 0.12s, color 0.12s' }}
+              onMouseEnter={e => { const el = e.currentTarget as HTMLElement; el.style.borderColor = 'rgba(255,255,255,0.28)'; el.style.color = '#d4d0cc' }}
+              onMouseLeave={e => { const el = e.currentTarget as HTMLElement; el.style.borderColor = 'rgba(255,255,255,0.14)'; el.style.color = '#9b9a9a' }}
+            >
+              Preview
+            </a>
+            <button
+              type="button"
+              onClick={() => void publishAll()}
+              disabled={publishing}
+              aria-busy={publishing}
+              style={{ flex: 1, padding: '0.6rem', background: teal, border: 'none', borderRadius: 7, color: '#fff', fontSize: '0.82rem', fontFamily: ui, fontWeight: 600, cursor: publishing ? 'wait' : 'pointer', opacity: publishing ? 0.7 : 1, transition: 'opacity 0.12s, filter 0.12s' }}
+              onMouseEnter={e => { if (!publishing) (e.currentTarget as HTMLElement).style.filter = 'brightness(1.1)' }}
+              onMouseLeave={e => { (e.currentTarget as HTMLElement).style.filter = 'none' }}
+            >
+              {publishing ? 'Publishing...' : 'Publish'}
+            </button>
+          </div>
+        </div>
+
+        {/* ---- Right: website preview ---- */}
+        <div style={{ flex: 1, background: '#0e0e0e', display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', position: 'relative' }}>
+          <iframe
+            src="/"
+            style={{ width: '100%', height: '100%', border: 'none' }}
+            title="Website preview"
+          />
         </div>
       </div>
     </div>

--- a/app/builder/SiteEditorClient.tsx
+++ b/app/builder/SiteEditorClient.tsx
@@ -1,7 +1,8 @@
 'use client'
 import { useState, useCallback, useRef, useEffect } from 'react'
 
-const ui = "'Archivo', system-ui, sans-serif"
+// System font stack matches Pixieset's clean UI look
+const ui = "Inter, system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif"
 const mono = "'Roboto Mono', monospace"
 const teal = '#1db48e'
 
@@ -15,6 +16,30 @@ export interface SitePage {
   displayOrder?: number | null
   updatedAt?: string | null
 }
+
+// ---------------------------------------------------------------------------
+// Hardcoded site navigation - mirrors the actual public site structure
+// ---------------------------------------------------------------------------
+
+type NavChild = { key: string; label: string; href: string }
+type NavItem  = { key: string; label: string; href: string; children?: NavChild[] }
+
+const SITE_NAV: NavItem[] = [
+  { key: 'home',         label: 'Home',         href: '/' },
+  { key: 'about',        label: 'About',         href: '/about' },
+  {
+    key: 'portfolio', label: 'Portfolio', href: '/portfolio',
+    children: [
+      { key: 'portraits', label: 'Portraits', href: '/portfolio/portraits' },
+      { key: 'family',    label: 'Family',    href: '/portfolio/family'    },
+      { key: 'weddings',  label: 'Weddings',  href: '/portfolio/weddings'  },
+    ],
+  },
+  { key: 'services',     label: 'Services',      href: '/services'      },
+  { key: 'testimonials', label: 'Testimonials',  href: '/testimonials'  },
+  { key: 'contact',      label: 'Contact',       href: '/contact'       },
+  { key: 'blog',         label: 'Blog',          href: '/blog'          },
+]
 
 // ---------------------------------------------------------------------------
 // Icons
@@ -74,14 +99,6 @@ function IconHome() {
   )
 }
 
-function IconBlog() {
-  return (
-    <svg width="14" height="14" viewBox="0 0 14 14" fill="none" aria-hidden="true">
-      <path d="M2 10l7-7 2 2-7 7H2v-2z" stroke="currentColor" strokeWidth="1.2" strokeLinejoin="round"/>
-    </svg>
-  )
-}
-
 function IconDots() {
   return (
     <svg width="14" height="14" viewBox="0 0 14 14" fill="none" aria-hidden="true">
@@ -100,9 +117,12 @@ function IconExternal() {
   )
 }
 
-function IconChevronDown() {
+function IconChevronDown({ rotated }: { rotated?: boolean }) {
   return (
-    <svg width="12" height="12" viewBox="0 0 12 12" fill="none" aria-hidden="true">
+    <svg
+      width="12" height="12" viewBox="0 0 12 12" fill="none" aria-hidden="true"
+      style={{ transition: 'transform 0.18s', transform: rotated ? 'rotate(180deg)' : 'none', flexShrink: 0 }}
+    >
       <path d="M2.5 4.5L6 8l3.5-3.5" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round" strokeLinejoin="round"/>
     </svg>
   )
@@ -128,62 +148,123 @@ function IconPlus() {
 }
 
 // ---------------------------------------------------------------------------
-// Page context menu
+// Hardcoded nav page row (Home, About, Portfolio, etc.)
 // ---------------------------------------------------------------------------
 
-function PageMenu({ page, onDelete, onToggleNav, onClose }: {
-  page: SitePage
-  onDelete: () => void
-  onToggleNav: () => void
-  onClose: () => void
+function NavPageRow({
+  item, selectedKey, onSelect, expanded, onToggleExpand,
+}: {
+  item: NavItem
+  selectedKey: string
+  onSelect: (key: string, href: string) => void
+  expanded: boolean
+  onToggleExpand: () => void
 }) {
-  const ref = useRef<HTMLDivElement>(null)
-
-  useEffect(() => {
-    const handler = (e: MouseEvent) => {
-      if (ref.current && !ref.current.contains(e.target as Node)) onClose()
-    }
-    document.addEventListener('mousedown', handler)
-    return () => document.removeEventListener('mousedown', handler)
-  }, [onClose])
-
-  const items = [
-    { label: 'Edit page', action: () => { window.location.href = `/builder/${page.slug ?? ''}` } },
-    { label: page.showInNav ? 'Remove from menu' : 'Add to menu', action: onToggleNav },
-    { label: 'Delete', action: onDelete, danger: true },
-  ]
+  const [hovered, setHovered] = useState(false)
+  const isActive   = selectedKey === item.key
+  const hasChildren = (item.children?.length ?? 0) > 0
 
   return (
+    <>
+      <div
+        role="button"
+        tabIndex={0}
+        onClick={() => { if (hasChildren) onToggleExpand(); onSelect(item.key, item.href) }}
+        onKeyDown={e => { if (e.key === 'Enter' || e.key === ' ') { if (hasChildren) onToggleExpand(); onSelect(item.key, item.href) } }}
+        onMouseEnter={() => setHovered(true)}
+        onMouseLeave={() => setHovered(false)}
+        style={{
+          display: 'flex', alignItems: 'center', gap: '0.55rem',
+          padding: '0.45rem 0.75rem', borderRadius: 6, cursor: 'pointer',
+          background: isActive ? 'rgba(255,255,255,0.08)' : hovered ? 'rgba(255,255,255,0.04)' : 'transparent',
+          transition: 'background 0.1s',
+        }}
+      >
+        <span style={{ color: isActive ? '#9b9a9a' : '#4a4a4a', flexShrink: 0, display: 'flex', alignItems: 'center' }}>
+          {item.key === 'home' ? <IconHome /> : <IconPage />}
+        </span>
+
+        <span style={{
+          flex: 1, fontSize: '0.875rem', fontFamily: ui,
+          fontWeight: isActive ? 500 : 400,
+          color: isActive ? '#ffffff' : '#c8c4c0',
+          overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', minWidth: 0,
+        }}>
+          {item.label}
+        </span>
+
+        {hasChildren && (
+          <span style={{ color: '#4a4a4a', display: 'flex', alignItems: 'center' }}>
+            <IconChevronDown rotated={expanded} />
+          </span>
+        )}
+
+        {!hasChildren && hovered && (
+          <a
+            href={item.href} target="_blank" rel="noopener noreferrer"
+            onClick={e => e.stopPropagation()}
+            style={{ color: '#4a4a4a', display: 'flex', alignItems: 'center', flexShrink: 0, lineHeight: 1 }}
+            title={`View ${item.label} live`}
+          >
+            <IconExternal />
+          </a>
+        )}
+      </div>
+
+      {/* Sub-pages (Portfolio children) */}
+      {hasChildren && expanded && item.children?.map(child => (
+        <SubPageRow
+          key={child.key}
+          child={child}
+          isActive={selectedKey === child.key}
+          onSelect={onSelect}
+        />
+      ))}
+    </>
+  )
+}
+
+function SubPageRow({ child, isActive, onSelect }: {
+  child: NavChild
+  isActive: boolean
+  onSelect: (key: string, href: string) => void
+}) {
+  const [hovered, setHovered] = useState(false)
+  return (
     <div
-      ref={ref}
+      role="button"
+      tabIndex={0}
+      onClick={() => onSelect(child.key, child.href)}
+      onKeyDown={e => { if (e.key === 'Enter' || e.key === ' ') onSelect(child.key, child.href) }}
+      onMouseEnter={() => setHovered(true)}
+      onMouseLeave={() => setHovered(false)}
       style={{
-        position: 'absolute', right: 4, top: '100%', zIndex: 200,
-        background: '#232323', border: '1px solid rgba(255,255,255,0.1)',
-        borderRadius: 8, padding: '0.3rem', minWidth: 170,
-        boxShadow: '0 8px 32px rgba(0,0,0,0.7)',
+        display: 'flex', alignItems: 'center', gap: '0.55rem',
+        padding: '0.4rem 0.75rem 0.4rem 2.35rem',
+        borderRadius: 6, cursor: 'pointer',
+        background: isActive ? 'rgba(255,255,255,0.08)' : hovered ? 'rgba(255,255,255,0.04)' : 'transparent',
+        transition: 'background 0.1s',
       }}
     >
-      {items.map(item => (
-        <button
-          key={item.label}
-          type="button"
-          onClick={() => { item.action(); onClose() }}
-          style={{ display: 'block', width: '100%', textAlign: 'left', padding: '0.5rem 0.7rem', background: 'none', border: 'none', borderRadius: 5, fontSize: '0.8rem', fontFamily: ui, color: item.danger ? '#f87171' : '#c4bfb9', cursor: 'pointer' }}
-          onMouseEnter={e => { (e.currentTarget as HTMLElement).style.background = 'rgba(255,255,255,0.06)' }}
-          onMouseLeave={e => { (e.currentTarget as HTMLElement).style.background = 'none' }}
-        >
-          {item.label}
-        </button>
-      ))}
+      <span style={{ color: isActive ? '#9b9a9a' : '#4a4a4a', flexShrink: 0, display: 'flex', alignItems: 'center' }}>
+        <IconPage />
+      </span>
+      <span style={{
+        flex: 1, fontSize: '0.85rem', fontFamily: ui,
+        fontWeight: isActive ? 500 : 400,
+        color: isActive ? '#ffffff' : '#c0bcb8',
+      }}>
+        {child.label}
+      </span>
     </div>
   )
 }
 
 // ---------------------------------------------------------------------------
-// Single page row
+// Custom Puck page row (NOT IN MENU section)
 // ---------------------------------------------------------------------------
 
-function PageRow({ page, onDelete, onToggleNav, onRefresh }: {
+function PuckPageRow({ page, onDelete, onToggleNav, onRefresh }: {
   page: SitePage
   onDelete: (id: string | number) => void
   onToggleNav: (id: string | number, current: boolean) => void
@@ -191,15 +272,22 @@ function PageRow({ page, onDelete, onToggleNav, onRefresh }: {
 }) {
   const [menuOpen, setMenuOpen] = useState(false)
   const [hovered, setHovered] = useState(false)
-  const isHome = Boolean(page.isHomepage)
+  const menuRef = useRef<HTMLDivElement>(null)
 
-  const pageIcon = isHome ? <IconHome /> : (page.slug === 'blog' ? <IconBlog /> : <IconPage />)
+  useEffect(() => {
+    if (!menuOpen) return
+    const handler = (e: MouseEvent) => {
+      if (menuRef.current && !menuRef.current.contains(e.target as Node)) setMenuOpen(false)
+    }
+    document.addEventListener('mousedown', handler)
+    return () => document.removeEventListener('mousedown', handler)
+  }, [menuOpen])
 
   return (
     <div
       style={{
         position: 'relative', display: 'flex', alignItems: 'center', gap: '0.55rem',
-        padding: '0.5rem 0.75rem', borderRadius: 6, cursor: 'pointer',
+        padding: '0.45rem 0.75rem', borderRadius: 6, cursor: 'pointer',
         background: hovered ? 'rgba(255,255,255,0.04)' : 'transparent',
         transition: 'background 0.1s',
       }}
@@ -207,43 +295,46 @@ function PageRow({ page, onDelete, onToggleNav, onRefresh }: {
       onMouseLeave={() => { if (!menuOpen) setHovered(false) }}
       onClick={() => { if (!menuOpen) window.location.href = `/builder/${page.slug ?? ''}` }}
     >
-      <span style={{ color: '#6b6b6b', flexShrink: 0, display: 'flex', alignItems: 'center' }}>
-        {pageIcon}
-      </span>
-
-      <span style={{ flex: 1, fontSize: '0.85rem', fontFamily: ui, fontWeight: 400, color: '#d4d0cc', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', minWidth: 0 }}>
+      <span style={{ color: '#4a4a4a', flexShrink: 0, display: 'flex', alignItems: 'center' }}><IconPage /></span>
+      <span style={{ flex: 1, fontSize: '0.875rem', fontFamily: ui, color: '#c0bcb8', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', minWidth: 0 }}>
         {page.title ?? 'Untitled'}
       </span>
-
-      {hovered && !menuOpen && page.published && page.slug && (
-        <a
-          href={`/${page.slug}`} target="_blank" rel="noopener noreferrer"
-          onClick={e => e.stopPropagation()}
-          style={{ color: '#6b6b6b', display: 'flex', alignItems: 'center', flexShrink: 0, lineHeight: 1 }}
-          title="View live"
-        >
-          <IconExternal />
-        </a>
-      )}
-
       {hovered && (
         <button
           type="button"
           onClick={e => { e.stopPropagation(); setMenuOpen(o => !o) }}
-          style={{ background: 'none', border: 'none', color: '#6b6b6b', cursor: 'pointer', padding: '0.1rem 0.2rem', borderRadius: 4, display: 'flex', alignItems: 'center', flexShrink: 0 }}
+          style={{ background: 'none', border: 'none', color: '#4a4a4a', cursor: 'pointer', padding: '0.1rem 0.2rem', borderRadius: 4, display: 'flex', alignItems: 'center', flexShrink: 0 }}
           aria-label={`Options for ${page.title ?? 'page'}`}
         >
           <IconDots />
         </button>
       )}
-
       {menuOpen && (
-        <PageMenu
-          page={page}
-          onDelete={() => { onDelete(page.id); setMenuOpen(false); setHovered(false) }}
-          onToggleNav={() => { onToggleNav(page.id, Boolean(page.showInNav)); onRefresh(); setMenuOpen(false) }}
-          onClose={() => { setMenuOpen(false); setHovered(false) }}
-        />
+        <div
+          ref={menuRef}
+          style={{
+            position: 'absolute', right: 4, top: '100%', zIndex: 200,
+            background: '#232323', border: '1px solid rgba(255,255,255,0.1)',
+            borderRadius: 8, padding: '0.3rem', minWidth: 170,
+            boxShadow: '0 8px 32px rgba(0,0,0,0.7)',
+          }}
+        >
+          {[
+            { label: 'Edit in builder', action: () => { window.location.href = `/builder/${page.slug ?? ''}` } },
+            { label: page.showInNav ? 'Remove from menu' : 'Add to menu', action: () => { void onToggleNav(page.id, Boolean(page.showInNav)); onRefresh(); setMenuOpen(false); setHovered(false) } },
+            { label: 'Delete', danger: true, action: () => { onDelete(page.id); setMenuOpen(false); setHovered(false) } },
+          ].map(item => (
+            <button
+              key={item.label} type="button"
+              onClick={() => { item.action(); setMenuOpen(false) }}
+              style={{ display: 'block', width: '100%', textAlign: 'left', padding: '0.5rem 0.7rem', background: 'none', border: 'none', borderRadius: 5, fontSize: '0.8rem', fontFamily: ui, color: item.danger ? '#f87171' : '#c4bfb9', cursor: 'pointer' }}
+              onMouseEnter={e => { (e.currentTarget as HTMLElement).style.background = 'rgba(255,255,255,0.06)' }}
+              onMouseLeave={e => { (e.currentTarget as HTMLElement).style.background = 'none' }}
+            >
+              {item.label}
+            </button>
+          ))}
+        </div>
       )}
     </div>
   )
@@ -288,19 +379,17 @@ function NewPageModal({ onClose }: { onClose: () => void }) {
       onKeyDown={e => { if (e.key === 'Escape') onClose() }}
     >
       <div style={{ background: '#1c1c1c', border: '1px solid rgba(255,255,255,0.1)', borderRadius: 12, padding: '1.75rem', width: 380, display: 'flex', flexDirection: 'column', gap: '1.1rem', boxShadow: '0 24px 64px rgba(0,0,0,0.8)' }}>
-        <h2 id="new-page-label" style={{ margin: 0, fontFamily: ui, fontSize: '1rem', fontWeight: 600, color: '#e6e1de' }}>New page</h2>
-
+        <h2 id="new-page-label" style={{ margin: 0, fontFamily: ui, fontSize: '1rem', fontWeight: 600, color: '#e6e1de' }}>New custom page</h2>
         <label style={{ display: 'flex', flexDirection: 'column', gap: '0.4rem' }}>
           <span style={{ fontFamily: mono, fontSize: '0.68rem', color: '#7a7a7a', letterSpacing: '0.06em' }}>Page title</span>
           <input
             autoFocus type="text" value={title}
             onChange={e => setTitle(e.target.value)}
             onKeyDown={e => { if (e.key === 'Enter') void create() }}
-            placeholder="e.g. About Me"
+            placeholder="e.g. FAQ"
             style={{ background: '#111', border: '1px solid rgba(255,255,255,0.12)', borderRadius: 7, padding: '0.6rem 0.75rem', color: '#e6e1de', fontSize: '0.88rem', outline: 'none', fontFamily: ui }}
           />
         </label>
-
         <label style={{ display: 'flex', flexDirection: 'column', gap: '0.4rem' }}>
           <span style={{ fontFamily: mono, fontSize: '0.68rem', color: '#7a7a7a', letterSpacing: '0.06em' }}>Template</span>
           <select
@@ -313,13 +402,9 @@ function NewPageModal({ onClose }: { onClose: () => void }) {
             <option value="gallery">Gallery Showcase</option>
           </select>
         </label>
-
         {error && <p role="alert" style={{ margin: 0, fontFamily: mono, fontSize: '0.75rem', color: '#f87171' }}>{error}</p>}
-
         <div style={{ display: 'flex', gap: '0.6rem', justifyContent: 'flex-end' }}>
-          <button type="button" onClick={onClose} style={{ background: 'none', border: '1px solid rgba(255,255,255,0.15)', color: '#9b9a9a', borderRadius: 7, padding: '0.5rem 1rem', fontSize: '0.82rem', fontFamily: ui, cursor: 'pointer' }}>
-            Cancel
-          </button>
+          <button type="button" onClick={onClose} style={{ background: 'none', border: '1px solid rgba(255,255,255,0.15)', color: '#9b9a9a', borderRadius: 7, padding: '0.5rem 1rem', fontSize: '0.82rem', fontFamily: ui, cursor: 'pointer' }}>Cancel</button>
           <button
             type="button" onClick={() => void create()} disabled={!title.trim() || creating} aria-busy={creating}
             style={{ background: teal, border: 'none', color: '#fff', borderRadius: 7, padding: '0.5rem 1.2rem', fontSize: '0.82rem', fontWeight: 600, fontFamily: ui, cursor: !title.trim() || creating ? 'not-allowed' : 'pointer', opacity: !title.trim() || creating ? 0.5 : 1 }}
@@ -333,18 +418,16 @@ function NewPageModal({ onClose }: { onClose: () => void }) {
 }
 
 // ---------------------------------------------------------------------------
-// Main
+// Product switcher dropdown
 // ---------------------------------------------------------------------------
 
-type Tab = 'pages' | 'design' | 'blog' | 'settings'
-
 const SWITCHER_ITEMS = [
-  { label: 'Portfolio', desc: 'Galleries and photos', href: '/gallery-editor', color: '#0d9488' },
-  { label: 'Website', desc: 'Pages and content', href: '/builder', color: '#2563eb', active: true },
-  { label: 'Blog', desc: 'Posts and articles', href: '/admin/collections/posts', color: '#7c3aed' },
-  { label: 'Bookings', desc: 'Services and availability', href: '/admin/globals/booking-settings', color: '#b45309' },
-  { label: 'Testimonials', desc: 'Client reviews', href: '/admin/collections/testimonials', color: '#059669' },
-  { label: 'Studio', desc: 'Site settings', href: '/admin', color: '#475569' },
+  { label: 'Portfolio',     desc: 'Galleries and photos',    href: '/gallery-editor',                    color: '#0d9488' },
+  { label: 'Website',       desc: 'Pages and content',       href: '/builder',                           color: '#2563eb', active: true },
+  { label: 'Blog',          desc: 'Posts and articles',      href: '/admin/collections/posts',           color: '#7c3aed' },
+  { label: 'Bookings',      desc: 'Services and availability', href: '/admin/globals/booking-settings', color: '#b45309' },
+  { label: 'Testimonials',  desc: 'Client reviews',          href: '/admin/collections/testimonials',    color: '#059669' },
+  { label: 'Studio',        desc: 'Site settings',           href: '/admin',                             color: '#475569' },
 ]
 
 function ProductSwitcher({ onClose, anchorRef }: { onClose: () => void; anchorRef: React.RefObject<HTMLButtonElement | null> }) {
@@ -358,9 +441,7 @@ function ProductSwitcher({ onClose, anchorRef }: { onClose: () => void; anchorRe
     }
     const handler = (e: MouseEvent) => {
       if (ref.current && !ref.current.contains(e.target as Node) &&
-          anchorRef.current && !anchorRef.current.contains(e.target as Node)) {
-        onClose()
-      }
+          anchorRef.current && !anchorRef.current.contains(e.target as Node)) onClose()
     }
     document.addEventListener('mousedown', handler)
     return () => document.removeEventListener('mousedown', handler)
@@ -369,25 +450,13 @@ function ProductSwitcher({ onClose, anchorRef }: { onClose: () => void; anchorRe
   return (
     <div
       ref={ref}
-      style={{
-        position: 'fixed', top: pos.top, left: pos.left, zIndex: 500,
-        background: '#1c1c1c', border: '1px solid rgba(255,255,255,0.1)',
-        borderRadius: 10, padding: '0.5rem', width: 240,
-        boxShadow: '0 12px 40px rgba(0,0,0,0.7)',
-      }}
+      style={{ position: 'fixed', top: pos.top, left: pos.left, zIndex: 500, background: '#1c1c1c', border: '1px solid rgba(255,255,255,0.1)', borderRadius: 10, padding: '0.5rem', width: 240, boxShadow: '0 12px 40px rgba(0,0,0,0.7)' }}
     >
       {SWITCHER_ITEMS.map(item => (
         // eslint-disable-next-line @next/next/no-html-link-for-pages
         <a
-          key={item.label}
-          href={item.href}
-          onClick={onClose}
-          style={{
-            display: 'flex', alignItems: 'center', gap: '0.75rem',
-            padding: '0.6rem 0.75rem', borderRadius: 7, textDecoration: 'none',
-            background: item.active ? 'rgba(255,255,255,0.06)' : 'none',
-            transition: 'background 0.1s',
-          }}
+          key={item.label} href={item.href} onClick={onClose}
+          style={{ display: 'flex', alignItems: 'center', gap: '0.75rem', padding: '0.6rem 0.75rem', borderRadius: 7, textDecoration: 'none', background: item.active ? 'rgba(255,255,255,0.06)' : 'none', transition: 'background 0.1s' }}
           onMouseEnter={e => { (e.currentTarget as HTMLElement).style.background = 'rgba(255,255,255,0.07)' }}
           onMouseLeave={e => { (e.currentTarget as HTMLElement).style.background = item.active ? 'rgba(255,255,255,0.06)' : 'none' }}
         >
@@ -404,6 +473,12 @@ function ProductSwitcher({ onClose, anchorRef }: { onClose: () => void; anchorRe
   )
 }
 
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+type Tab = 'pages' | 'design' | 'blog' | 'settings'
+
 export function SiteEditorClient({ initialPages }: { initialPages: SitePage[] }) {
   const [pages, setPages] = useState<SitePage[]>(initialPages)
   const [activeTab, setActiveTab] = useState<Tab>('pages')
@@ -412,12 +487,24 @@ export function SiteEditorClient({ initialPages }: { initialPages: SitePage[] })
   const [showSwitcher, setShowSwitcher] = useState(false)
   const switcherBtnRef = useRef<HTMLButtonElement>(null)
 
+  // Which page is selected and shown in the preview pane
+  const [selectedKey, setSelectedKey] = useState('home')
+  const [previewHref, setPreviewHref] = useState('/')
+
+  // Portfolio sub-pages expand/collapse
+  const [portfolioExpanded, setPortfolioExpanded] = useState(false)
+
   const reload = useCallback(() => {
     fetch('/api/pages?sort=displayOrder&limit=100&depth=0', { credentials: 'include' })
       .then(r => r.json())
       .then((d: { docs?: SitePage[] }) => setPages(d.docs ?? []))
       .catch(() => {})
   }, [])
+
+  const handleSelect = (key: string, href: string) => {
+    setSelectedKey(key)
+    setPreviewHref(href)
+  }
 
   const deletePage = async (id: string | number) => {
     if (!confirm('Delete this page? This cannot be undone.')) return
@@ -449,15 +536,17 @@ export function SiteEditorClient({ initialPages }: { initialPages: SitePage[] })
     setPublishing(false)
   }
 
-  const inMenu = pages.filter(p => p.showInNav)
-  const notInMenu = pages.filter(p => !p.showInNav)
+  // Custom Puck builder pages always go in NOT IN MENU
+  const customPages = pages.filter(p => !p.showInNav)
 
   const tabs: { id: Tab; icon: React.ReactNode; label: string }[] = [
-    { id: 'pages', icon: <IconPages />, label: 'Pages' },
-    { id: 'design', icon: <IconBrush />, label: 'Design' },
-    { id: 'blog', icon: <IconPen />, label: 'Blog' },
+    { id: 'pages',    icon: <IconPages />,   label: 'Pages'    },
+    { id: 'design',   icon: <IconBrush />,   label: 'Design'   },
+    { id: 'blog',     icon: <IconPen />,     label: 'Blog'     },
     { id: 'settings', icon: <IconSettings />, label: 'Settings' },
   ]
+
+  const previewLabel = previewHref === '/' ? 'tynnellhollinsphotography.com' : `tynnellhollinsphotography.com${previewHref}`
 
   return (
     <div style={{ display: 'flex', flexDirection: 'column', height: '100vh', background: '#141414', color: '#d4d0cc', fontFamily: ui }}>
@@ -467,7 +556,6 @@ export function SiteEditorClient({ initialPages }: { initialPages: SitePage[] })
 
       {/* ---- Top bar ---- */}
       <div style={{ height: 52, flexShrink: 0, display: 'flex', alignItems: 'center', justifyContent: 'space-between', padding: '0 1.25rem', borderBottom: '1px solid rgba(255,255,255,0.07)', background: '#141414' }}>
-        {/* Left: product switcher */}
         <button
           ref={switcherBtnRef}
           type="button"
@@ -480,7 +568,6 @@ export function SiteEditorClient({ initialPages }: { initialPages: SitePage[] })
           Website <IconChevronDown />
         </button>
 
-        {/* Right: nav icons + avatar */}
         <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
           {/* eslint-disable-next-line @next/next/no-html-link-for-pages */}
           <a
@@ -498,7 +585,7 @@ export function SiteEditorClient({ initialPages }: { initialPages: SitePage[] })
         </div>
       </div>
 
-      {/* ---- Body (sidebar + preview) ---- */}
+      {/* ---- Body ---- */}
       <div style={{ flex: 1, display: 'flex', overflow: 'hidden' }}>
 
         {/* ---- Sidebar ---- */}
@@ -508,18 +595,11 @@ export function SiteEditorClient({ initialPages }: { initialPages: SitePage[] })
           <div style={{ display: 'flex', borderBottom: '1px solid rgba(255,255,255,0.07)' }}>
             {tabs.map(t => (
               <button
-                key={t.id}
-                type="button"
+                key={t.id} type="button"
                 onClick={() => setActiveTab(t.id)}
                 aria-pressed={activeTab === t.id}
                 title={t.label}
-                style={{
-                  flex: 1, display: 'flex', alignItems: 'center', justifyContent: 'center',
-                  padding: '0.85rem 0.5rem', background: 'none', border: 'none', cursor: 'pointer',
-                  color: activeTab === t.id ? teal : '#4a4a4a',
-                  borderBottom: `2px solid ${activeTab === t.id ? teal : 'transparent'}`,
-                  transition: 'color 0.12s, border-color 0.12s',
-                }}
+                style={{ flex: 1, display: 'flex', alignItems: 'center', justifyContent: 'center', padding: '0.85rem 0.5rem', background: 'none', border: 'none', cursor: 'pointer', color: activeTab === t.id ? teal : '#4a4a4a', borderBottom: `2px solid ${activeTab === t.id ? teal : 'transparent'}`, transition: 'color 0.12s, border-color 0.12s' }}
                 onMouseEnter={e => { if (activeTab !== t.id) (e.currentTarget as HTMLElement).style.color = '#9b9a9a' }}
                 onMouseLeave={e => { if (activeTab !== t.id) (e.currentTarget as HTMLElement).style.color = '#4a4a4a' }}
               >
@@ -531,13 +611,12 @@ export function SiteEditorClient({ initialPages }: { initialPages: SitePage[] })
           {/* Pages tab */}
           {activeTab === 'pages' && (
             <>
-              {/* Pages heading + Add Page */}
               <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', padding: '1rem 1rem 0.5rem' }}>
-                <span style={{ fontFamily: ui, fontSize: '0.88rem', fontWeight: 600, color: '#d4d0cc' }}>Pages</span>
+                <span style={{ fontFamily: ui, fontSize: '0.9rem', fontWeight: 600, color: '#e0dcd8' }}>Pages</span>
                 <button
                   type="button"
                   onClick={() => setShowModal(true)}
-                  style={{ display: 'flex', alignItems: 'center', gap: '0.3rem', background: 'none', border: 'none', cursor: 'pointer', color: teal, fontSize: '0.8rem', fontFamily: ui, fontWeight: 500, padding: '0.25rem 0.4rem', borderRadius: 5 }}
+                  style={{ display: 'flex', alignItems: 'center', gap: '0.3rem', background: 'none', border: 'none', cursor: 'pointer', color: teal, fontSize: '0.82rem', fontFamily: ui, fontWeight: 500, padding: '0.25rem 0.4rem', borderRadius: 5 }}
                   onMouseEnter={e => { (e.currentTarget as HTMLElement).style.background = 'rgba(29,180,142,0.08)' }}
                   onMouseLeave={e => { (e.currentTarget as HTMLElement).style.background = 'none' }}
                 >
@@ -545,31 +624,29 @@ export function SiteEditorClient({ initialPages }: { initialPages: SitePage[] })
                 </button>
               </div>
 
-              {/* Page list */}
               <div style={{ flex: 1, overflowY: 'auto', padding: '0.25rem 0.5rem' }}>
-                {/* SITE MENU */}
-                <p style={{ margin: '0.5rem 0 0.3rem 0.75rem', fontFamily: mono, fontSize: '0.58rem', letterSpacing: '0.12em', color: '#4a4a4a', textTransform: 'uppercase' }}>Site Menu</p>
-                {inMenu.length > 0
-                  ? inMenu.map(p => (
-                      <PageRow key={String(p.id)} page={p} onDelete={deletePage} onToggleNav={toggleNav} onRefresh={reload} />
-                    ))
-                  : <p style={{ margin: '0 0 0.5rem 0.75rem', fontFamily: mono, fontSize: '0.72rem', color: '#3a3a3a' }}>No pages in menu</p>
-                }
 
-                {/* NOT IN MENU */}
-                {notInMenu.length > 0 && (
+                {/* SITE MENU - hardcoded real pages */}
+                <p style={{ margin: '0.5rem 0 0.3rem 0.75rem', fontFamily: mono, fontSize: '0.58rem', letterSpacing: '0.12em', color: '#4a4a4a', textTransform: 'uppercase' }}>Site Menu</p>
+                {SITE_NAV.map(item => (
+                  <NavPageRow
+                    key={item.key}
+                    item={item}
+                    selectedKey={selectedKey}
+                    onSelect={handleSelect}
+                    expanded={item.key === 'portfolio' ? portfolioExpanded : false}
+                    onToggleExpand={() => { if (item.key === 'portfolio') setPortfolioExpanded(x => !x) }}
+                  />
+                ))}
+
+                {/* NOT IN MENU - custom Puck builder pages */}
+                {customPages.length > 0 && (
                   <>
-                    <p style={{ margin: '1rem 0 0.3rem 0.75rem', fontFamily: mono, fontSize: '0.58rem', letterSpacing: '0.12em', color: '#4a4a4a', textTransform: 'uppercase' }}>Not in Menu</p>
-                    {notInMenu.map(p => (
-                      <PageRow key={String(p.id)} page={p} onDelete={deletePage} onToggleNav={toggleNav} onRefresh={reload} />
+                    <p style={{ margin: '1.25rem 0 0.3rem 0.75rem', fontFamily: mono, fontSize: '0.58rem', letterSpacing: '0.12em', color: '#4a4a4a', textTransform: 'uppercase' }}>Not in Menu</p>
+                    {customPages.map(p => (
+                      <PuckPageRow key={String(p.id)} page={p} onDelete={deletePage} onToggleNav={toggleNav} onRefresh={reload} />
                     ))}
                   </>
-                )}
-
-                {pages.length === 0 && (
-                  <p style={{ fontFamily: mono, fontSize: '0.75rem', color: '#3a3a3a', padding: '0.5rem 0.75rem' }}>
-                    No pages yet. Click &quot;Add Page&quot; to create one.
-                  </p>
                 )}
               </div>
             </>
@@ -594,37 +671,34 @@ export function SiteEditorClient({ initialPages }: { initialPages: SitePage[] })
           {/* Blog tab */}
           {activeTab === 'blog' && (
             <div style={{ flex: 1, padding: '1.25rem 1rem', display: 'flex', flexDirection: 'column', gap: '0.5rem' }}>
-              <p style={{ margin: '0 0 0.75rem', fontFamily: ui, fontSize: '0.88rem', fontWeight: 600, color: '#d4d0cc' }}>Blog</p>
+              <p style={{ margin: '0 0 0.75rem', fontFamily: ui, fontSize: '0.9rem', fontWeight: 600, color: '#e0dcd8' }}>Blog</p>
               {/* eslint-disable-next-line @next/next/no-html-link-for-pages */}
-              <a href="/admin/collections/posts" style={{ display: 'block', padding: '0.55rem 0.75rem', background: 'rgba(255,255,255,0.03)', border: '1px solid rgba(255,255,255,0.07)', borderRadius: 7, color: '#c4bfb9', textDecoration: 'none', fontFamily: ui, fontSize: '0.83rem' }}
-                onMouseEnter={e => { (e.currentTarget as HTMLElement).style.background = 'rgba(255,255,255,0.06)' }}
-                onMouseLeave={e => { (e.currentTarget as HTMLElement).style.background = 'rgba(255,255,255,0.03)' }}
-              >
-                All Posts
-              </a>
-              {/* eslint-disable-next-line @next/next/no-html-link-for-pages */}
-              <a href="/admin/collections/posts/create" style={{ display: 'block', padding: '0.55rem 0.75rem', background: 'rgba(255,255,255,0.03)', border: '1px solid rgba(255,255,255,0.07)', borderRadius: 7, color: '#c4bfb9', textDecoration: 'none', fontFamily: ui, fontSize: '0.83rem' }}
-                onMouseEnter={e => { (e.currentTarget as HTMLElement).style.background = 'rgba(255,255,255,0.06)' }}
-                onMouseLeave={e => { (e.currentTarget as HTMLElement).style.background = 'rgba(255,255,255,0.03)' }}
-              >
-                New Post
-              </a>
+              {[
+                { label: 'All Posts',  href: '/admin/collections/posts'        },
+                { label: 'New Post',   href: '/admin/collections/posts/create' },
+              ].map(item => (
+                <a key={item.href} href={item.href}
+                  style={{ display: 'block', padding: '0.55rem 0.75rem', background: 'rgba(255,255,255,0.03)', border: '1px solid rgba(255,255,255,0.07)', borderRadius: 7, color: '#c4bfb9', textDecoration: 'none', fontFamily: ui, fontSize: '0.83rem' }}
+                  onMouseEnter={e => { (e.currentTarget as HTMLElement).style.background = 'rgba(255,255,255,0.06)' }}
+                  onMouseLeave={e => { (e.currentTarget as HTMLElement).style.background = 'rgba(255,255,255,0.03)' }}
+                >
+                  {item.label}
+                </a>
+              ))}
             </div>
           )}
 
           {/* Settings tab */}
           {activeTab === 'settings' && (
             <div style={{ flex: 1, padding: '1.25rem 1rem', display: 'flex', flexDirection: 'column', gap: '0.5rem' }}>
-              <p style={{ margin: '0 0 0.75rem', fontFamily: ui, fontSize: '0.88rem', fontWeight: 600, color: '#d4d0cc' }}>Settings</p>
+              <p style={{ margin: '0 0 0.75rem', fontFamily: ui, fontSize: '0.9rem', fontWeight: 600, color: '#e0dcd8' }}>Settings</p>
               {/* eslint-disable @next/next/no-html-link-for-pages */}
               {[
                 { label: 'Site Config', href: '/admin/globals/site-config' },
-                { label: 'Hero Slides', href: '/admin/globals/hero-slides' },
-                { label: 'About Page', href: '/admin/globals/about-page' },
+                { label: 'Hero Slides', href: '/admin/globals/hero-slides'  },
+                { label: 'About Page',  href: '/admin/globals/about-page'   },
               ].map(item => (
-                <a
-                  key={item.href}
-                  href={item.href}
+                <a key={item.href} href={item.href}
                   style={{ display: 'block', padding: '0.55rem 0.75rem', background: 'rgba(255,255,255,0.03)', border: '1px solid rgba(255,255,255,0.07)', borderRadius: 7, color: '#c4bfb9', textDecoration: 'none', fontFamily: ui, fontSize: '0.83rem' }}
                   onMouseEnter={e => { (e.currentTarget as HTMLElement).style.background = 'rgba(255,255,255,0.06)' }}
                   onMouseLeave={e => { (e.currentTarget as HTMLElement).style.background = 'rgba(255,255,255,0.03)' }}
@@ -649,9 +723,8 @@ export function SiteEditorClient({ initialPages }: { initialPages: SitePage[] })
             <button
               type="button"
               onClick={() => void publishAll()}
-              disabled={publishing}
-              aria-busy={publishing}
-              style={{ flex: 1, padding: '0.6rem', background: teal, border: 'none', borderRadius: 7, color: '#fff', fontSize: '0.82rem', fontFamily: ui, fontWeight: 600, cursor: publishing ? 'wait' : 'pointer', opacity: publishing ? 0.7 : 1, transition: 'opacity 0.12s, filter 0.12s' }}
+              disabled={publishing} aria-busy={publishing}
+              style={{ flex: 1, padding: '0.6rem', background: teal, border: 'none', borderRadius: 7, color: '#fff', fontSize: '0.82rem', fontFamily: ui, fontWeight: 600, cursor: publishing ? 'wait' : 'pointer', opacity: publishing ? 0.7 : 1, transition: 'opacity 0.12s' }}
               onMouseEnter={e => { if (!publishing) (e.currentTarget as HTMLElement).style.filter = 'brightness(1.1)' }}
               onMouseLeave={e => { (e.currentTarget as HTMLElement).style.filter = 'none' }}
             >
@@ -660,12 +733,29 @@ export function SiteEditorClient({ initialPages }: { initialPages: SitePage[] })
           </div>
         </div>
 
-        {/* ---- Right: website preview ---- */}
-        <div style={{ flex: 1, background: '#0e0e0e', display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', position: 'relative' }}>
+        {/* ---- Right: live page preview ---- */}
+        <div style={{ flex: 1, background: '#0e0e0e', position: 'relative', overflow: 'hidden' }}>
+          {/* Address bar */}
+          <div style={{ position: 'absolute', top: 0, left: 0, right: 0, height: 36, display: 'flex', alignItems: 'center', justifyContent: 'space-between', padding: '0 1rem', background: '#0a0a0a', borderBottom: '1px solid rgba(255,255,255,0.06)', zIndex: 10 }}>
+            <span style={{ fontFamily: mono, fontSize: '0.72rem', color: '#4a4a4a', letterSpacing: '0.02em' }}>
+              {previewLabel}
+            </span>
+            <a
+              href={previewHref} target="_blank" rel="noopener noreferrer"
+              style={{ display: 'flex', alignItems: 'center', gap: '0.25rem', color: '#4a4a4a', fontSize: '0.72rem', fontFamily: ui, textDecoration: 'none', padding: '0.2rem 0.5rem', borderRadius: 4, background: 'rgba(255,255,255,0.04)' }}
+              onMouseEnter={e => { (e.currentTarget as HTMLElement).style.color = '#9b9a9a' }}
+              onMouseLeave={e => { (e.currentTarget as HTMLElement).style.color = '#4a4a4a' }}
+            >
+              <IconExternal /> Open
+            </a>
+          </div>
+
+          {/* Live preview iframe - key changes force a reload when page changes */}
           <iframe
-            src="/"
-            style={{ width: '100%', height: '100%', border: 'none' }}
-            title="Website preview"
+            key={previewHref}
+            src={previewHref}
+            style={{ position: 'absolute', top: 36, left: 0, right: 0, bottom: 0, width: '100%', height: 'calc(100% - 36px)', border: 'none' }}
+            title={`Preview: ${previewLabel}`}
           />
         </div>
       </div>

--- a/app/components/AboutPreview/AboutPreview.module.css
+++ b/app/components/AboutPreview/AboutPreview.module.css
@@ -40,18 +40,28 @@
 
 .eyebrow {
   font-family: var(--font-body);
-  font-size: 0.75rem;
-  letter-spacing: 0.2em;
+  font-size: 0.7rem;
+  letter-spacing: 0.28em;
   text-transform: uppercase;
   color: var(--color-detail);
 }
 
-.heading {
+.greeting {
   font-family: var(--font-display);
-  font-size: clamp(2.5rem, 4vw, 4rem);
-  font-weight: 700;
+  font-size: clamp(3rem, 5vw, 5rem);
+  font-weight: 400;
   color: var(--color-heading);
-  line-height: 1.15;
+  line-height: 1;
+  margin: -0.25rem 0 0;
+}
+
+.heading {
+  font-family: var(--font-display-bold);
+  font-size: clamp(1.6rem, 2.4vw, 2.4rem);
+  font-weight: 400;
+  color: var(--color-body);
+  line-height: 1.25;
+  margin-top: 0.25rem;
 }
 
 .body {

--- a/app/components/AboutPreview/AboutPreview.tsx
+++ b/app/components/AboutPreview/AboutPreview.tsx
@@ -30,13 +30,14 @@ export default function AboutPreview({ about }: Props) {
         )}
       </div>
       <div className={styles.content}>
-        <p className={styles.eyebrow}>About Tynnell</p>
+        <p className={styles.eyebrow}>About</p>
+        <p className={styles.greeting}>{"Hey, I'm Tynnell Hollins"}</p>
         <h2 className={styles.heading}>{about?.tagline ?? 'Every Moment Deserves to Last Forever'}</h2>
         <p className={styles.body}>
           {about?.previewBio ??
-            'Based in New Mexico, Tynnell Hollins is a photographer who believes the best images are the ones that feel like a memory. Warm, honest, and full of life. From weddings to family portraits, she brings the same quiet attention to every shoot.'}
+            'Based in New Mexico, I believe the best images are the ones that feel like a memory. Warm, honest, and full of life. From weddings to family portraits, I bring the same quiet attention to every session.'}
         </p>
-        <Link href="/about" className={styles.cta}>Meet Tynnell</Link>
+        <Link href="/about" className={styles.cta}>My Story</Link>
       </div>
     </section>
   )

--- a/app/components/Contact/Contact.module.css
+++ b/app/components/Contact/Contact.module.css
@@ -1,40 +1,40 @@
 .section {
-  background-color: var(--color-bg);
-  padding: var(--padding-block) var(--padding-x);
+  background-color: #0C0C0C;
+  padding: 8rem var(--padding-x);
+  text-align: center;
 }
 
 .inner {
-  max-width: 640px;
+  max-width: 700px;
   margin: 0 auto;
-  text-align: center;
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 1.5rem;
+  gap: 1.75rem;
 }
 
 .eyebrow {
   font-family: var(--font-body);
   font-size: 0.7rem;
-  letter-spacing: 0.25em;
+  letter-spacing: 0.3em;
   text-transform: uppercase;
-  color: var(--color-detail);
+  color: rgba(214, 209, 206, 0.45);
 }
 
 .heading {
   font-family: var(--font-display);
-  font-size: clamp(2.5rem, 5vw, 4rem);
-  color: var(--color-heading);
+  font-size: clamp(3.5rem, 7vw, 6.5rem);
+  color: #D6D1CE;
   font-weight: 400;
-  line-height: 1.15;
+  line-height: 1.05;
 }
 
 .body {
   font-family: var(--font-prose);
-  font-size: 0.9375rem;
-  line-height: 1.75;
-  color: var(--color-body);
-  max-width: 420px;
+  font-size: 0.875rem;
+  line-height: 1.8;
+  color: rgba(214, 209, 206, 0.6);
+  max-width: 400px;
 }
 
 .actions {
@@ -46,10 +46,11 @@
 }
 
 .btn {
-  display: inline-block;
+  display: inline-flex;
+  align-items: center;
   padding: 0.9rem 2.5rem;
-  background-color: var(--color-btn-bg);
-  color: var(--color-btn-text);
+  background-color: #9B9A9A;
+  color: #0C0C0C;
   font-family: var(--font-body);
   font-size: 0.7rem;
   letter-spacing: 0.18em;
@@ -57,12 +58,10 @@
   text-decoration: none;
   transition: background-color 0.2s ease;
   min-height: 44px;
-  display: flex;
-  align-items: center;
 }
 
 .btn:hover {
-  background-color: var(--color-btn-hover);
+  background-color: #D6D1CE;
 }
 
 .btnSecondary {
@@ -70,8 +69,8 @@
   align-items: center;
   padding: 0.9rem 2.5rem;
   background: transparent;
-  color: var(--color-detail);
-  border: 1px solid rgba(155, 154, 154, 0.3);
+  color: rgba(214, 209, 206, 0.55);
+  border: 1px solid rgba(214, 209, 206, 0.18);
   font-family: var(--font-body);
   font-size: 0.7rem;
   letter-spacing: 0.18em;
@@ -82,6 +81,6 @@
 }
 
 .btnSecondary:hover {
-  color: var(--color-heading);
-  border-color: var(--color-detail);
+  color: #D6D1CE;
+  border-color: rgba(214, 209, 206, 0.4);
 }

--- a/app/components/Footer/Footer.module.css
+++ b/app/components/Footer/Footer.module.css
@@ -1,121 +1,172 @@
 .footer {
-  background: var(--color-bg-accent);
-  border-top: 1px solid rgba(214, 209, 206, 0.08);
-  padding: 4rem var(--padding-x) 2.5rem;
+  background: var(--color-bg);
+  border-top: 1px solid var(--color-border);
   margin-top: auto;
 }
 
-.inner {
-  max-width: 1200px;
-  margin: 0 auto;
-}
+/* ── CTA row ─────────────────────────────────────────────── */
 
-.top {
-  display: grid;
-  grid-template-columns: 1fr auto;
-  gap: 3rem;
-  align-items: start;
-  padding-bottom: 3rem;
-  border-bottom: 1px solid rgba(214, 209, 206, 0.08);
-}
-
-/* Brand */
-.brand {
+.cta {
+  padding: 4rem var(--padding-x);
   display: flex;
-  flex-direction: column;
-  gap: 0.4rem;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 3rem;
+  border-bottom: 1px solid var(--color-border);
 }
 
-.brandName {
-  font-family: var(--font-display);
-  font-size: 2rem;
-  font-weight: 400;
+.ctaText {
+  font-family: var(--font-body);
+  font-size: 0.78rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--color-body);
+  line-height: 2;
+  max-width: 520px;
+}
+
+.ctaLink {
+  font-family: var(--font-body);
+  font-size: 0.7rem;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
   color: var(--color-heading);
-  line-height: 1.1;
+  text-decoration: none;
+  white-space: nowrap;
+  flex-shrink: 0;
+  position: relative;
+  padding-bottom: 0.5rem;
+  transition: color 0.2s ease;
 }
 
-.brandSub {
-  font-family: var(--font-body);
-  font-size: 0.68rem;
-  letter-spacing: 0.15em;
-  text-transform: uppercase;
+.ctaLink::after {
+  content: '';
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  height: 1px;
+  background: currentColor;
+}
+
+.ctaLink:hover {
   color: var(--color-detail);
 }
 
-/* Nav links */
-.nav {
-  display: grid;
-  grid-template-columns: repeat(2, auto);
-  gap: 0.5rem 3rem;
-  list-style: none;
-  text-align: right;
+/* ── Instagram strip ─────────────────────────────────────── */
+
+.instagram {
+  padding: 2.5rem var(--padding-x);
+  border-bottom: 1px solid var(--color-border);
+  display: flex;
+  align-items: center;
+  gap: 3rem;
 }
 
-.navLink {
+.igInfo {
+  flex-shrink: 0;
+}
+
+.igLabel {
   font-family: var(--font-body);
-  font-size: 0.72rem;
-  letter-spacing: 0.1em;
+  font-size: 0.6rem;
+  letter-spacing: 0.2em;
   text-transform: uppercase;
   color: var(--color-detail);
+  margin-bottom: 0.5rem;
+}
+
+.igHandle {
+  font-family: var(--font-heading);
+  font-size: 0.95rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  color: var(--color-heading);
   text-decoration: none;
   transition: color 0.2s ease;
 }
 
-.navLink:hover {
-  color: var(--color-heading);
+.igHandle:hover {
+  color: var(--color-detail);
 }
 
-/* Bottom bar */
+.igPhotos {
+  display: flex;
+  gap: 0.5rem;
+  flex: 1;
+  max-width: 560px;
+}
+
+.igPhoto {
+  flex: 1;
+  aspect-ratio: 1;
+  position: relative;
+  overflow: hidden;
+  max-width: 130px;
+}
+
+.igPhotoImg {
+  object-fit: cover;
+  transition: transform 0.4s ease;
+}
+
+.igPhoto:hover .igPhotoImg {
+  transform: scale(1.04);
+}
+
+/* ── Bottom bar ──────────────────────────────────────────── */
+
 .bottom {
+  padding: 1.5rem var(--padding-x);
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding-top: 2rem;
-  gap: 2rem;
-  flex-wrap: wrap;
+  gap: 1.5rem;
 }
 
-.contact {
+.socials {
   display: flex;
   align-items: center;
-  gap: 2rem;
+  gap: 1.25rem;
 }
 
-.contactLink {
-  font-family: var(--font-body);
-  font-size: 0.7rem;
-  letter-spacing: 0.08em;
+.socialLink {
   color: var(--color-detail);
-  text-decoration: none;
-  transition: color 0.2s ease;
   display: flex;
   align-items: center;
-  gap: 0.5rem;
+  transition: color 0.2s ease;
 }
 
-.contactLink:hover {
+.socialLink:hover {
   color: var(--color-heading);
 }
 
 .copy {
   font-family: var(--font-body);
-  font-size: 0.65rem;
-  letter-spacing: 0.08em;
-  color: rgba(155, 154, 154, 0.5);
+  font-size: 0.62rem;
+  letter-spacing: 0.1em;
+  color: var(--color-detail);
+  opacity: 0.5;
 }
 
-/* Responsive */
-@media (max-width: 640px) {
-  .top {
-    grid-template-columns: 1fr;
-    gap: 2rem;
-    padding-bottom: 2rem;
+/* ── Responsive ──────────────────────────────────────────── */
+
+@media (max-width: 768px) {
+  .cta {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 1.5rem;
+    padding: 3rem var(--padding-x);
   }
 
-  .nav {
-    grid-template-columns: repeat(3, auto);
-    text-align: left;
-    gap: 0.5rem 1.5rem;
+  .instagram {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 1.5rem;
+  }
+
+  .igPhotos {
+    max-width: 100%;
   }
 
   .bottom {

--- a/app/components/Footer/Footer.tsx
+++ b/app/components/Footer/Footer.tsx
@@ -1,56 +1,108 @@
 import Link from 'next/link'
-import { navLinks } from '@/app/constants/nav'
+import Image from 'next/image'
+import { getPayload } from 'payload'
+import config from '@payload-config'
 import { CONTACT_EMAIL } from '@/app/lib/constants'
 import styles from './Footer.module.css'
 
 const INSTAGRAM_URL = 'https://instagram.com/tynnellhollinsphotography'
-const INSTAGRAM_HANDLE = '@tynnellhollinsphotography'
+const TIKTOK_URL = 'https://tiktok.com/@tynnellhollinsphotography'
 
-export default function Footer() {
+export default async function Footer() {
   const year = new Date().getFullYear()
+
+  const payload = await getPayload({ config })
+  const { docs: stripPhotos } = await payload.find({
+    collection: 'photos',
+    where: { featured: { equals: true } },
+    sort: '-updatedAt',
+    limit: 4,
+    depth: 0,
+  })
 
   return (
     <footer className={styles.footer}>
-      <div className={styles.inner}>
-        <div className={styles.top}>
-          <div className={styles.brand}>
-            <span className={styles.brandName}>Tynnell Hollins Photography</span>
-            <span className={styles.brandSub}>Albuquerque, New Mexico</span>
-          </div>
-          <ul className={styles.nav} aria-label="Footer navigation">
-            {navLinks.filter(l => l.href !== '/').map(link => (
-              <li key={link.href}>
-                <Link href={link.href} className={styles.navLink}>{link.label}</Link>
-              </li>
-            ))}
-          </ul>
-        </div>
+      {/* CTA row */}
+      <div className={styles.cta}>
+        <p className={styles.ctaText}>
+          Send me a message, and I&apos;ll set up a free discovery call to start planning your dream session.
+        </p>
+        <Link href="/contact" className={styles.ctaLink}>
+          Let&apos;s connect
+        </Link>
+      </div>
 
-        <div className={styles.bottom}>
-          <div className={styles.contact}>
-            <a
-              href={INSTAGRAM_URL}
-              target="_blank"
-              rel="noopener noreferrer"
-              className={styles.contactLink}
-              aria-label="Tynnell Hollins Photography on Instagram"
-            >
-              <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
-                <path d="M12 2.163c3.204 0 3.584.012 4.85.07 3.252.148 4.771 1.691 4.919 4.919.058 1.265.069 1.645.069 4.849 0 3.205-.012 3.584-.069 4.849-.149 3.225-1.664 4.771-4.919 4.919-1.266.058-1.644.07-4.85.07-3.204 0-3.584-.012-4.849-.07-3.26-.149-4.771-1.699-4.919-4.92-.058-1.265-.07-1.644-.07-4.849 0-3.204.013-3.583.07-4.849.149-3.227 1.664-4.771 4.919-4.919 1.266-.057 1.645-.069 4.849-.069zm0-2.163c-3.259 0-3.667.014-4.947.072-4.358.2-6.78 2.618-6.98 6.98-.059 1.281-.073 1.689-.073 4.948 0 3.259.014 3.668.072 4.948.2 4.358 2.618 6.78 6.98 6.98 1.281.058 1.689.072 4.948.072 3.259 0 3.668-.014 4.948-.072 4.354-.2 6.782-2.618 6.979-6.98.059-1.28.073-1.689.073-4.948 0-3.259-.014-3.667-.072-4.947-.196-4.354-2.617-6.78-6.979-6.98-1.281-.059-1.69-.073-4.949-.073zm0 5.838c-3.403 0-6.162 2.759-6.162 6.162s2.759 6.163 6.162 6.163 6.162-2.759 6.162-6.163c0-3.403-2.759-6.162-6.162-6.162zm0 10.162c-2.209 0-4-1.79-4-4 0-2.209 1.791-4 4-4s4 1.791 4 4c0 2.21-1.791 4-4 4zm6.406-11.845c-.796 0-1.441.645-1.441 1.44s.645 1.44 1.441 1.44c.795 0 1.439-.645 1.439-1.44s-.644-1.44-1.439-1.44z"/>
-              </svg>
-              {INSTAGRAM_HANDLE}
-            </a>
-            <a href={`mailto:${CONTACT_EMAIL}`} className={styles.contactLink}>
-              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" aria-hidden="true">
-                <path strokeLinecap="round" strokeLinejoin="round" d="M21.75 6.75v10.5a2.25 2.25 0 0 1-2.25 2.25h-15a2.25 2.25 0 0 1-2.25-2.25V6.75m19.5 0A2.25 2.25 0 0 0 19.5 4.5h-15a2.25 2.25 0 0 0-2.25 2.25m19.5 0v.243a2.25 2.25 0 0 1-1.07 1.916l-7.5 4.615a2.25 2.25 0 0 1-2.36 0L3.32 8.91a2.25 2.25 0 0 1-1.07-1.916V6.75" />
-              </svg>
-              {CONTACT_EMAIL}
-            </a>
-          </div>
-          <p className={styles.copy}>
-            &copy; {year} Tynnell Hollins Photography. All rights reserved.
-          </p>
+      {/* Instagram strip */}
+      <div className={styles.instagram}>
+        <div className={styles.igInfo}>
+          <p className={styles.igLabel}>Follow me on Instagram</p>
+          <a
+            href={INSTAGRAM_URL}
+            target="_blank"
+            rel="noopener noreferrer"
+            className={styles.igHandle}
+            aria-label="Tynnell Hollins Photography on Instagram"
+          >
+            @tynnellhollinsphotography
+          </a>
         </div>
+        {stripPhotos.length > 0 && (
+          <div className={styles.igPhotos} aria-hidden="true">
+            {stripPhotos.map(photo => {
+              const src = photo.sizes?.card?.url ?? photo.url
+              if (!src) return null
+              return (
+                <div key={photo.id} className={styles.igPhoto}>
+                  <Image
+                    src={src}
+                    alt=""
+                    fill
+                    sizes="120px"
+                    className={styles.igPhotoImg}
+                  />
+                </div>
+              )
+            })}
+          </div>
+        )}
+      </div>
+
+      {/* Bottom bar */}
+      <div className={styles.bottom}>
+        <div className={styles.socials}>
+          <a
+            href={INSTAGRAM_URL}
+            target="_blank"
+            rel="noopener noreferrer"
+            className={styles.socialLink}
+            aria-label="Instagram"
+          >
+            <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+              <path d="M12 2.163c3.204 0 3.584.012 4.85.07 3.252.148 4.771 1.691 4.919 4.919.058 1.265.069 1.645.069 4.849 0 3.205-.012 3.584-.069 4.849-.149 3.225-1.664 4.771-4.919 4.919-1.266.058-1.644.07-4.85.07-3.204 0-3.584-.012-4.849-.07-3.26-.149-4.771-1.699-4.919-4.92-.058-1.265-.07-1.644-.07-4.849 0-3.204.013-3.583.07-4.849.149-3.227 1.664-4.771 4.919-4.919 1.266-.057 1.645-.069 4.849-.069zm0-2.163c-3.259 0-3.667.014-4.947.072-4.358.2-6.78 2.618-6.98 6.98-.059 1.281-.073 1.689-.073 4.948 0 3.259.014 3.668.072 4.948.2 4.358 2.618 6.78 6.98 6.98 1.281.058 1.689.072 4.948.072 3.259 0 3.668-.014 4.948-.072 4.354-.2 6.782-2.618 6.979-6.98.059-1.28.073-1.689.073-4.948 0-3.259-.014-3.667-.072-4.947-.196-4.354-2.617-6.78-6.979-6.98-1.281-.059-1.69-.073-4.949-.073zm0 5.838c-3.403 0-6.162 2.759-6.162 6.162s2.759 6.163 6.162 6.163 6.162-2.759 6.162-6.163c0-3.403-2.759-6.162-6.162-6.162zm0 10.162c-2.209 0-4-1.79-4-4 0-2.209 1.791-4 4-4s4 1.791 4 4c0 2.21-1.791 4-4 4zm6.406-11.845c-.796 0-1.441.645-1.441 1.44s.645 1.44 1.441 1.44c.795 0 1.439-.645 1.439-1.44s-.644-1.44-1.439-1.44z" />
+            </svg>
+          </a>
+          <a
+            href={TIKTOK_URL}
+            target="_blank"
+            rel="noopener noreferrer"
+            className={styles.socialLink}
+            aria-label="TikTok"
+          >
+            <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+              <path d="M19.59 6.69a4.83 4.83 0 0 1-3.77-4.25V2h-3.45v13.67a2.89 2.89 0 0 1-2.88 2.5 2.89 2.89 0 0 1-2.89-2.89 2.89 2.89 0 0 1 2.89-2.89c.28 0 .54.04.79.1V9.01a6.33 6.33 0 0 0-.79-.05 6.34 6.34 0 0 0-6.34 6.34 6.34 6.34 0 0 0 6.34 6.34 6.34 6.34 0 0 0 6.33-6.34V8.69a8.22 8.22 0 0 0 4.82 1.55V6.79a4.85 4.85 0 0 1-1.05-.1z" />
+            </svg>
+          </a>
+          <a
+            href={`mailto:${CONTACT_EMAIL}`}
+            className={styles.socialLink}
+            aria-label={`Email ${CONTACT_EMAIL}`}
+          >
+            <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" aria-hidden="true">
+              <path strokeLinecap="round" strokeLinejoin="round" d="M21.75 6.75v10.5a2.25 2.25 0 0 1-2.25 2.25h-15a2.25 2.25 0 0 1-2.25-2.25V6.75m19.5 0A2.25 2.25 0 0 0 19.5 4.5h-15a2.25 2.25 0 0 0-2.25 2.25m19.5 0v.243a2.25 2.25 0 0 1-1.07 1.916l-7.5 4.615a2.25 2.25 0 0 1-2.36 0L3.32 8.91a2.25 2.25 0 0 1-1.07-1.916V6.75" />
+            </svg>
+          </a>
+        </div>
+        <p className={styles.copy}>&copy; {year} Tynnell Hollins Photography</p>
       </div>
     </footer>
   )

--- a/app/components/Hero/Hero.module.css
+++ b/app/components/Hero/Hero.module.css
@@ -51,7 +51,7 @@
   font-family: var(--font-display);
   font-size: clamp(3rem, 8vw, 7rem);
   font-weight: 700;
-  color: var(--color-heading);
+  color: rgba(255, 255, 255, 0.95);
   text-shadow: 0 2px 20px rgba(0, 0, 0, 0.5);
   line-height: 1.1;
 }

--- a/app/components/MobileMenu/MobileMenu.module.css
+++ b/app/components/MobileMenu/MobileMenu.module.css
@@ -9,9 +9,7 @@
   opacity: 0;
   pointer-events: none;
   transform: translateY(-8px);
-  transition:
-    opacity 0.3s ease,
-    transform 0.3s ease;
+  transition: opacity 0.3s ease, transform 0.3s ease;
 }
 
 .overlay.open {
@@ -27,27 +25,82 @@
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 2.5rem;
+  gap: 2rem;
 }
 
 .item {
-  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
 }
 
 .link {
   font-family: var(--font-heading);
-  font-size: 1.5rem;
-  font-weight: 400;
+  font-size: 1.4rem;
+  font-weight: 700;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
   color: var(--color-heading);
   text-decoration: none;
-  letter-spacing: 0.2em;
-  text-transform: uppercase;
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 0;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.6rem;
   transition: color 0.2s ease;
-  display: block;
 }
 
 .link:hover,
 .link:focus-visible {
   color: var(--color-detail);
+  outline: none;
+}
+
+/* Expand button (Portfolio with children) */
+.expandBtn {
+  font-family: var(--font-heading);
+}
+
+.chevron {
+  display: inline-block;
+  width: 0;
+  height: 0;
+  border-left: 5px solid transparent;
+  border-right: 5px solid transparent;
+  border-top: 6px solid currentColor;
+  transition: transform 0.2s ease;
+  margin-top: 2px;
+}
+
+.chevronOpen {
+  transform: rotate(180deg);
+}
+
+/* Sub-items */
+.subLinks {
+  list-style: none;
+  margin: 0.75rem 0 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.subLink {
+  font-family: var(--font-body);
+  font-size: 0.72rem;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  color: var(--color-detail);
+  text-decoration: none;
+  transition: color 0.2s ease;
+}
+
+.subLink:hover,
+.subLink:focus-visible {
+  color: var(--color-heading);
   outline: none;
 }

--- a/app/components/MobileMenu/MobileMenu.tsx
+++ b/app/components/MobileMenu/MobileMenu.tsx
@@ -1,5 +1,5 @@
 'use client'
-import { useEffect, useRef } from 'react'
+import { useState, useEffect, useRef } from 'react'
 import Link from 'next/link'
 import { usePathname } from 'next/navigation'
 import { navLinks, type NavLink } from '@/app/constants/nav'
@@ -15,61 +15,46 @@ export default function MobileMenu({ isOpen, onClose, links = navLinks }: Mobile
   const menuRef = useRef<HTMLDivElement>(null)
   const previousFocusRef = useRef<HTMLElement | null>(null)
   const pathname = usePathname()
+  const [expandedItem, setExpandedItem] = useState<string | null>(null)
 
   useEffect(() => {
     if (isOpen) {
-      // Remember what had focus before the menu opened so we can restore it on close
       previousFocusRef.current = document.activeElement as HTMLElement
-      // Focus first focusable element on open
       const focusable = menuRef.current?.querySelectorAll<HTMLElement>(
         'a, button, [tabindex]:not([tabindex="-1"])'
       )
       if (focusable?.length) focusable[0].focus()
     } else {
-      // Return focus to the element that opened the menu
       previousFocusRef.current?.focus()
+      setExpandedItem(null)
     }
   }, [isOpen])
 
   useEffect(() => {
     if (!isOpen) return
-
     const handleKeyDown = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') {
-        onClose()
-        return
-      }
-
-      // Focus trap
+      if (e.key === 'Escape') { onClose(); return }
       if (e.key === 'Tab' && menuRef.current) {
         const focusableEls = Array.from(
           menuRef.current.querySelectorAll<HTMLElement>(
             'a, button, [tabindex]:not([tabindex="-1"])'
           )
-        ).filter((el) => !el.hasAttribute('disabled'))
-
+        ).filter(el => !el.hasAttribute('disabled'))
         if (!focusableEls.length) return
-
         const first = focusableEls[0]
         const last = focusableEls[focusableEls.length - 1]
-
         if (e.shiftKey) {
-          if (document.activeElement === first) {
-            e.preventDefault()
-            last.focus()
-          }
+          if (document.activeElement === first) { e.preventDefault(); last.focus() }
         } else {
-          if (document.activeElement === last) {
-            e.preventDefault()
-            first.focus()
-          }
+          if (document.activeElement === last) { e.preventDefault(); first.focus() }
         }
       }
     }
-
     document.addEventListener('keydown', handleKeyDown)
     return () => document.removeEventListener('keydown', handleKeyDown)
   }, [isOpen, onClose])
+
+  useEffect(() => { onClose() }, [pathname, onClose])
 
   return (
     <div
@@ -83,17 +68,51 @@ export default function MobileMenu({ isOpen, onClose, links = navLinks }: Mobile
     >
       <nav aria-label="Mobile navigation">
         <ul className={styles.links}>
-          {links.map((link) => (
+          {links.map(link => (
             <li key={link.href} className={styles.item}>
-              <Link
-                href={link.href}
-                className={styles.link}
-                onClick={onClose}
-                tabIndex={isOpen ? 0 : -1}
-                aria-current={pathname === link.href ? 'page' : undefined}
-              >
-                {link.label}
-              </Link>
+              {link.children ? (
+                <>
+                  <button
+                    className={`${styles.link} ${styles.expandBtn}`}
+                    onClick={() => setExpandedItem(expandedItem === link.href ? null : link.href)}
+                    aria-expanded={expandedItem === link.href}
+                    tabIndex={isOpen ? 0 : -1}
+                  >
+                    {link.label}
+                    <span
+                      className={`${styles.chevron} ${expandedItem === link.href ? styles.chevronOpen : ''}`}
+                      aria-hidden="true"
+                    />
+                  </button>
+                  {expandedItem === link.href && (
+                    <ul className={styles.subLinks}>
+                      {link.children.map(child => (
+                        <li key={child.href}>
+                          <Link
+                            href={child.href}
+                            className={styles.subLink}
+                            onClick={onClose}
+                            tabIndex={isOpen ? 0 : -1}
+                            aria-current={pathname === child.href ? 'page' : undefined}
+                          >
+                            {child.label}
+                          </Link>
+                        </li>
+                      ))}
+                    </ul>
+                  )}
+                </>
+              ) : (
+                <Link
+                  href={link.href}
+                  className={styles.link}
+                  onClick={onClose}
+                  tabIndex={isOpen ? 0 : -1}
+                  aria-current={pathname === link.href ? 'page' : undefined}
+                >
+                  {link.label}
+                </Link>
+              )}
             </li>
           ))}
         </ul>

--- a/app/components/Navbar/Navbar.module.css
+++ b/app/components/Navbar/Navbar.module.css
@@ -5,65 +5,173 @@
   right: 0;
   z-index: 100;
   display: flex;
-  align-items: center;
+  align-items: flex-start;
   justify-content: space-between;
   padding: 1.5rem var(--padding-x);
   background: transparent;
-  transition: background 0.3s ease;
+  transition: background 0.35s ease, padding 0.3s ease;
 }
 
 .scrolled {
   background: var(--color-bg);
+  padding: 1rem var(--padding-x);
 }
 
-/* Keep navbar visible over the mobile overlay */
 .menuOpen {
   background: var(--color-bg);
 }
 
+/* ── Brand ───────────────────────────────────────────────── */
+
 .brand {
-  font-family: var(--font-heading);
-  font-size: 0.875rem;
-  font-weight: 500;
-  color: var(--color-heading);
-  letter-spacing: 0.02em;
-  text-transform: uppercase;
+  display: flex;
+  flex-direction: column;
   text-decoration: none;
+  line-height: 1.08;
+  flex-shrink: 0;
 }
 
-/* ── Desktop links ───────────────────────────────────────── */
+.brandLine {
+  display: block;
+  font-family: var(--font-heading);
+  font-size: 1rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(255, 255, 255, 0.95);
+  transition: color 0.3s ease;
+}
 
-.links {
+.scrolled .brandLine,
+.menuOpen .brandLine {
+  color: var(--color-heading);
+}
+
+/* ── Desktop link rows ───────────────────────────────────── */
+
+.linksWrapper {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 0.35rem;
+}
+
+.row {
   list-style: none;
   margin: 0;
   padding: 0;
   display: flex;
-  gap: 2rem;
+  align-items: center;
+  gap: 1.75rem;
 }
+
+.row2 {
+  align-self: flex-end;
+}
+
+/* ── Nav links ───────────────────────────────────────────── */
 
 .link {
   font-family: var(--font-body);
-  font-size: 0.75rem;
-  font-weight: 300;
-  color: var(--color-heading);
-  text-decoration: none;
-  letter-spacing: 0.2em;
+  font-size: 0.68rem;
+  font-weight: 400;
+  letter-spacing: 0.18em;
   text-transform: uppercase;
+  color: rgba(255, 255, 255, 0.85);
+  text-decoration: none;
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 0;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
   transition: color 0.2s ease;
+  white-space: nowrap;
 }
 
 .link:hover {
-  color: var(--color-body);
+  color: rgba(255, 255, 255, 1);
 }
 
-/* ── Hamburger button ────────────────────────────────────── */
+.scrolled .link,
+.menuOpen .link {
+  color: var(--color-detail);
+}
+
+.scrolled .link:hover,
+.menuOpen .link:hover {
+  color: var(--color-heading);
+}
+
+/* ── Portfolio dropdown ──────────────────────────────────── */
+
+.hasDropdown {
+  position: relative;
+}
+
+.arrow {
+  display: inline-block;
+  width: 0;
+  height: 0;
+  border-left: 3.5px solid transparent;
+  border-right: 3.5px solid transparent;
+  border-top: 4px solid currentColor;
+  transition: transform 0.2s ease;
+  margin-top: 1px;
+}
+
+.arrowOpen {
+  transform: rotate(180deg);
+}
+
+.dropdown {
+  position: absolute;
+  top: calc(100% + 0.9rem);
+  right: 0;
+  list-style: none;
+  margin: 0;
+  padding: 0.4rem 0;
+  background: var(--color-bg);
+  border: 1px solid var(--color-border);
+  min-width: 148px;
+  z-index: 200;
+  opacity: 0;
+  pointer-events: none;
+  transform: translateY(-4px);
+  transition: opacity 0.18s ease, transform 0.18s ease;
+}
+
+.dropdownOpen {
+  opacity: 1;
+  pointer-events: all;
+  transform: translateY(0);
+}
+
+.dropdownItem {
+  display: block;
+  padding: 0.55rem 1.2rem;
+  font-family: var(--font-body);
+  font-size: 0.65rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--color-detail);
+  text-decoration: none;
+  transition: color 0.15s ease, background 0.15s ease;
+}
+
+.dropdownItem:hover {
+  color: var(--color-heading);
+  background: var(--color-bg-hover);
+}
+
+/* ── Hamburger ───────────────────────────────────────────── */
 
 .hamburger {
   display: none;
   flex-direction: column;
   justify-content: center;
   gap: 5px;
-  /* 44px minimum tap target (WCAG 2.5.5) */
   width: 44px;
   height: 44px;
   background: none;
@@ -71,60 +179,45 @@
   cursor: pointer;
   padding: 6px;
   z-index: 101;
+  flex-shrink: 0;
 }
 
 .bar {
   display: block;
   width: 100%;
   height: 1px;
-  background: var(--color-heading);
+  background: rgba(255, 255, 255, 0.9);
   transform-origin: center;
-  transition:
-    transform 0.3s ease,
-    opacity 0.3s ease;
+  transition: transform 0.3s ease, opacity 0.3s ease, background 0.3s ease;
 }
 
-/* Animate to X when open */
+.scrolled .bar,
+.menuOpen .bar {
+  background: var(--color-heading);
+}
+
 .hamburgerOpen .bar:nth-child(1) {
   transform: translateY(6px) rotate(45deg);
 }
-
 .hamburgerOpen .bar:nth-child(2) {
   opacity: 0;
   transform: scaleX(0);
 }
-
 .hamburgerOpen .bar:nth-child(3) {
   transform: translateY(-6px) rotate(-45deg);
 }
 
 /* ── Responsive ──────────────────────────────────────────── */
 
-@media (min-width: 769px) and (max-width: 1024px) {
-  .navbar {
-    padding: 1.25rem var(--padding-x);
-  }
-
-  .brand {
-    font-size: 0.75rem;
-  }
-
-  .links {
-    gap: 1.25rem;
-  }
-
-  .link {
-    font-size: 0.65rem;
-    letter-spacing: 0.15em;
-  }
+@media (min-width: 769px) and (max-width: 1080px) {
+  .row { gap: 1.1rem; }
+  .link { font-size: 0.6rem; letter-spacing: 0.12em; }
+  .brandLine { font-size: 0.85rem; }
 }
 
 @media (max-width: 768px) {
-  .links {
-    display: none;
-  }
-
-  .hamburger {
-    display: flex;
-  }
+  .linksWrapper { display: none; }
+  .hamburger { display: flex; }
+  .brandLine { font-size: 0.9rem; }
+  .navbar { align-items: center; }
 }

--- a/app/components/Navbar/Navbar.tsx
+++ b/app/components/Navbar/Navbar.tsx
@@ -1,5 +1,5 @@
 'use client'
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useRef } from 'react'
 import Link from 'next/link'
 import { usePathname } from 'next/navigation'
 import { navLinks, type NavLink } from '@/app/constants/nav'
@@ -7,13 +7,15 @@ import { useScrollLock } from '@/app/hooks/useScrollLock'
 import MobileMenu from '@/app/components/MobileMenu/MobileMenu'
 import styles from './Navbar.module.css'
 
-// `builderLinks` are pages flagged "show in menu" in the visual builder
-// (TYN-226). They are appended after the built-in site links.
+const ROW1 = ['Home', 'About', 'Portfolio', 'Services', 'Testimonials']
+
 export default function Navbar({ builderLinks = [] }: { builderLinks?: NavLink[] }) {
   const [scrolled, setScrolled] = useState(false)
   const [menuOpen, setMenuOpen] = useState(false)
+  const [portfolioOpen, setPortfolioOpen] = useState(false)
   const pathname = usePathname()
   const isHome = pathname === '/'
+  const dropdownRef = useRef<HTMLLIElement>(null)
 
   useScrollLock(menuOpen)
 
@@ -30,46 +32,109 @@ export default function Navbar({ builderLinks = [] }: { builderLinks?: NavLink[]
     }
   }, [])
 
-  const closeMenu = () => setMenuOpen(false)
+  useEffect(() => {
+    if (!portfolioOpen) return
+    const handler = (e: MouseEvent) => {
+      if (dropdownRef.current && !dropdownRef.current.contains(e.target as Node)) {
+        setPortfolioOpen(false)
+      }
+    }
+    document.addEventListener('mousedown', handler)
+    return () => document.removeEventListener('mousedown', handler)
+  }, [portfolioOpen])
+
+  useEffect(() => { setPortfolioOpen(false) }, [pathname])
 
   const allLinks = [...navLinks, ...builderLinks]
+  const row1Links = allLinks.filter(l => ROW1.includes(l.label))
+  const row2Links = allLinks.filter(l => !ROW1.includes(l.label))
 
   const navClass = [
     styles.navbar,
     !isHome || scrolled ? styles.scrolled : '',
     menuOpen ? styles.menuOpen : '',
-  ]
-    .filter(Boolean)
-    .join(' ')
+  ].filter(Boolean).join(' ')
 
   return (
     <>
       <nav className={navClass} aria-label="Main navigation">
         <Link href="/" className={styles.brand} aria-label="Tynnell Hollins Photography, home">
-          Tynnell Hollins Photography
+          <span className={styles.brandLine}>Tynnell</span>
+          <span className={styles.brandLine}>Hollins</span>
+          <span className={styles.brandLine}>Photography</span>
         </Link>
 
-        {/* Desktop links */}
-        <ul className={styles.links} aria-label="Site navigation">
-          {allLinks.map((link) => (
-            <li key={link.href}>
-              <Link
-                href={link.href}
-                className={styles.link}
-                aria-current={pathname === link.href ? 'page' : undefined}
-              >
-                {link.label}
-              </Link>
-            </li>
-          ))}
-        </ul>
+        <div className={styles.linksWrapper}>
+          <ul className={styles.row} aria-label="Site navigation">
+            {row1Links.map(link =>
+              link.children ? (
+                <li
+                  key={link.href}
+                  className={styles.hasDropdown}
+                  ref={dropdownRef}
+                  onMouseEnter={() => setPortfolioOpen(true)}
+                  onMouseLeave={() => setPortfolioOpen(false)}
+                >
+                  <button
+                    className={styles.link}
+                    onClick={() => setPortfolioOpen(p => !p)}
+                    aria-expanded={portfolioOpen}
+                    aria-haspopup="true"
+                  >
+                    {link.label}
+                    <span className={`${styles.arrow} ${portfolioOpen ? styles.arrowOpen : ''}`} aria-hidden="true" />
+                  </button>
+                  <ul className={`${styles.dropdown} ${portfolioOpen ? styles.dropdownOpen : ''}`} role="menu">
+                    {link.children.map(child => (
+                      <li key={child.href} role="none">
+                        <Link
+                          href={child.href}
+                          className={styles.dropdownItem}
+                          role="menuitem"
+                          onClick={() => setPortfolioOpen(false)}
+                        >
+                          {child.label}
+                        </Link>
+                      </li>
+                    ))}
+                  </ul>
+                </li>
+              ) : (
+                <li key={link.href}>
+                  <Link
+                    href={link.href}
+                    className={styles.link}
+                    aria-current={pathname === link.href ? 'page' : undefined}
+                  >
+                    {link.label}
+                  </Link>
+                </li>
+              )
+            )}
+          </ul>
 
-        {/* Hamburger button - mobile only */}
+          {row2Links.length > 0 && (
+            <ul className={`${styles.row} ${styles.row2}`}>
+              {row2Links.map(link => (
+                <li key={link.href}>
+                  <Link
+                    href={link.href}
+                    className={styles.link}
+                    aria-current={pathname === link.href ? 'page' : undefined}
+                  >
+                    {link.label}
+                  </Link>
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+
         <button
           className={`${styles.hamburger} ${menuOpen ? styles.hamburgerOpen : ''}`}
-          onClick={() => setMenuOpen((prev) => !prev)}
+          onClick={() => setMenuOpen(p => !p)}
           aria-label={menuOpen ? 'Close navigation menu' : 'Open navigation menu'}
-          aria-expanded={menuOpen ? 'true' : 'false'}
+          aria-expanded={menuOpen}
           aria-controls="mobile-menu"
         >
           <span className={styles.bar} aria-hidden="true" />
@@ -78,7 +143,7 @@ export default function Navbar({ builderLinks = [] }: { builderLinks?: NavLink[]
         </button>
       </nav>
 
-      <MobileMenu isOpen={menuOpen} onClose={closeMenu} links={allLinks} />
+      <MobileMenu isOpen={menuOpen} onClose={() => setMenuOpen(false)} links={allLinks} />
     </>
   )
 }

--- a/app/components/Navbar/Navbar.tsx
+++ b/app/components/Navbar/Navbar.tsx
@@ -51,7 +51,7 @@ export default function Navbar({ builderLinks = [] }: { builderLinks?: NavLink[]
 
   const navClass = [
     styles.navbar,
-    !isHome || scrolled ? styles.scrolled : '',
+    scrolled ? styles.scrolled : '',
     menuOpen ? styles.menuOpen : '',
   ].filter(Boolean).join(' ')
 

--- a/app/components/PortfolioTeaser/PortfolioTeaser.module.css
+++ b/app/components/PortfolioTeaser/PortfolioTeaser.module.css
@@ -138,6 +138,8 @@
 
 @media (max-width: 480px) {
   .grid {
-    grid-template-columns: 1fr;
+    grid-template-columns: repeat(2, 1fr);
+    gap: 1.25rem;
+    padding: 0.75rem;
   }
 }

--- a/app/constants/nav.ts
+++ b/app/constants/nav.ts
@@ -1,12 +1,21 @@
 export interface NavLink {
   label: string
   href: string
+  children?: NavLink[]
 }
 
 export const navLinks: NavLink[] = [
   { label: 'Home', href: '/' },
   { label: 'About', href: '/about' },
-  { label: 'Portfolio', href: '/portfolio' },
+  {
+    label: 'Portfolio',
+    href: '/portfolio',
+    children: [
+      { label: 'Portraits', href: '/portfolio/portraits' },
+      { label: 'Family', href: '/portfolio/family' },
+      { label: 'Weddings', href: '/portfolio/weddings' },
+    ],
+  },
   { label: 'Services', href: '/services' },
   { label: 'Testimonials', href: '/testimonials' },
   { label: 'Contact', href: '/contact' },

--- a/components/admin/Dashboard.tsx
+++ b/components/admin/Dashboard.tsx
@@ -156,8 +156,7 @@ const PRODUCTS: Product[] = [
     color: '#2563eb',
     icon: <GlobeIcon />,
     links: [
-      { label: 'Website Editor', href: '/builder' },
-      { label: 'New Page', href: '/builder' },
+      { label: 'Website Editor', href: '/builder', external: true },
       { label: 'Hero Slides', href: '/admin/globals/hero-slides' },
       { label: 'About Page', href: '/admin/globals/about-page' },
       { label: 'Site Config', href: '/admin/globals/site-config' },
@@ -263,35 +262,36 @@ function ProductCard({ product }: { product: Product }) {
 
       {/* Sub-links */}
       <div style={{ display: 'flex', flexDirection: 'column', gap: '0.1rem' }}>
-        {product.links.map(link => (
-          link.external
-            ? (
+        {product.links.map(link => {
+          const isHttp = link.href.startsWith('http')
+          if (link.external) {
+            return (
               // eslint-disable-next-line @next/next/no-html-link-for-pages
               <a
-                key={link.href}
+                key={link.label}
                 href={link.href}
-                target="_blank"
-                rel="noopener noreferrer"
+                {...(isHttp ? { target: '_blank', rel: 'noopener noreferrer' } : {})}
                 style={linkStyle}
                 onMouseEnter={e => { (e.currentTarget as HTMLElement).style.color = '#E6E1DE' }}
                 onMouseLeave={e => { (e.currentTarget as HTMLElement).style.color = '' }}
               >
                 {link.label}
-                <ExternalArrow />
+                {isHttp && <ExternalArrow />}
               </a>
             )
-            : (
-              <Link
-                key={link.href}
-                href={link.href}
-                style={linkStyle}
-                onMouseEnter={e => { (e.currentTarget as HTMLElement).style.color = '#E6E1DE' }}
-                onMouseLeave={e => { (e.currentTarget as HTMLElement).style.color = '' }}
-              >
-                {link.label}
-              </Link>
-            )
-        ))}
+          }
+          return (
+            <Link
+              key={link.label}
+              href={link.href}
+              style={linkStyle}
+              onMouseEnter={e => { (e.currentTarget as HTMLElement).style.color = '#E6E1DE' }}
+              onMouseLeave={e => { (e.currentTarget as HTMLElement).style.color = '' }}
+            >
+              {link.label}
+            </Link>
+          )
+        })}
       </div>
     </div>
   )
@@ -421,7 +421,8 @@ export function Dashboard() {
                 const photoCount = Array.isArray(g.photos) ? g.photos.length : 0
                 const isPublished = g.status !== 'draft'
                 return (
-                  <Link
+                  // eslint-disable-next-line @next/next/no-html-link-for-pages
+                  <a
                     key={g.id}
                     href={`/gallery-editor/${g.id}`}
                     style={{
@@ -460,14 +461,15 @@ export function Dashboard() {
                     <span style={{ fontSize: '0.65rem', color: isPublished ? '#4ade80' : '#666', fontFamily: "'Roboto Mono', monospace", whiteSpace: 'nowrap', flexShrink: 0 }}>
                       {isPublished ? 'Published' : 'Draft'}
                     </span>
-                  </Link>
+                  </a>
                 )
               })}
             </div>
           ) : (
             <p style={{ fontSize: '0.8rem', color: '#555', fontFamily: "'Roboto Mono', monospace" }}>No collections yet.</p>
           )}
-          <Link href="/gallery-editor" style={quickFooterLink}>View all collections</Link>
+          {/* eslint-disable-next-line @next/next/no-html-link-for-pages */}
+          <a href="/gallery-editor" style={quickFooterLink}>View all collections</a>
         </div>
 
         {/* Recent Orders */}

--- a/components/admin/Dashboard.tsx
+++ b/components/admin/Dashboard.tsx
@@ -409,7 +409,7 @@ export function Dashboard() {
       <p style={sectionLabelStyle}>QUICK ACCESS</p>
       <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: '1.25rem' }}>
 
-        {/* Recent Collections - Pixieset style rows */}
+        {/* Recent Collections */}
         <div style={quickCardStyle}>
           <div style={quickCardHeader}>
             <span style={{ width: '10px', height: '10px', borderRadius: '50%', background: '#0d9488', display: 'inline-block' }} />

--- a/components/admin/PostGridView.tsx
+++ b/components/admin/PostGridView.tsx
@@ -6,8 +6,9 @@ import Link from 'next/link'
 type CoverImage = {
   url?: string | null
   sizes?: {
-    thumbnail?: { url?: string | null } | null
+    hero?: { url?: string | null } | null
     card?: { url?: string | null } | null
+    thumbnail?: { url?: string | null } | null
   } | null
 }
 
@@ -28,15 +29,14 @@ const LIMIT = 48
 function formatDate(iso: string | null | undefined): string {
   if (!iso) return ''
   try {
-    return new Date(iso).toLocaleDateString('en-US', { year: 'numeric', month: 'short', day: 'numeric' })
-  } catch {
-    return ''
-  }
+    return new Date(iso).toLocaleDateString('en-US', { year: 'numeric', month: 'long', day: 'numeric' })
+  } catch { return '' }
 }
 
-function getCoverUrl(post: PostDoc): string | null {
+function getCoverUrl(post: PostDoc, size: 'hero' | 'card' = 'card'): string | null {
   if (!post.coverImage || typeof post.coverImage === 'number') return null
   const ci = post.coverImage as CoverImage
+  if (size === 'hero') return ci.sizes?.hero?.url ?? ci.url ?? null
   return ci.sizes?.card?.url ?? ci.sizes?.thumbnail?.url ?? ci.url ?? null
 }
 
@@ -51,10 +51,8 @@ export function PostGridView() {
   const [debouncedSearch, setDebouncedSearch] = useState('')
   const searchTimeout = useRef<ReturnType<typeof setTimeout> | null>(null)
   const [togglingIds, setTogglingIds] = useState<Set<number>>(new Set())
-  const [loadError, setLoadError] = useState('')
   const [toggleError, setToggleError] = useState('')
 
-  // Strip Payload's default query params from the URL
   useEffect(() => {
     if (typeof window !== 'undefined' && window.location.search) {
       window.history.replaceState(null, '', window.location.pathname)
@@ -63,73 +61,40 @@ export function PostGridView() {
 
   useEffect(() => {
     if (searchTimeout.current) clearTimeout(searchTimeout.current)
-    searchTimeout.current = setTimeout(() => {
-      setDebouncedSearch(search)
-      setPage(1)
-    }, 300)
+    searchTimeout.current = setTimeout(() => { setDebouncedSearch(search); setPage(1) }, 300)
     return () => { if (searchTimeout.current) clearTimeout(searchTimeout.current) }
   }, [search])
 
   useEffect(() => {
     setLoading(true)
-    const params = new URLSearchParams({
-      limit: String(LIMIT),
-      page: String(page),
-      depth: '1',
-      sort: '-publishedAt',
-    })
+    const params = new URLSearchParams({ limit: String(LIMIT), page: String(page), depth: '1', sort: '-publishedAt' })
     if (debouncedSearch) params.append('where[title][contains]', debouncedSearch)
     if (statusFilter !== 'all') params.append('where[status][equals]', statusFilter)
-
     fetch(`/api/posts?${params.toString()}`, { credentials: 'include' })
       .then(r => r.json())
-      .then(data => {
-        setPosts(data.docs ?? [])
-        setTotal(data.totalDocs ?? 0)
-        setTotalPages(data.totalPages ?? 1)
-        setLoading(false)
-      })
-      .catch(() => { setLoading(false); setLoadError("Couldn't load posts. Check your connection and try again.") })
+      .then(data => { setPosts(data.docs ?? []); setTotal(data.totalDocs ?? 0); setTotalPages(data.totalPages ?? 1); setLoading(false) })
+      .catch(() => setLoading(false))
   }, [debouncedSearch, statusFilter, page])
 
   const toggleStatus = useCallback(async (e: React.MouseEvent, post: PostDoc) => {
-    e.preventDefault()
-    e.stopPropagation()
+    e.preventDefault(); e.stopPropagation()
     if (togglingIds.has(post.id)) return
     setTogglingIds(prev => new Set([...prev, post.id]))
     const newStatus = post.status === 'published' ? 'draft' : 'published'
     const body: Record<string, unknown> = { status: newStatus }
-    if (newStatus === 'published' && !post.publishedAt) {
-      body.publishedAt = new Date().toISOString()
-    }
+    if (newStatus === 'published' && !post.publishedAt) body.publishedAt = new Date().toISOString()
     try {
-      const res = await fetch(`/api/posts/${post.id}`, {
-        method: 'PATCH',
-        credentials: 'include',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(body),
-      })
+      const res = await fetch(`/api/posts/${post.id}`, { method: 'PATCH', credentials: 'include', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(body) })
       if (res.ok) {
-        setPosts(prev => prev.map(p =>
-          p.id === post.id
-            ? { ...p, status: newStatus, publishedAt: body.publishedAt as string | undefined ?? p.publishedAt }
-            : p
-        ))
-        if (statusFilter !== 'all') {
-          setPosts(prev => prev.filter(p => p.id !== post.id || p.status === statusFilter))
-          setTotal(n => n - 1)
-        }
-      } else {
-        setToggleError("Couldn't save - please try again.")
-        setTimeout(() => setToggleError(''), 3500)
-      }
-    } catch {
-      setToggleError("Couldn't save - please try again.")
-      setTimeout(() => setToggleError(''), 3500)
-    } finally {
-      setTogglingIds(prev => { const next = new Set(prev); next.delete(post.id); return next })
-    }
+        setPosts(prev => prev.map(p => p.id === post.id ? { ...p, status: newStatus, publishedAt: body.publishedAt as string ?? p.publishedAt } : p))
+        if (statusFilter !== 'all') { setPosts(prev => prev.filter(p => p.id !== post.id || p.status === statusFilter)); setTotal(n => n - 1) }
+      } else { setToggleError("Couldn't save - please try again."); setTimeout(() => setToggleError(''), 3500) }
+    } catch { setToggleError("Couldn't save - please try again."); setTimeout(() => setToggleError(''), 3500) }
+    finally { setTogglingIds(prev => { const n = new Set(prev); n.delete(post.id); return n }) }
   }, [togglingIds, statusFilter])
+
+  const featuredPost = posts[0] ?? null
+  const heroCover = featuredPost ? getCoverUrl(featuredPost, 'hero') : null
 
   const filters: { value: StatusFilter; label: string }[] = [
     { value: 'all', label: 'All' },
@@ -138,47 +103,45 @@ export function PostGridView() {
   ]
 
   return (
-    <div style={{ fontFamily: 'var(--font-body, system-ui)', color: 'var(--theme-text, #e6e1de)', minHeight: '100vh' }}>
+    <div style={{ fontFamily: 'Roboto Mono, monospace', color: 'var(--theme-text, #e6e1de)', minHeight: '100vh', background: 'var(--theme-bg, #0c0c0c)' }}>
       <style>{`
-        @keyframes pulse { 0%, 100% { opacity: 1; } 50% { opacity: 0.4; } }
-        .post-card:hover { border-color: var(--theme-elevation-400, #3a3a3a) !important; transform: translateY(-2px); }
-        .post-card-img:hover img { transform: scale(1.04); }
+        @keyframes pulse { 0%,100%{opacity:1} 50%{opacity:0.4} }
+        .pgv-card:hover { border-color: var(--theme-elevation-300,#2a2a2a) !important; }
+        .pgv-card:hover .pgv-card-img img { transform: scale(1.04); }
+        .pgv-hero-img:hover img { transform: scale(1.025); }
       `}</style>
 
-      {/* Filter bar — Pixieset horizontal tab style */}
-      <div style={{
-        display: 'flex',
-        alignItems: 'stretch',
-        justifyContent: 'space-between',
-        borderBottom: '1px solid var(--theme-elevation-200, #1e1e1e)',
-        padding: '0 1.5rem',
-      }}>
-        <div style={{ display: 'flex', alignItems: 'center', gap: '0.25rem' }}>
+      {/* ── Hero cover image (matches public /blog layout) ── */}
+      <div style={{ position: 'relative', width: '100%', height: '260px', overflow: 'hidden', background: 'var(--theme-elevation-100, #131313)', flexShrink: 0 }}>
+        {heroCover && (
+          <div className="pgv-hero-img" style={{ position: 'absolute', inset: 0, overflow: 'hidden' }}>
+            {/* eslint-disable-next-line @next/next/no-img-element */}
+            <img src={heroCover} alt="" style={{ width: '100%', height: '100%', objectFit: 'cover', transition: 'transform 0.9s ease' }} />
+          </div>
+        )}
+        {heroCover && (
+          <div style={{ position: 'absolute', inset: 0, background: 'linear-gradient(to bottom, rgba(12,12,12,0.05) 0%, rgba(12,12,12,0) 30%, rgba(12,12,12,0.65) 100%)' }} />
+        )}
+        {/* BLOG label */}
+        <span style={{ position: 'absolute', bottom: '1.25rem', right: '1.5rem', fontFamily: 'Roboto Mono, monospace', fontSize: '0.55rem', letterSpacing: '0.45em', textTransform: 'uppercase', color: 'rgba(255,255,255,0.55)', writingMode: 'vertical-rl', pointerEvents: 'none', zIndex: 2 }} aria-hidden="true">Blog</span>
+        {/* New Post button — top right */}
+        <Link href="/admin/collections/posts/create" style={{ position: 'absolute', top: '1rem', right: '1.5rem', display: 'inline-flex', alignItems: 'center', gap: '0.3rem', padding: '0.4rem 0.9rem', background: 'rgba(16,185,129,0.9)', backdropFilter: 'blur(4px)', color: '#fff', borderRadius: '3px', fontSize: '0.6rem', fontFamily: 'Roboto Mono, monospace', letterSpacing: '0.1em', textTransform: 'uppercase', fontWeight: 600, textDecoration: 'none', zIndex: 3 }}>
+          + New Post
+        </Link>
+      </div>
+
+      {/* ── Filter bar (matches public /blog filter bar) ── */}
+      <div style={{ display: 'flex', alignItems: 'stretch', justifyContent: 'space-between', borderBottom: '1px solid var(--theme-elevation-200, #1e1e1e)', padding: '0 1.5rem' }}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: '0.15rem' }}>
           {filters.map((f, i) => {
             const active = statusFilter === f.value
             return (
               <React.Fragment key={f.value}>
-                {i > 0 && (
-                  <span style={{ color: 'var(--theme-elevation-400, #3a3a3a)', fontSize: '0.6rem', padding: '0 0.5rem', userSelect: 'none' }}>·</span>
-                )}
+                {i > 0 && <span style={{ color: '#2a2a2a', fontSize: '0.55rem', padding: '0 0.6rem', userSelect: 'none' }}>·</span>}
                 <button
                   onClick={() => { setStatusFilter(f.value); setPage(1) }}
                   aria-pressed={active}
-                  style={{
-                    background: 'none',
-                    border: 'none',
-                    borderBottom: active ? '1px solid var(--theme-text, #d6d1ce)' : '1px solid transparent',
-                    marginBottom: '-1px',
-                    padding: '1rem 0.25rem',
-                    fontFamily: 'Roboto Mono, monospace',
-                    fontSize: '0.6rem',
-                    letterSpacing: '0.22em',
-                    textTransform: 'uppercase',
-                    color: active ? 'var(--theme-text, #d6d1ce)' : 'var(--theme-text-dim, #9b9a9a)',
-                    cursor: 'pointer',
-                    whiteSpace: 'nowrap',
-                    transition: 'color 0.15s',
-                  }}
+                  style={{ background: 'none', border: 'none', borderBottom: active ? '1px solid var(--theme-text, #d6d1ce)' : '1px solid transparent', marginBottom: '-1px', padding: '0.9rem 0.15rem', fontFamily: 'Roboto Mono, monospace', fontSize: '0.6rem', letterSpacing: '0.22em', textTransform: 'uppercase', color: active ? 'var(--theme-text, #d6d1ce)' : 'var(--theme-text-dim, #9b9a9a)', cursor: 'pointer', whiteSpace: 'nowrap', transition: 'color 0.15s' }}
                 >
                   {f.label}
                 </button>
@@ -186,123 +149,85 @@ export function PostGridView() {
             )
           })}
           {!loading && (
-            <span style={{ fontFamily: 'Roboto Mono, monospace', fontSize: '0.58rem', letterSpacing: '0.1em', color: 'var(--theme-text-dim, #9b9a9a)', opacity: 0.55, marginLeft: '1.25rem' }}>
+            <span style={{ fontSize: '0.55rem', letterSpacing: '0.1em', color: 'var(--theme-text-dim, #9b9a9a)', opacity: 0.5, marginLeft: '1.25rem' }}>
               {total} {total === 1 ? 'post' : 'posts'}
             </span>
           )}
         </div>
-
-        <div style={{ display: 'flex', alignItems: 'center', gap: '0.75rem', padding: '0.75rem 0' }}>
-          {/* Search */}
+        {/* Search */}
+        <div style={{ display: 'flex', alignItems: 'center', padding: '0.6rem 0' }}>
           <div style={{ position: 'relative', display: 'flex', alignItems: 'center' }}>
-            <svg width="14" height="14" viewBox="0 0 16 16" fill="none" aria-hidden="true" style={{ position: 'absolute', left: '0.5rem', color: 'var(--theme-text-dim, #9b9a9a)', pointerEvents: 'none' }}>
+            <svg width="13" height="13" viewBox="0 0 16 16" fill="none" aria-hidden="true" style={{ position: 'absolute', left: '0.5rem', color: 'var(--theme-text-dim, #9b9a9a)', pointerEvents: 'none' }}>
               <circle cx="6.5" cy="6.5" r="5" stroke="currentColor" strokeWidth="1.25" />
               <path d="M10.5 10.5L14 14" stroke="currentColor" strokeWidth="1.25" strokeLinecap="round" />
             </svg>
             <input
               type="search"
-              placeholder="Search posts..."
+              placeholder="Search..."
               aria-label="Search posts"
               value={search}
               onChange={e => setSearch(e.target.value)}
-              style={{
-                padding: '0.4rem 0.6rem 0.4rem 1.75rem',
-                background: 'var(--theme-elevation-100, #131313)',
-                border: '1px solid var(--theme-elevation-300, #2a2a2a)',
-                borderRadius: '3px',
-                color: 'var(--theme-text, #e6e1de)',
-                fontSize: '0.72rem',
-                fontFamily: 'Roboto Mono, monospace',
-                outline: 'none',
-                width: '180px',
-              }}
+              style={{ padding: '0.35rem 0.6rem 0.35rem 1.7rem', background: 'var(--theme-elevation-100, #131313)', border: '1px solid var(--theme-elevation-200, #1a1a1a)', borderRadius: '2px', color: 'var(--theme-text, #e6e1de)', fontSize: '0.6rem', fontFamily: 'Roboto Mono, monospace', letterSpacing: '0.05em', outline: 'none', width: '140px' }}
             />
           </div>
-
-          {/* New Post button */}
-          <Link
-            href="/admin/collections/posts/create"
-            style={{
-              display: 'inline-flex',
-              alignItems: 'center',
-              gap: '0.3rem',
-              padding: '0.45rem 1rem',
-              background: 'var(--theme-success-500, #10B981)',
-              color: '#fff',
-              borderRadius: '3px',
-              fontSize: '0.68rem',
-              fontFamily: 'Roboto Mono, monospace',
-              letterSpacing: '0.08em',
-              textTransform: 'uppercase',
-              fontWeight: 600,
-              textDecoration: 'none',
-              whiteSpace: 'nowrap',
-            }}
-          >
-            + New Post
-          </Link>
         </div>
       </div>
 
-      {/* Error alerts */}
-      {loadError && (
-        <div role="alert" style={{ margin: '1rem 1.5rem 0', padding: '0.55rem 0.75rem', background: 'rgba(248,113,113,0.08)', border: '1px solid rgba(248,113,113,0.25)', borderRadius: 3, fontSize: '0.78rem', color: '#f0a3a3' }}>
-          {loadError}
-        </div>
-      )}
       {toggleError && (
-        <div role="alert" style={{ margin: '1rem 1.5rem 0', padding: '0.55rem 0.75rem', background: 'rgba(248,113,113,0.08)', border: '1px solid rgba(248,113,113,0.25)', borderRadius: 3, fontSize: '0.78rem', color: '#f0a3a3' }}>
-          {toggleError}
-        </div>
+        <div role="alert" style={{ margin: '0.75rem 1.5rem', padding: '0.5rem 0.75rem', background: 'rgba(248,113,113,0.08)', border: '1px solid rgba(248,113,113,0.25)', borderRadius: 2, fontSize: '0.72rem', color: '#f0a3a3' }}>{toggleError}</div>
       )}
 
-      {/* Grid */}
-      <div style={{ padding: '1.75rem 1.5rem' }}>
+      {/* ── 2-column post grid (matches public /blog grid) ── */}
+      <div style={{ padding: '2rem 1.5rem' }}>
         {loading ? (
-          <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fill, minmax(280px, 1fr))', gap: '1rem' }}>
-            {Array.from({ length: 6 }).map((_, i) => (
-              <div key={i} style={{ background: 'var(--theme-elevation-200, #1a1a1a)', borderRadius: '4px', paddingBottom: '52%', animation: 'pulse 1.5s infinite' }} />
+          <div style={{ display: 'grid', gridTemplateColumns: 'repeat(2, 1fr)', gap: '2rem 1.5rem' }}>
+            {Array.from({ length: 4 }).map((_, i) => (
+              <div key={i}>
+                <div style={{ width: '100%', paddingBottom: '66%', background: 'var(--theme-elevation-200, #1a1a1a)', borderRadius: '2px', animation: 'pulse 1.5s infinite' }} />
+                <div style={{ height: '0.75rem', background: 'var(--theme-elevation-200,#1a1a1a)', borderRadius: 2, marginTop: '0.85rem', animation: 'pulse 1.5s infinite', width: '70%' }} />
+                <div style={{ height: '0.6rem', background: 'var(--theme-elevation-200,#1a1a1a)', borderRadius: 2, marginTop: '0.5rem', animation: 'pulse 1.5s infinite', width: '40%' }} />
+              </div>
             ))}
           </div>
         ) : posts.length === 0 ? (
-          <div style={{ textAlign: 'center', padding: '5rem 2rem', color: 'var(--theme-text-dim, #9b9a9a)', fontSize: '0.8rem', fontFamily: 'Roboto Mono, monospace', letterSpacing: '0.08em' }}>
-            {debouncedSearch || statusFilter !== 'all'
-              ? 'No posts match your filters.'
-              : 'No blog posts yet. Click New Post above to write your first one.'}
+          <div style={{ textAlign: 'center', padding: '4rem 2rem', color: 'var(--theme-text-dim, #9b9a9a)', fontSize: '0.72rem', letterSpacing: '0.08em' }}>
+            {debouncedSearch || statusFilter !== 'all' ? 'No posts match your filters.' : 'No blog posts yet. Click + New Post above to write your first one.'}
           </div>
         ) : (
-          <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fill, minmax(280px, 1fr))', gap: '1.5rem' }}>
+          <div style={{ display: 'grid', gridTemplateColumns: 'repeat(2, 1fr)', gap: '2.5rem 1.5rem' }}>
             {posts.map(post => {
               const coverUrl = getCoverUrl(post)
               return (
-                <div key={post.id} style={{ position: 'relative', background: 'var(--theme-elevation-100, #131313)', border: '1px solid var(--theme-elevation-200, #1a1a1a)', borderRadius: '4px', overflow: 'hidden', transition: 'border-color 0.15s, transform 0.15s' }} className="post-card">
-                  <Link href={`/admin/collections/posts/${post.id}`} style={{ display: 'block', textDecoration: 'none', color: 'inherit' }} title={post.title}>
-                    <div style={{ width: '100%', paddingBottom: '60%', position: 'relative', background: 'var(--theme-elevation-200, #1a1a1a)', overflow: 'hidden' }} className="post-card-img">
+                <div key={post.id} className="pgv-card" style={{ position: 'relative', border: '1px solid transparent', transition: 'border-color 0.15s', borderRadius: '2px', overflow: 'hidden' }}>
+                  <Link href={`/admin/collections/posts/${post.id}`} style={{ display: 'block', textDecoration: 'none', color: 'inherit' }}>
+                    {/* Cover image — 3:2 ratio matching public blog cards */}
+                    <div className="pgv-card-img" style={{ position: 'relative', width: '100%', paddingBottom: '66%', overflow: 'hidden', background: 'var(--theme-elevation-100, #131313)' }}>
                       {coverUrl ? (
                         // eslint-disable-next-line @next/next/no-img-element
-                        <img src={coverUrl} alt={post.title} style={{ position: 'absolute', inset: 0, width: '100%', height: '100%', objectFit: 'cover', transition: 'transform 0.5s ease' }} loading="lazy" />
+                        <img src={coverUrl} alt={post.title} style={{ position: 'absolute', inset: 0, width: '100%', height: '100%', objectFit: 'cover', transition: 'transform 0.6s ease' }} loading="lazy" />
                       ) : (
-                        <div style={{ position: 'absolute', inset: 0, display: 'flex', alignItems: 'center', justifyContent: 'center', fontSize: '2rem', color: 'var(--theme-elevation-400, #3a3a3a)' }}>&#9998;</div>
+                        <div style={{ position: 'absolute', inset: 0, display: 'flex', alignItems: 'center', justifyContent: 'center', fontSize: '1.75rem', color: 'var(--theme-elevation-400, #3a3a3a)' }}>&#9998;</div>
                       )}
                     </div>
-                    <div style={{ padding: '0.85rem 0.9rem 1rem' }}>
-                      <div style={{ fontFamily: 'Archivo, sans-serif', fontSize: '0.875rem', fontWeight: 500, lineHeight: 1.35, color: 'var(--theme-text, #e6e1de)', marginBottom: '0.3rem', display: '-webkit-box', WebkitLineClamp: 2, WebkitBoxOrient: 'vertical', overflow: 'hidden' }}>
-                        {post.title}
-                      </div>
+                    {/* Card body */}
+                    <div style={{ paddingTop: '0.85rem' }}>
                       {post.publishedAt && (
-                        <div style={{ fontFamily: 'Roboto Mono, monospace', fontSize: '0.65rem', color: 'var(--theme-text-dim, #9b9a9a)', letterSpacing: '0.06em' }}>
+                        <div style={{ fontSize: '0.58rem', letterSpacing: '0.15em', textTransform: 'uppercase', color: 'var(--theme-text-dim, #9b9a9a)', opacity: 0.65, marginBottom: '0.4rem' }}>
                           {formatDate(post.publishedAt)}
                         </div>
                       )}
+                      <div style={{ fontFamily: 'Archivo, sans-serif', fontSize: '1rem', fontWeight: 400, lineHeight: 1.25, color: 'var(--theme-text, #d6d1ce)', marginBottom: '0.4rem', display: '-webkit-box', WebkitLineClamp: 2, WebkitBoxOrient: 'vertical', overflow: 'hidden' }}>
+                        {post.title}
+                      </div>
                       {post.excerpt && (
-                        <div style={{ fontFamily: 'Roboto Mono, monospace', fontSize: '0.68rem', color: 'var(--theme-text-dim, #9b9a9a)', marginTop: '0.4rem', lineHeight: 1.55, display: '-webkit-box', WebkitLineClamp: 2, WebkitBoxOrient: 'vertical', overflow: 'hidden' }}>
+                        <div style={{ fontSize: '0.72rem', lineHeight: 1.6, color: 'var(--theme-text-dim, #9b9a9a)', display: '-webkit-box', WebkitLineClamp: 2, WebkitBoxOrient: 'vertical', overflow: 'hidden' }}>
                           {post.excerpt}
                         </div>
                       )}
                     </div>
                   </Link>
 
-                  {/* Publish/draft quick-toggle — sibling of Link, not child */}
+                  {/* Publish/draft quick-toggle on cover image */}
                   <button
                     type="button"
                     onClick={(e) => { void toggleStatus(e, post) }}
@@ -310,27 +235,7 @@ export function PostGridView() {
                     aria-busy={togglingIds.has(post.id)}
                     aria-pressed={post.status === 'published'}
                     aria-label={post.status === 'published' ? 'Published - click to revert to draft' : 'Draft - click to publish'}
-                    title={post.status === 'published' ? 'Published - click to revert to draft' : 'Draft - click to publish'}
-                    style={{
-                      position: 'absolute',
-                      top: '0.5rem',
-                      right: '0.5rem',
-                      zIndex: 1,
-                      padding: '0.18rem 0.5rem',
-                      background: post.status === 'published' ? 'rgba(16,185,129,0.85)' : 'rgba(100,100,100,0.75)',
-                      backdropFilter: 'blur(4px)',
-                      borderRadius: '3px',
-                      fontSize: '0.55rem',
-                      letterSpacing: '0.12em',
-                      textTransform: 'uppercase',
-                      color: '#fff',
-                      fontWeight: 600,
-                      border: 'none',
-                      cursor: togglingIds.has(post.id) ? 'wait' : 'pointer',
-                      opacity: togglingIds.has(post.id) ? 0.5 : 1,
-                      fontFamily: 'Roboto Mono, monospace',
-                      transition: 'background 0.15s',
-                    }}
+                    style={{ position: 'absolute', top: '0.5rem', right: '0.5rem', zIndex: 1, padding: '0.2rem 0.55rem', background: post.status === 'published' ? 'rgba(16,185,129,0.85)' : 'rgba(80,80,80,0.8)', backdropFilter: 'blur(4px)', borderRadius: '2px', fontSize: '0.52rem', letterSpacing: '0.14em', textTransform: 'uppercase', color: '#fff', fontWeight: 600, border: 'none', cursor: togglingIds.has(post.id) ? 'wait' : 'pointer', opacity: togglingIds.has(post.id) ? 0.5 : 1, fontFamily: 'Roboto Mono, monospace', transition: 'background 0.15s' }}
                   >
                     {post.status ?? 'draft'}
                   </button>
@@ -340,22 +245,11 @@ export function PostGridView() {
           </div>
         )}
 
-        {/* Pagination */}
         {totalPages > 1 && !loading && (
           <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', gap: '0.5rem', marginTop: '2.5rem' }}>
-            <button
-              style={{ padding: '0.375rem 0.75rem', background: 'var(--theme-elevation-100,#131313)', border: '1px solid var(--theme-elevation-300,#2a2a2a)', borderRadius: '3px', color: 'var(--theme-text,#e6e1de)', fontSize: '0.72rem', fontFamily: 'Roboto Mono, monospace', cursor: page === 1 ? 'default' : 'pointer', opacity: page === 1 ? 0.4 : 1 }}
-              onClick={() => setPage(p => Math.max(1, p - 1))}
-              disabled={page === 1}
-            >Prev</button>
-            <span style={{ fontSize: '0.72rem', fontFamily: 'Roboto Mono, monospace', color: 'var(--theme-text-dim,#9b9a9a)' }}>
-              {page} / {totalPages}
-            </span>
-            <button
-              style={{ padding: '0.375rem 0.75rem', background: 'var(--theme-elevation-100,#131313)', border: '1px solid var(--theme-elevation-300,#2a2a2a)', borderRadius: '3px', color: 'var(--theme-text,#e6e1de)', fontSize: '0.72rem', fontFamily: 'Roboto Mono, monospace', cursor: page === totalPages ? 'default' : 'pointer', opacity: page === totalPages ? 0.4 : 1 }}
-              onClick={() => setPage(p => Math.min(totalPages, p + 1))}
-              disabled={page === totalPages}
-            >Next</button>
+            <button style={{ padding: '0.35rem 0.7rem', background: 'var(--theme-elevation-100,#131313)', border: '1px solid var(--theme-elevation-200,#1a1a1a)', borderRadius: '2px', color: 'var(--theme-text,#e6e1de)', fontSize: '0.65rem', fontFamily: 'Roboto Mono, monospace', letterSpacing: '0.08em', cursor: page === 1 ? 'default' : 'pointer', opacity: page === 1 ? 0.4 : 1 }} onClick={() => setPage(p => Math.max(1, p - 1))} disabled={page === 1}>Prev</button>
+            <span style={{ fontSize: '0.65rem', fontFamily: 'Roboto Mono, monospace', color: 'var(--theme-text-dim,#9b9a9a)' }}>{page} / {totalPages}</span>
+            <button style={{ padding: '0.35rem 0.7rem', background: 'var(--theme-elevation-100,#131313)', border: '1px solid var(--theme-elevation-200,#1a1a1a)', borderRadius: '2px', color: 'var(--theme-text,#e6e1de)', fontSize: '0.65rem', fontFamily: 'Roboto Mono, monospace', letterSpacing: '0.08em', cursor: page === totalPages ? 'default' : 'pointer', opacity: page === totalPages ? 0.4 : 1 }} onClick={() => setPage(p => Math.min(totalPages, p + 1))} disabled={page === totalPages}>Next</button>
           </div>
         )}
       </div>

--- a/components/admin/PostGridView.tsx
+++ b/components/admin/PostGridView.tsx
@@ -23,161 +23,6 @@ type PostDoc = {
 
 type StatusFilter = 'all' | 'published' | 'draft'
 
-const css = {
-  root: {
-    padding: '1.5rem',
-    fontFamily: 'var(--font-body, system-ui, sans-serif)',
-    color: 'var(--theme-text, #e6e1de)',
-    minHeight: '100vh',
-  } as React.CSSProperties,
-  toolbar: {
-    display: 'flex',
-    alignItems: 'center',
-    gap: '0.75rem',
-    marginBottom: '1rem',
-    flexWrap: 'wrap' as const,
-  } as React.CSSProperties,
-  search: {
-    flex: '1 1 200px',
-    minWidth: '140px',
-    padding: '0.5rem 0.75rem',
-    background: 'var(--theme-elevation-100, #131313)',
-    border: '1px solid var(--theme-elevation-300, #2a2a2a)',
-    borderRadius: '4px',
-    color: 'var(--theme-text, #e6e1de)',
-    fontSize: '0.875rem',
-    outline: 'none',
-  } as React.CSSProperties,
-  newBtn: {
-    display: 'inline-flex',
-    alignItems: 'center',
-    gap: '0.4rem',
-    padding: '0.5rem 1rem',
-    background: 'var(--theme-success-500, #10B981)',
-    color: '#fff',
-    borderRadius: '4px',
-    fontSize: '0.875rem',
-    fontWeight: 600,
-    textDecoration: 'none',
-    whiteSpace: 'nowrap' as const,
-    marginLeft: 'auto',
-  } as React.CSSProperties,
-  count: {
-    fontSize: '0.8rem',
-    color: 'var(--theme-text-dim, #9b9a9a)',
-    whiteSpace: 'nowrap' as const,
-  } as React.CSSProperties,
-  grid: {
-    display: 'grid',
-    gridTemplateColumns: 'repeat(auto-fill, minmax(260px, 1fr))',
-    gap: '1rem',
-  } as React.CSSProperties,
-  card: {
-    background: 'var(--theme-elevation-100, #131313)',
-    borderRadius: '6px',
-    overflow: 'hidden',
-    textDecoration: 'none',
-    color: 'inherit',
-    display: 'block',
-    border: '1px solid var(--theme-elevation-200, #1a1a1a)',
-    transition: 'border-color 0.15s, transform 0.15s',
-  } as React.CSSProperties,
-  imgWrap: {
-    width: '100%',
-    paddingBottom: '52%',
-    position: 'relative' as const,
-    background: 'var(--theme-elevation-200, #1a1a1a)',
-    overflow: 'hidden',
-  } as React.CSSProperties,
-  img: {
-    position: 'absolute' as const,
-    inset: 0,
-    width: '100%',
-    height: '100%',
-    objectFit: 'cover' as const,
-  } as React.CSSProperties,
-  placeholder: {
-    position: 'absolute' as const,
-    inset: 0,
-    display: 'flex',
-    alignItems: 'center',
-    justifyContent: 'center',
-    fontSize: '2.5rem',
-    color: 'var(--theme-elevation-400, #3a3a3a)',
-  } as React.CSSProperties,
-  statusBadge: (status: 'draft' | 'published' | null | undefined): React.CSSProperties => ({
-    position: 'absolute',
-    top: '0.5rem',
-    right: '0.5rem',
-    padding: '0.18rem 0.5rem',
-    background: status === 'published' ? 'rgba(16,185,129,0.85)' : 'rgba(100,100,100,0.75)',
-    backdropFilter: 'blur(4px)',
-    borderRadius: '3px',
-    fontSize: '0.58rem',
-    letterSpacing: '0.12em',
-    textTransform: 'uppercase',
-    color: '#fff',
-    fontWeight: 600,
-  }),
-  cardBody: {
-    padding: '0.75rem',
-  } as React.CSSProperties,
-  cardTitle: {
-    fontSize: '0.875rem',
-    fontWeight: 500,
-    fontFamily: 'Archivo, sans-serif',
-    lineHeight: 1.35,
-    color: 'var(--theme-text, #e6e1de)',
-    marginBottom: '0.3rem',
-    display: '-webkit-box',
-    WebkitLineClamp: 2,
-    WebkitBoxOrient: 'vertical' as const,
-    overflow: 'hidden',
-  } as React.CSSProperties,
-  cardDate: {
-    fontSize: '0.68rem',
-    color: 'var(--theme-text-dim, #9b9a9a)',
-    fontFamily: 'Roboto Mono, monospace',
-  } as React.CSSProperties,
-  cardExcerpt: {
-    fontSize: '0.72rem',
-    color: 'var(--theme-text-dim, #9b9a9a)',
-    marginTop: '0.35rem',
-    lineHeight: 1.5,
-    display: '-webkit-box',
-    WebkitLineClamp: 2,
-    WebkitBoxOrient: 'vertical' as const,
-    overflow: 'hidden',
-  } as React.CSSProperties,
-  empty: {
-    textAlign: 'center' as const,
-    padding: '4rem 2rem',
-    color: 'var(--theme-text-dim, #9b9a9a)',
-    fontSize: '0.9rem',
-  } as React.CSSProperties,
-  skeleton: {
-    background: 'var(--theme-elevation-200, #1a1a1a)',
-    borderRadius: '6px',
-    paddingBottom: '52%',
-    position: 'relative' as const,
-    animation: 'pulse 1.5s infinite',
-  } as React.CSSProperties,
-}
-
-const filterBtn = (active: boolean): React.CSSProperties => ({
-  padding: '0.3rem 0.7rem',
-  background: active ? 'var(--theme-elevation-500, #9B9A9A)' : 'var(--theme-elevation-100, #131313)',
-  border: `1px solid ${active ? 'transparent' : 'var(--theme-elevation-300, #2a2a2a)'}`,
-  borderRadius: '20px',
-  color: active ? '#fff' : 'var(--theme-text-dim, #9b9a9a)',
-  fontSize: '0.68rem',
-  letterSpacing: '0.08em',
-  textTransform: 'capitalize',
-  cursor: 'pointer',
-  fontWeight: active ? 600 : 400,
-  whiteSpace: 'nowrap',
-})
-
 const LIMIT = 48
 
 function formatDate(iso: string | null | undefined): string {
@@ -187,6 +32,12 @@ function formatDate(iso: string | null | undefined): string {
   } catch {
     return ''
   }
+}
+
+function getCoverUrl(post: PostDoc): string | null {
+  if (!post.coverImage || typeof post.coverImage === 'number') return null
+  const ci = post.coverImage as CoverImage
+  return ci.sizes?.card?.url ?? ci.sizes?.thumbnail?.url ?? ci.url ?? null
 }
 
 export function PostGridView() {
@@ -202,6 +53,13 @@ export function PostGridView() {
   const [togglingIds, setTogglingIds] = useState<Set<number>>(new Set())
   const [loadError, setLoadError] = useState('')
   const [toggleError, setToggleError] = useState('')
+
+  // Strip Payload's default query params from the URL
+  useEffect(() => {
+    if (typeof window !== 'undefined' && window.location.search) {
+      window.history.replaceState(null, '', window.location.pathname)
+    }
+  }, [])
 
   useEffect(() => {
     if (searchTimeout.current) clearTimeout(searchTimeout.current)
@@ -220,12 +78,8 @@ export function PostGridView() {
       depth: '1',
       sort: '-publishedAt',
     })
-    if (debouncedSearch) {
-      params.append('where[title][contains]', debouncedSearch)
-    }
-    if (statusFilter !== 'all') {
-      params.append('where[status][equals]', statusFilter)
-    }
+    if (debouncedSearch) params.append('where[title][contains]', debouncedSearch)
+    if (statusFilter !== 'all') params.append('where[status][equals]', statusFilter)
 
     fetch(`/api/posts?${params.toString()}`, { credentials: 'include' })
       .then(r => r.json())
@@ -245,7 +99,6 @@ export function PostGridView() {
     setTogglingIds(prev => new Set([...prev, post.id]))
     const newStatus = post.status === 'published' ? 'draft' : 'published'
     const body: Record<string, unknown> = { status: newStatus }
-    // Set publishedAt on first publish if not already set
     if (newStatus === 'published' && !post.publishedAt) {
       body.publishedAt = new Date().toISOString()
     }
@@ -262,7 +115,6 @@ export function PostGridView() {
             ? { ...p, status: newStatus, publishedAt: body.publishedAt as string | undefined ?? p.publishedAt }
             : p
         ))
-        // Remove from list if status filter is active and no longer matches
         if (statusFilter !== 'all') {
           setPosts(prev => prev.filter(p => p.id !== post.id || p.status === statusFilter))
           setTotal(n => n - 1)
@@ -275,166 +127,238 @@ export function PostGridView() {
       setToggleError("Couldn't save - please try again.")
       setTimeout(() => setToggleError(''), 3500)
     } finally {
-      setTogglingIds(prev => {
-        const next = new Set(prev)
-        next.delete(post.id)
-        return next
-      })
+      setTogglingIds(prev => { const next = new Set(prev); next.delete(post.id); return next })
     }
   }, [togglingIds, statusFilter])
 
-  const getCoverUrl = (post: PostDoc): string | null => {
-    if (!post.coverImage || typeof post.coverImage === 'number') return null
-    const ci = post.coverImage as CoverImage
-    return ci.sizes?.card?.url ?? ci.sizes?.thumbnail?.url ?? ci.url ?? null
-  }
+  const filters: { value: StatusFilter; label: string }[] = [
+    { value: 'all', label: 'All' },
+    { value: 'published', label: 'Published' },
+    { value: 'draft', label: 'Draft' },
+  ]
 
   return (
-    <div style={css.root}>
+    <div style={{ fontFamily: 'var(--font-body, system-ui)', color: 'var(--theme-text, #e6e1de)', minHeight: '100vh' }}>
       <style>{`
         @keyframes pulse { 0%, 100% { opacity: 1; } 50% { opacity: 0.4; } }
         .post-card:hover { border-color: var(--theme-elevation-400, #3a3a3a) !important; transform: translateY(-2px); }
+        .post-card-img:hover img { transform: scale(1.04); }
       `}</style>
 
-      {/* Toolbar */}
-      <div style={css.toolbar}>
-        <input
-          type="search"
-          placeholder="Search posts..."
-          aria-label="Search posts"
-          value={search}
-          onChange={e => setSearch(e.target.value)}
-          style={css.search}
-        />
-        {!loading && (
-          <span style={css.count}>{total} {total === 1 ? 'post' : 'posts'}</span>
-        )}
-        <Link href="/admin/collections/posts/create" style={css.newBtn}>
-          + New Post
-        </Link>
-      </div>
-
-      {/* Status filter */}
-      <div style={{ display: 'flex', gap: '0.4rem', marginBottom: '1.25rem' }}>
-        {(['all', 'published', 'draft'] as StatusFilter[]).map(s => (
-          <button
-            key={s}
-            style={{
-              ...filterBtn(statusFilter === s),
-              ...(s === 'published' && statusFilter === s ? { background: 'rgba(16,185,129,0.2)', color: '#10B981', borderColor: 'transparent' } : {}),
-            }}
-            aria-pressed={statusFilter === s}
-            onClick={() => { setStatusFilter(s); setPage(1) }}
-          >
-            {s === 'all' ? 'All' : s.charAt(0).toUpperCase() + s.slice(1)}
-          </button>
-        ))}
-      </div>
-
-      {loadError && <div role="alert" style={{ marginBottom: '0.75rem', padding: '0.55rem 0.75rem', background: 'rgba(248,113,113,0.08)', border: '1px solid rgba(248,113,113,0.25)', borderRadius: 4, fontSize: '0.8rem', color: '#f0a3a3' }}>{loadError}</div>}
-      {toggleError && <div role="alert" style={{ marginBottom: '0.75rem', padding: '0.55rem 0.75rem', background: 'rgba(248,113,113,0.08)', border: '1px solid rgba(248,113,113,0.25)', borderRadius: 4, fontSize: '0.8rem', color: '#f0a3a3' }}>{toggleError}</div>}
-
-      {/* Grid */}
-      {loading ? (
-        <div style={css.grid}>
-          {Array.from({ length: 6 }).map((_, i) => (
-            <div key={i} style={css.skeleton} />
-          ))}
-        </div>
-      ) : posts.length === 0 ? (
-        <div style={css.empty}>
-          {debouncedSearch || statusFilter !== 'all'
-            ? 'No posts match your filters.'
-            : 'No blog posts yet. Click New Post above to write your first one.'}
-        </div>
-      ) : (
-        <div style={css.grid}>
-          {posts.map(post => {
-            const coverUrl = getCoverUrl(post)
+      {/* Filter bar — Pixieset horizontal tab style */}
+      <div style={{
+        display: 'flex',
+        alignItems: 'stretch',
+        justifyContent: 'space-between',
+        borderBottom: '1px solid var(--theme-elevation-200, #1e1e1e)',
+        padding: '0 1.5rem',
+      }}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: '0.25rem' }}>
+          {filters.map((f, i) => {
+            const active = statusFilter === f.value
             return (
-              <div key={post.id} style={{ ...css.card, position: 'relative' }} className="post-card">
-                {/* Full-card nav link — button sits above it via z-index */}
-                <Link
-                  href={`/admin/collections/posts/${post.id}`}
-                  style={{ display: 'block', textDecoration: 'none', color: 'inherit' }}
-                  title={post.title}
-                >
-                  <div style={css.imgWrap}>
-                    {coverUrl ? (
-                      // eslint-disable-next-line @next/next/no-img-element
-                      <img src={coverUrl} alt={post.title} style={css.img} loading="lazy" />
-                    ) : (
-                      <div style={css.placeholder}>&#9998;</div>
-                    )}
-                  </div>
-                  <div style={css.cardBody}>
-                    <div style={css.cardTitle}>{post.title}</div>
-                    {post.publishedAt && (
-                      <div style={css.cardDate}>{formatDate(post.publishedAt)}</div>
-                    )}
-                    {post.excerpt && (
-                      <div style={css.cardExcerpt}>{post.excerpt}</div>
-                    )}
-                  </div>
-                </Link>
-                {/* Publish/Draft quick-toggle — sibling of <a>, not child */}
+              <React.Fragment key={f.value}>
+                {i > 0 && (
+                  <span style={{ color: 'var(--theme-elevation-400, #3a3a3a)', fontSize: '0.6rem', padding: '0 0.5rem', userSelect: 'none' }}>·</span>
+                )}
                 <button
-                  type="button"
-                  onClick={(e) => { void toggleStatus(e, post) }}
-                  disabled={togglingIds.has(post.id)}
-                  aria-busy={togglingIds.has(post.id)}
-                  title={post.status === 'published' ? 'Published - click to revert to draft' : 'Draft - click to publish'}
-                  aria-label={post.status === 'published' ? 'Published - click to revert to draft' : 'Draft - click to publish'}
-                  aria-pressed={post.status === 'published'}
+                  onClick={() => { setStatusFilter(f.value); setPage(1) }}
+                  aria-pressed={active}
                   style={{
-                    position: 'absolute',
-                    top: '0.5rem',
-                    right: '0.5rem',
-                    zIndex: 1,
-                    padding: '0.18rem 0.5rem',
-                    background: post.status === 'published'
-                      ? 'rgba(16,185,129,0.85)'
-                      : 'rgba(100,100,100,0.75)',
-                    backdropFilter: 'blur(4px)',
-                    borderRadius: '3px',
-                    fontSize: '0.58rem',
-                    letterSpacing: '0.12em',
-                    textTransform: 'uppercase' as const,
-                    color: '#fff',
-                    fontWeight: 600,
+                    background: 'none',
                     border: 'none',
-                    cursor: togglingIds.has(post.id) ? 'wait' : 'pointer',
-                    opacity: togglingIds.has(post.id) ? 0.5 : 1,
-                    fontFamily: 'inherit',
-                    transition: 'background 0.15s',
+                    borderBottom: active ? '1px solid var(--theme-text, #d6d1ce)' : '1px solid transparent',
+                    marginBottom: '-1px',
+                    padding: '1rem 0.25rem',
+                    fontFamily: 'Roboto Mono, monospace',
+                    fontSize: '0.6rem',
+                    letterSpacing: '0.22em',
+                    textTransform: 'uppercase',
+                    color: active ? 'var(--theme-text, #d6d1ce)' : 'var(--theme-text-dim, #9b9a9a)',
+                    cursor: 'pointer',
+                    whiteSpace: 'nowrap',
+                    transition: 'color 0.15s',
                   }}
                 >
-                  {post.status ?? 'draft'}
+                  {f.label}
                 </button>
-              </div>
+              </React.Fragment>
             )
           })}
+          {!loading && (
+            <span style={{ fontFamily: 'Roboto Mono, monospace', fontSize: '0.58rem', letterSpacing: '0.1em', color: 'var(--theme-text-dim, #9b9a9a)', opacity: 0.55, marginLeft: '1.25rem' }}>
+              {total} {total === 1 ? 'post' : 'posts'}
+            </span>
+          )}
+        </div>
+
+        <div style={{ display: 'flex', alignItems: 'center', gap: '0.75rem', padding: '0.75rem 0' }}>
+          {/* Search */}
+          <div style={{ position: 'relative', display: 'flex', alignItems: 'center' }}>
+            <svg width="14" height="14" viewBox="0 0 16 16" fill="none" aria-hidden="true" style={{ position: 'absolute', left: '0.5rem', color: 'var(--theme-text-dim, #9b9a9a)', pointerEvents: 'none' }}>
+              <circle cx="6.5" cy="6.5" r="5" stroke="currentColor" strokeWidth="1.25" />
+              <path d="M10.5 10.5L14 14" stroke="currentColor" strokeWidth="1.25" strokeLinecap="round" />
+            </svg>
+            <input
+              type="search"
+              placeholder="Search posts..."
+              aria-label="Search posts"
+              value={search}
+              onChange={e => setSearch(e.target.value)}
+              style={{
+                padding: '0.4rem 0.6rem 0.4rem 1.75rem',
+                background: 'var(--theme-elevation-100, #131313)',
+                border: '1px solid var(--theme-elevation-300, #2a2a2a)',
+                borderRadius: '3px',
+                color: 'var(--theme-text, #e6e1de)',
+                fontSize: '0.72rem',
+                fontFamily: 'Roboto Mono, monospace',
+                outline: 'none',
+                width: '180px',
+              }}
+            />
+          </div>
+
+          {/* New Post button */}
+          <Link
+            href="/admin/collections/posts/create"
+            style={{
+              display: 'inline-flex',
+              alignItems: 'center',
+              gap: '0.3rem',
+              padding: '0.45rem 1rem',
+              background: 'var(--theme-success-500, #10B981)',
+              color: '#fff',
+              borderRadius: '3px',
+              fontSize: '0.68rem',
+              fontFamily: 'Roboto Mono, monospace',
+              letterSpacing: '0.08em',
+              textTransform: 'uppercase',
+              fontWeight: 600,
+              textDecoration: 'none',
+              whiteSpace: 'nowrap',
+            }}
+          >
+            + New Post
+          </Link>
+        </div>
+      </div>
+
+      {/* Error alerts */}
+      {loadError && (
+        <div role="alert" style={{ margin: '1rem 1.5rem 0', padding: '0.55rem 0.75rem', background: 'rgba(248,113,113,0.08)', border: '1px solid rgba(248,113,113,0.25)', borderRadius: 3, fontSize: '0.78rem', color: '#f0a3a3' }}>
+          {loadError}
+        </div>
+      )}
+      {toggleError && (
+        <div role="alert" style={{ margin: '1rem 1.5rem 0', padding: '0.55rem 0.75rem', background: 'rgba(248,113,113,0.08)', border: '1px solid rgba(248,113,113,0.25)', borderRadius: 3, fontSize: '0.78rem', color: '#f0a3a3' }}>
+          {toggleError}
         </div>
       )}
 
-      {/* Pagination */}
-      {totalPages > 1 && !loading && (
-        <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', gap: '0.5rem', marginTop: '2rem' }}>
-          <button
-            style={{ padding: '0.375rem 0.75rem', background: 'var(--theme-elevation-100,#131313)', border: '1px solid var(--theme-elevation-300,#2a2a2a)', borderRadius: '4px', color: 'var(--theme-text,#e6e1de)', fontSize: '0.8rem', cursor: page === 1 ? 'default' : 'pointer', opacity: page === 1 ? 0.4 : 1 }}
-            onClick={() => setPage(p => Math.max(1, p - 1))}
-            disabled={page === 1}
-          >Prev</button>
-          <span style={{ fontSize: '0.8rem', color: 'var(--theme-text-dim,#9b9a9a)' }}>
-            {page} / {totalPages}
-          </span>
-          <button
-            style={{ padding: '0.375rem 0.75rem', background: 'var(--theme-elevation-100,#131313)', border: '1px solid var(--theme-elevation-300,#2a2a2a)', borderRadius: '4px', color: 'var(--theme-text,#e6e1de)', fontSize: '0.8rem', cursor: page === totalPages ? 'default' : 'pointer', opacity: page === totalPages ? 0.4 : 1 }}
-            onClick={() => setPage(p => Math.min(totalPages, p + 1))}
-            disabled={page === totalPages}
-          >Next</button>
-        </div>
-      )}
+      {/* Grid */}
+      <div style={{ padding: '1.75rem 1.5rem' }}>
+        {loading ? (
+          <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fill, minmax(280px, 1fr))', gap: '1rem' }}>
+            {Array.from({ length: 6 }).map((_, i) => (
+              <div key={i} style={{ background: 'var(--theme-elevation-200, #1a1a1a)', borderRadius: '4px', paddingBottom: '52%', animation: 'pulse 1.5s infinite' }} />
+            ))}
+          </div>
+        ) : posts.length === 0 ? (
+          <div style={{ textAlign: 'center', padding: '5rem 2rem', color: 'var(--theme-text-dim, #9b9a9a)', fontSize: '0.8rem', fontFamily: 'Roboto Mono, monospace', letterSpacing: '0.08em' }}>
+            {debouncedSearch || statusFilter !== 'all'
+              ? 'No posts match your filters.'
+              : 'No blog posts yet. Click New Post above to write your first one.'}
+          </div>
+        ) : (
+          <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fill, minmax(280px, 1fr))', gap: '1.5rem' }}>
+            {posts.map(post => {
+              const coverUrl = getCoverUrl(post)
+              return (
+                <div key={post.id} style={{ position: 'relative', background: 'var(--theme-elevation-100, #131313)', border: '1px solid var(--theme-elevation-200, #1a1a1a)', borderRadius: '4px', overflow: 'hidden', transition: 'border-color 0.15s, transform 0.15s' }} className="post-card">
+                  <Link href={`/admin/collections/posts/${post.id}`} style={{ display: 'block', textDecoration: 'none', color: 'inherit' }} title={post.title}>
+                    <div style={{ width: '100%', paddingBottom: '60%', position: 'relative', background: 'var(--theme-elevation-200, #1a1a1a)', overflow: 'hidden' }} className="post-card-img">
+                      {coverUrl ? (
+                        // eslint-disable-next-line @next/next/no-img-element
+                        <img src={coverUrl} alt={post.title} style={{ position: 'absolute', inset: 0, width: '100%', height: '100%', objectFit: 'cover', transition: 'transform 0.5s ease' }} loading="lazy" />
+                      ) : (
+                        <div style={{ position: 'absolute', inset: 0, display: 'flex', alignItems: 'center', justifyContent: 'center', fontSize: '2rem', color: 'var(--theme-elevation-400, #3a3a3a)' }}>&#9998;</div>
+                      )}
+                    </div>
+                    <div style={{ padding: '0.85rem 0.9rem 1rem' }}>
+                      <div style={{ fontFamily: 'Archivo, sans-serif', fontSize: '0.875rem', fontWeight: 500, lineHeight: 1.35, color: 'var(--theme-text, #e6e1de)', marginBottom: '0.3rem', display: '-webkit-box', WebkitLineClamp: 2, WebkitBoxOrient: 'vertical', overflow: 'hidden' }}>
+                        {post.title}
+                      </div>
+                      {post.publishedAt && (
+                        <div style={{ fontFamily: 'Roboto Mono, monospace', fontSize: '0.65rem', color: 'var(--theme-text-dim, #9b9a9a)', letterSpacing: '0.06em' }}>
+                          {formatDate(post.publishedAt)}
+                        </div>
+                      )}
+                      {post.excerpt && (
+                        <div style={{ fontFamily: 'Roboto Mono, monospace', fontSize: '0.68rem', color: 'var(--theme-text-dim, #9b9a9a)', marginTop: '0.4rem', lineHeight: 1.55, display: '-webkit-box', WebkitLineClamp: 2, WebkitBoxOrient: 'vertical', overflow: 'hidden' }}>
+                          {post.excerpt}
+                        </div>
+                      )}
+                    </div>
+                  </Link>
+
+                  {/* Publish/draft quick-toggle — sibling of Link, not child */}
+                  <button
+                    type="button"
+                    onClick={(e) => { void toggleStatus(e, post) }}
+                    disabled={togglingIds.has(post.id)}
+                    aria-busy={togglingIds.has(post.id)}
+                    aria-pressed={post.status === 'published'}
+                    aria-label={post.status === 'published' ? 'Published - click to revert to draft' : 'Draft - click to publish'}
+                    title={post.status === 'published' ? 'Published - click to revert to draft' : 'Draft - click to publish'}
+                    style={{
+                      position: 'absolute',
+                      top: '0.5rem',
+                      right: '0.5rem',
+                      zIndex: 1,
+                      padding: '0.18rem 0.5rem',
+                      background: post.status === 'published' ? 'rgba(16,185,129,0.85)' : 'rgba(100,100,100,0.75)',
+                      backdropFilter: 'blur(4px)',
+                      borderRadius: '3px',
+                      fontSize: '0.55rem',
+                      letterSpacing: '0.12em',
+                      textTransform: 'uppercase',
+                      color: '#fff',
+                      fontWeight: 600,
+                      border: 'none',
+                      cursor: togglingIds.has(post.id) ? 'wait' : 'pointer',
+                      opacity: togglingIds.has(post.id) ? 0.5 : 1,
+                      fontFamily: 'Roboto Mono, monospace',
+                      transition: 'background 0.15s',
+                    }}
+                  >
+                    {post.status ?? 'draft'}
+                  </button>
+                </div>
+              )
+            })}
+          </div>
+        )}
+
+        {/* Pagination */}
+        {totalPages > 1 && !loading && (
+          <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', gap: '0.5rem', marginTop: '2.5rem' }}>
+            <button
+              style={{ padding: '0.375rem 0.75rem', background: 'var(--theme-elevation-100,#131313)', border: '1px solid var(--theme-elevation-300,#2a2a2a)', borderRadius: '3px', color: 'var(--theme-text,#e6e1de)', fontSize: '0.72rem', fontFamily: 'Roboto Mono, monospace', cursor: page === 1 ? 'default' : 'pointer', opacity: page === 1 ? 0.4 : 1 }}
+              onClick={() => setPage(p => Math.max(1, p - 1))}
+              disabled={page === 1}
+            >Prev</button>
+            <span style={{ fontSize: '0.72rem', fontFamily: 'Roboto Mono, monospace', color: 'var(--theme-text-dim,#9b9a9a)' }}>
+              {page} / {totalPages}
+            </span>
+            <button
+              style={{ padding: '0.375rem 0.75rem', background: 'var(--theme-elevation-100,#131313)', border: '1px solid var(--theme-elevation-300,#2a2a2a)', borderRadius: '3px', color: 'var(--theme-text,#e6e1de)', fontSize: '0.72rem', fontFamily: 'Roboto Mono, monospace', cursor: page === totalPages ? 'default' : 'pointer', opacity: page === totalPages ? 0.4 : 1 }}
+              onClick={() => setPage(p => Math.min(totalPages, p + 1))}
+              disabled={page === totalPages}
+            >Next</button>
+          </div>
+        )}
+      </div>
     </div>
   )
 }

--- a/components/admin/PostGridView.tsx
+++ b/components/admin/PostGridView.tsx
@@ -352,64 +352,66 @@ export function PostGridView() {
           {posts.map(post => {
             const coverUrl = getCoverUrl(post)
             return (
-              <Link
-                key={post.id}
-                href={`/admin/collections/posts/${post.id}`}
-                style={css.card}
-                className="post-card"
-                title={post.title}
-              >
-                <div style={css.imgWrap}>
-                  {coverUrl ? (
-                    // eslint-disable-next-line @next/next/no-img-element
-                    <img src={coverUrl} alt={post.title} style={css.img} loading="lazy" />
-                  ) : (
-                    <div style={css.placeholder}>&#9998;</div>
-                  )}
-                  {/* Publish/Draft quick-toggle */}
-                  <button
-                    type="button"
-                    onClick={(e) => { void toggleStatus(e, post) }}
-                    disabled={togglingIds.has(post.id)}
-                    aria-busy={togglingIds.has(post.id)}
-                    title={post.status === 'published' ? 'Published - click to revert to draft' : 'Draft - click to publish'}
-                    aria-label={post.status === 'published' ? 'Published - click to revert to draft' : 'Draft - click to publish'}
-                    aria-pressed={post.status === 'published'}
-                    style={{
-                      position: 'absolute',
-                      top: '0.5rem',
-                      right: '0.5rem',
-                      padding: '0.18rem 0.5rem',
-                      background: post.status === 'published'
-                        ? 'rgba(16,185,129,0.85)'
-                        : 'rgba(100,100,100,0.75)',
-                      backdropFilter: 'blur(4px)',
-                      borderRadius: '3px',
-                      fontSize: '0.58rem',
-                      letterSpacing: '0.12em',
-                      textTransform: 'uppercase' as const,
-                      color: '#fff',
-                      fontWeight: 600,
-                      border: 'none',
-                      cursor: togglingIds.has(post.id) ? 'wait' : 'pointer',
-                      opacity: togglingIds.has(post.id) ? 0.5 : 1,
-                      fontFamily: 'inherit',
-                      transition: 'background 0.15s',
-                    }}
-                  >
-                    {post.status ?? 'draft'}
-                  </button>
-                </div>
-                <div style={css.cardBody}>
-                  <div style={css.cardTitle}>{post.title}</div>
-                  {post.publishedAt && (
-                    <div style={css.cardDate}>{formatDate(post.publishedAt)}</div>
-                  )}
-                  {post.excerpt && (
-                    <div style={css.cardExcerpt}>{post.excerpt}</div>
-                  )}
-                </div>
-              </Link>
+              <div key={post.id} style={{ ...css.card, position: 'relative' }} className="post-card">
+                {/* Full-card nav link — button sits above it via z-index */}
+                <Link
+                  href={`/admin/collections/posts/${post.id}`}
+                  style={{ display: 'block', textDecoration: 'none', color: 'inherit' }}
+                  title={post.title}
+                >
+                  <div style={css.imgWrap}>
+                    {coverUrl ? (
+                      // eslint-disable-next-line @next/next/no-img-element
+                      <img src={coverUrl} alt={post.title} style={css.img} loading="lazy" />
+                    ) : (
+                      <div style={css.placeholder}>&#9998;</div>
+                    )}
+                  </div>
+                  <div style={css.cardBody}>
+                    <div style={css.cardTitle}>{post.title}</div>
+                    {post.publishedAt && (
+                      <div style={css.cardDate}>{formatDate(post.publishedAt)}</div>
+                    )}
+                    {post.excerpt && (
+                      <div style={css.cardExcerpt}>{post.excerpt}</div>
+                    )}
+                  </div>
+                </Link>
+                {/* Publish/Draft quick-toggle — sibling of <a>, not child */}
+                <button
+                  type="button"
+                  onClick={(e) => { void toggleStatus(e, post) }}
+                  disabled={togglingIds.has(post.id)}
+                  aria-busy={togglingIds.has(post.id)}
+                  title={post.status === 'published' ? 'Published - click to revert to draft' : 'Draft - click to publish'}
+                  aria-label={post.status === 'published' ? 'Published - click to revert to draft' : 'Draft - click to publish'}
+                  aria-pressed={post.status === 'published'}
+                  style={{
+                    position: 'absolute',
+                    top: '0.5rem',
+                    right: '0.5rem',
+                    zIndex: 1,
+                    padding: '0.18rem 0.5rem',
+                    background: post.status === 'published'
+                      ? 'rgba(16,185,129,0.85)'
+                      : 'rgba(100,100,100,0.75)',
+                    backdropFilter: 'blur(4px)',
+                    borderRadius: '3px',
+                    fontSize: '0.58rem',
+                    letterSpacing: '0.12em',
+                    textTransform: 'uppercase' as const,
+                    color: '#fff',
+                    fontWeight: 600,
+                    border: 'none',
+                    cursor: togglingIds.has(post.id) ? 'wait' : 'pointer',
+                    opacity: togglingIds.has(post.id) ? 0.5 : 1,
+                    fontFamily: 'inherit',
+                    transition: 'background 0.15s',
+                  }}
+                >
+                  {post.status ?? 'draft'}
+                </button>
+              </div>
             )
           })}
         </div>


### PR DESCRIPTION
## Summary

- **Navbar**: Stacked brand mark, 2-row nav, Portfolio dropdown with Portraits/Family/Weddings sub-links, transparent until scrolled
- **Portfolio**: 3-tile landing page (`/portfolio`) with full-height category tiles + dedicated sub-routes (`/portraits`, `/family`, `/weddings`)
- **Blog**: Full Pixieset-style rebuild - large cover image hero, vertical BLOG label, filter bar, post grid with taped polaroid cards; fallback hero image when no posts published; booking CTA removed
- **Services**: Unique heading + 3-step "How It Works" process section
- **Website editor** (`/builder`): Replaced Puck-only page list with hardcoded SITE MENU matching real site nav hierarchy (Home, About, Portfolio + sub-pages, Services, Testimonials, Contact, Book, Blog); live right-pane iframe preview; Portfolio auto-expands on select
- **Admin PostGridView**: Pixieset-style horizontal filter nav + redesigned post cards
- **Tokens**: Dark mode is always default; light mode media query removed

## Linear

TYN-247, TYN-248, TYN-249, TYN-250, TYN-252

## Test plan

- [ ] Navbar transparent on load, opaque on scroll - all pages
- [ ] Portfolio dropdown shows Portraits / Family / Weddings
- [ ] `/portfolio` shows 3-tile landing; each tile routes correctly
- [ ] `/blog` shows cover hero image (fallback when no posts, post cover when posts exist)
- [ ] Blog filter bar and post grid render with published posts
- [ ] `/services` shows How It Works section
- [ ] `/builder` sidebar shows full SITE MENU including Book
- [ ] Clicking any sidebar item updates the right-pane iframe preview
- [ ] Clicking Portfolio auto-expands sub-pages
- [ ] Admin post list shows horizontal filter nav