### PR TITLE
TYN-255: Page hero consistency - services, contact, success, cancel, about

### DIFF
--- a/app/(site)/about/page.module.css
+++ b/app/(site)/about/page.module.css
@@ -13,6 +13,12 @@
   overflow: hidden;
 }
 
+.heroFallback {
+  background-image: url('/hero-background.jpg');
+  background-size: cover;
+  background-position: center top;
+}
+
 .heroImg {
   object-fit: cover;
   object-position: center top;

--- a/app/(site)/about/page.tsx
+++ b/app/(site)/about/page.tsx
@@ -90,7 +90,7 @@ export default async function AboutPage() {
       <JsonLd data={personSchema} />
 
       {/* Hero */}
-      <section className={styles.hero}>
+      <section className={`${styles.hero}${!headshotHeroUrl ? ` ${styles.heroFallback}` : ''}`}>
         {headshotHeroUrl && (
           <Image
             src={headshotHeroUrl}

--- a/app/(site)/book/cancel/page.module.css
+++ b/app/(site)/book/cancel/page.module.css
@@ -1,43 +1,67 @@
 .page {
   min-height: 100vh;
   background: var(--color-bg);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  padding: 6rem var(--padding-x);
 }
 
+/* ── Hero ────────────────────────────────────────────────── */
+
+.hero {
+  position: relative;
+  width: 100%;
+  height: clamp(260px, 42vh, 480px);
+  background-image: url('/hero-background.jpg');
+  background-size: cover;
+  background-position: center;
+  overflow: hidden;
+  display: flex;
+  align-items: flex-end;
+}
+
+.heroOverlay {
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(to top, rgba(12,12,12,0.75) 0%, rgba(12,12,12,0.2) 55%, transparent 100%);
+  z-index: 1;
+}
+
+.heroContent {
+  position: relative;
+  z-index: 2;
+  padding: 3rem var(--padding-x);
+}
+
+.heroEyebrow {
+  font-family: var(--font-body);
+  font-size: 0.68rem;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+  color: rgba(214,209,206,0.65);
+  margin: 0 0 0.5rem;
+}
+
+.heroHeading {
+  font-family: var(--font-display);
+  font-size: clamp(3rem, 7vw, 5.5rem);
+  font-weight: 400;
+  color: #fff;
+  margin: 0;
+  line-height: 1.05;
+}
+
+/* ── Content ────────────────────────────────────────────── */
+
 .content {
-  max-width: 520px;
-  text-align: center;
+  max-width: 600px;
+  margin: 0 auto;
+  padding: 5rem var(--padding-x) 7rem;
   display: flex;
   flex-direction: column;
-  align-items: center;
   gap: 1.5rem;
 }
 
-.eyebrow {
-  font-family: var(--font-mono);
-  font-size: 0.65rem;
-  font-weight: 400;
-  letter-spacing: 0.25em;
-  text-transform: uppercase;
-  color: var(--color-detail);
-  margin: 0;
-}
-
-.heading {
-  font-family: var(--font-display);
-  font-size: clamp(3rem, 8vw, 5rem);
-  font-weight: 400;
-  color: var(--color-heading);
-  margin: 0;
-  line-height: 1.1;
-}
-
 .body {
-  font-family: var(--font-mono);
-  font-size: 0.82rem;
+  font-family: var(--font-body);
+  font-size: 0.875rem;
   font-weight: 300;
   line-height: 1.85;
   color: var(--color-body);
@@ -46,22 +70,23 @@
 
 .actions {
   display: flex;
-  flex-direction: column;
   align-items: center;
-  gap: 1rem;
+  gap: 1.5rem;
+  flex-wrap: wrap;
   margin-top: 0.5rem;
 }
 
 .tryAgainBtn {
-  font-family: var(--font-mono);
+  font-family: var(--font-heading);
   font-size: 0.7rem;
-  font-weight: 400;
-  letter-spacing: 0.2em;
+  font-weight: 600;
+  letter-spacing: 0.18em;
   text-transform: uppercase;
   color: var(--color-btn-text);
   background: var(--color-btn-bg);
   padding: 0.9rem 2.5rem;
   text-decoration: none;
+  display: inline-block;
   transition: background 0.2s ease;
 }
 
@@ -70,10 +95,10 @@
 }
 
 .contactLink {
-  font-family: var(--font-mono);
-  font-size: 0.68rem;
+  font-family: var(--font-body);
+  font-size: 0.72rem;
   font-weight: 300;
-  letter-spacing: 0.1em;
+  letter-spacing: 0.08em;
   color: var(--color-detail);
   text-decoration: underline;
   text-underline-offset: 3px;

--- a/app/(site)/book/cancel/page.tsx
+++ b/app/(site)/book/cancel/page.tsx
@@ -10,9 +10,14 @@ export const metadata: Metadata = {
 export default function BookCancelPage() {
   return (
     <main className={styles.page}>
+      <section className={styles.hero} aria-label="Payment cancelled">
+        <div className={styles.heroOverlay} />
+        <div className={styles.heroContent}>
+          <p className={styles.heroEyebrow}>No worries</p>
+          <h1 className={styles.heroHeading}>Payment Cancelled.</h1>
+        </div>
+      </section>
       <div className={styles.content}>
-        <p className={styles.eyebrow}>No worries</p>
-        <h1 className={styles.heading}>Payment Cancelled.</h1>
         <p className={styles.body}>
           Your booking wasn&apos;t completed. Nothing was charged. Your date hasn&apos;t been held yet.
         </p>

--- a/app/(site)/book/success/page.module.css
+++ b/app/(site)/book/success/page.module.css
@@ -1,43 +1,67 @@
 .page {
   min-height: 100vh;
   background: var(--color-bg);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  padding: 6rem var(--padding-x);
 }
 
+/* ── Hero ────────────────────────────────────────────────── */
+
+.hero {
+  position: relative;
+  width: 100%;
+  height: clamp(260px, 42vh, 480px);
+  background-image: url('/hero-background.jpg');
+  background-size: cover;
+  background-position: center;
+  overflow: hidden;
+  display: flex;
+  align-items: flex-end;
+}
+
+.heroOverlay {
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(to top, rgba(12,12,12,0.75) 0%, rgba(12,12,12,0.2) 55%, transparent 100%);
+  z-index: 1;
+}
+
+.heroContent {
+  position: relative;
+  z-index: 2;
+  padding: 3rem var(--padding-x);
+}
+
+.heroEyebrow {
+  font-family: var(--font-body);
+  font-size: 0.68rem;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+  color: rgba(214,209,206,0.65);
+  margin: 0 0 0.5rem;
+}
+
+.heroHeading {
+  font-family: var(--font-display);
+  font-size: clamp(3rem, 7vw, 5.5rem);
+  font-weight: 400;
+  color: #fff;
+  margin: 0;
+  line-height: 1.05;
+}
+
+/* ── Content ────────────────────────────────────────────── */
+
 .content {
-  max-width: 520px;
-  text-align: center;
+  max-width: 600px;
+  margin: 0 auto;
+  padding: 5rem var(--padding-x) 7rem;
   display: flex;
   flex-direction: column;
-  align-items: center;
   gap: 1.5rem;
 }
 
-.eyebrow {
-  font-family: var(--font-mono);
-  font-size: 0.65rem;
-  font-weight: 400;
-  letter-spacing: 0.25em;
-  text-transform: uppercase;
-  color: var(--color-detail);
-  margin: 0;
-}
-
-.heading {
-  font-family: var(--font-display);
-  font-size: clamp(3rem, 8vw, 5rem);
-  font-weight: 400;
-  color: var(--color-heading);
-  margin: 0;
-  line-height: 1.1;
-}
-
 .body {
-  font-family: var(--font-mono);
-  font-size: 0.82rem;
+  font-family: var(--font-body);
+  font-size: 0.875rem;
   font-weight: 300;
   line-height: 1.85;
   color: var(--color-body);
@@ -46,22 +70,23 @@
 
 .actions {
   display: flex;
-  flex-direction: column;
   align-items: center;
-  gap: 1rem;
+  gap: 1.5rem;
+  flex-wrap: wrap;
   margin-top: 0.5rem;
 }
 
 .homeBtn {
-  font-family: var(--font-mono);
+  font-family: var(--font-heading);
   font-size: 0.7rem;
-  font-weight: 400;
-  letter-spacing: 0.2em;
+  font-weight: 600;
+  letter-spacing: 0.18em;
   text-transform: uppercase;
   color: var(--color-btn-text);
   background: var(--color-btn-bg);
   padding: 0.9rem 2.5rem;
   text-decoration: none;
+  display: inline-block;
   transition: background 0.2s ease;
 }
 
@@ -70,10 +95,10 @@
 }
 
 .contactLink {
-  font-family: var(--font-mono);
-  font-size: 0.68rem;
+  font-family: var(--font-body);
+  font-size: 0.72rem;
   font-weight: 300;
-  letter-spacing: 0.1em;
+  letter-spacing: 0.08em;
   color: var(--color-detail);
   text-decoration: underline;
   text-underline-offset: 3px;

--- a/app/(site)/book/success/page.tsx
+++ b/app/(site)/book/success/page.tsx
@@ -10,11 +10,16 @@ export const metadata: Metadata = {
 export default function BookSuccessPage() {
   return (
     <main className={styles.page}>
+      <section className={styles.hero} aria-label="Booking confirmed">
+        <div className={styles.heroOverlay} />
+        <div className={styles.heroContent}>
+          <p className={styles.heroEyebrow}>You&apos;re on the calendar</p>
+          <h1 className={styles.heroHeading}>Deposit Received.</h1>
+        </div>
+      </section>
       <div className={styles.content}>
-        <p className={styles.eyebrow}>You&apos;re on the calendar</p>
-        <h1 className={styles.heading}>Deposit Received.</h1>
         <p className={styles.body}>
-          Your date is officially held. Check your inbox for a confirmation email;
+          Your date is officially held. Check your inbox for a confirmation email.
           I&apos;ll be in touch shortly to finalize the details and start planning your session.
         </p>
         <p className={styles.body}>

--- a/app/(site)/contact/page.module.css
+++ b/app/(site)/contact/page.module.css
@@ -1,14 +1,64 @@
 .main {
   min-height: 100vh;
-  padding: 8rem var(--padding-x) 5rem;
   background: var(--color-bg);
+}
+
+/* ── Hero ────────────────────────────────────────────────── */
+
+.hero {
+  position: relative;
+  width: 100%;
+  height: clamp(240px, 38vh, 420px);
+  background-image: url('/hero-background.jpg');
+  background-size: cover;
+  background-position: center;
+  overflow: hidden;
+  display: flex;
+  align-items: flex-end;
+}
+
+.heroOverlay {
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(to top, rgba(12,12,12,0.65) 0%, transparent 60%);
+  z-index: 1;
+}
+
+.heroContent {
+  position: relative;
+  z-index: 2;
+  padding: 2.5rem var(--padding-x);
+}
+
+.heroEyebrow {
+  font-family: var(--font-body);
+  font-size: 0.68rem;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+  color: rgba(214,209,206,0.65);
+  margin: 0 0 0.4rem;
+}
+
+.heroHeading {
+  font-family: var(--font-display);
+  font-size: clamp(2.5rem, 5vw, 4rem);
+  font-weight: 400;
+  color: #fff;
+  margin: 0;
+  line-height: 1.1;
+}
+
+.content {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 5rem var(--padding-x);
 }
 
 /* ── OOO banner ──────────────────────────────────────────── */
 
 .oooBanner {
   max-width: 1200px;
-  margin: 0 auto 3rem;
+  margin: 2rem auto 0;
   padding: 1rem 1.5rem;
   border: 1px solid rgba(214, 209, 206, 0.15);
   border-left: 3px solid var(--color-detail);
@@ -25,8 +75,6 @@
 }
 
 .grid {
-  max-width: 1200px;
-  margin: 0 auto;
   display: grid;
   grid-template-columns: 1fr 1.2fr;
   gap: 6rem;
@@ -37,7 +85,7 @@
 
 .editorial {
   position: sticky;
-  top: 8rem;
+  top: 6rem;
 }
 
 .eyebrow {
@@ -47,16 +95,7 @@
   letter-spacing: 0.25em;
   text-transform: uppercase;
   color: var(--color-detail);
-  margin: 0 0 1.25rem;
-}
-
-.heading {
-  font-family: var(--font-display);
-  font-size: clamp(3rem, 6vw, 5rem);
-  font-weight: 400;
-  line-height: 1.1;
-  color: var(--color-heading);
-  margin: 0 0 1.75rem;
+  margin: 0 0 1.5rem;
 }
 
 .body {
@@ -105,15 +144,15 @@
   .grid {
     gap: 3rem;
   }
-
-  .heading {
-    font-size: clamp(2.5rem, 5vw, 4rem);
-  }
 }
 
 @media (max-width: 768px) {
-  .main {
-    padding: 6rem 1.5rem 4rem;
+  .hero {
+    height: clamp(200px, 30vh, 320px);
+  }
+
+  .content {
+    padding: 3rem var(--padding-x) 4rem;
   }
 
   .grid {
@@ -123,10 +162,6 @@
 
   .editorial {
     position: static;
-  }
-
-  .heading {
-    font-size: clamp(2.5rem, 10vw, 3.5rem);
   }
 
   .body {

--- a/app/(site)/contact/page.tsx
+++ b/app/(site)/contact/page.tsx
@@ -97,37 +97,47 @@ export default async function ContactPage() {
   return (
     <main className={styles.main}>
       <JsonLd data={contactPageSchema} />
-      {oooMessage && (
-        <div className={styles.oooBanner} role="note" aria-label="Availability notice">
-          <p className={styles.oooMessage}>{oooMessage}</p>
-        </div>
-      )}
-      <div className={styles.grid}>
 
-        {/* Left - editorial */}
-        <div className={styles.editorial}>
-          <p className={styles.eyebrow}>Let&apos;s Connect</p>
-          <h1 className={styles.heading}>Let&apos;s Create<br />Something<br />Beautiful</h1>
-          <p className={styles.body}>
-            Every love story, milestone, and moment deserves to be told with intention.
-            Fill out the form and I&apos;ll be in touch within 48 hours.
-          </p>
-          <div className={styles.directContact}>
-            <a href={`mailto:${CONTACT_EMAIL}`} className={styles.contactLink}>
-              {CONTACT_EMAIL}
-            </a>
-            <span className={styles.contactDivider}>·</span>
-            <a href="https://instagram.com/tynnellhollinsphotography" className={styles.contactLink} target="_blank" rel="noopener noreferrer">
-              @tynnellhollinsphotography
-            </a>
+      {/* Hero */}
+      <section className={styles.hero} aria-label="Contact">
+        <div className={styles.heroOverlay} />
+        <div className={styles.heroContent}>
+          <p className={styles.heroEyebrow}>Let&apos;s Connect</p>
+          <p className={styles.heroHeading}>Let&apos;s Create Something Beautiful</p>
+        </div>
+      </section>
+
+      <div className={styles.content}>
+        {oooMessage && (
+          <div className={styles.oooBanner} role="note" aria-label="Availability notice">
+            <p className={styles.oooMessage}>{oooMessage}</p>
           </div>
-        </div>
+        )}
+        <div className={styles.grid}>
 
-        {/* Right - form */}
-        <div className={styles.formColumn}>
-          <ContactForm minDate={minDate} maxDate={maxDate} />
-        </div>
+          {/* Left - editorial */}
+          <div className={styles.editorial}>
+            <p className={styles.eyebrow}>Send an Inquiry</p>
+            <p className={styles.body}>
+              Every love story, milestone, and moment deserves to be told with intention.
+              Fill out the form and I&apos;ll be in touch within 48 hours.
+            </p>
+            <div className={styles.directContact}>
+              <a href={`mailto:${CONTACT_EMAIL}`} className={styles.contactLink}>
+                {CONTACT_EMAIL}
+              </a>
+              <a href="https://instagram.com/tynnellhollinsphotography" className={styles.contactLink} target="_blank" rel="noopener noreferrer">
+                @tynnellhollinsphotography
+              </a>
+            </div>
+          </div>
 
+          {/* Right - form */}
+          <div className={styles.formColumn}>
+            <ContactForm minDate={minDate} maxDate={maxDate} />
+          </div>
+
+        </div>
       </div>
     </main>
   )

--- a/app/(site)/services/page.module.css
+++ b/app/(site)/services/page.module.css
@@ -6,38 +6,74 @@
 /* ── Hero ────────────────────────────────────────────────── */
 
 .hero {
-  padding: calc(var(--padding-block) * 2) var(--padding-x) 5rem;
-  max-width: 860px;
-  margin: 0 auto;
-  text-align: center;
-  border-bottom: 1px solid var(--color-border-solid);
+  position: relative;
+  width: 100%;
+  height: clamp(320px, 55vh, 580px);
+  background-image: url('/hero-background.jpg');
+  background-size: cover;
+  background-position: center;
+  overflow: hidden;
+  display: flex;
+  align-items: flex-end;
+}
+
+.heroOverlay {
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(to top, rgba(12,12,12,0.72) 0%, rgba(12,12,12,0.18) 55%, transparent 100%);
+  z-index: 1;
+}
+
+.heroContent {
+  position: relative;
+  z-index: 2;
+  padding: 3rem var(--padding-x);
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 2rem;
+  width: 100%;
+}
+
+.heroTextBox {
+  background: var(--color-bg-overlay);
+  padding: 1.25rem 2rem;
+  backdrop-filter: blur(8px);
 }
 
 .eyebrow {
   font-family: var(--font-body);
-  font-size: 0.7rem;
-  letter-spacing: 0.25em;
+  font-size: 0.68rem;
+  letter-spacing: 0.22em;
   text-transform: uppercase;
-  color: var(--color-detail);
-  margin-bottom: 1.25rem;
+  color: rgba(214,209,206,0.7);
+  margin: 0 0 0.5rem;
 }
 
 .heroHeading {
-  font-family: var(--font-display);
-  font-size: clamp(2.5rem, 6vw, 5rem);
-  font-weight: 400;
-  color: var(--color-heading);
-  line-height: 1.1;
-  margin-bottom: 1.5rem;
+  font-family: var(--font-heading);
+  font-size: clamp(2rem, 4.5vw, 3.5rem);
+  font-weight: 700;
+  color: #fff;
+  line-height: 1;
+  margin: 0;
+  letter-spacing: -0.01em;
+}
+
+.heroDescBox {
+  background: var(--color-bg-overlay);
+  padding: 1.25rem 1.75rem;
+  backdrop-filter: blur(8px);
+  max-width: 380px;
 }
 
 .heroSub {
-  font-family: var(--font-prose);
-  font-size: 1rem;
-  line-height: 1.75;
-  color: var(--color-detail);
-  max-width: 520px;
-  margin: 0 auto;
+  font-family: var(--font-body);
+  font-size: 0.75rem;
+  line-height: 1.8;
+  color: rgba(214,209,206,0.9);
+  margin: 0;
+  letter-spacing: 0.03em;
 }
 
 /* ── How It Works ────────────────────────────────────────── */
@@ -359,10 +395,20 @@
 
 /* ── Responsive ──────────────────────────────────────────── */
 
-@media (max-width: 768px) {
-  .hero {
-    padding-bottom: 3.5rem;
+@media (max-width: 640px) {
+  .heroContent {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.75rem;
+    padding: 1.5rem var(--padding-x);
   }
+
+  .heroDescBox {
+    max-width: 100%;
+  }
+}
+
+@media (max-width: 768px) {
 
   .process {
     padding: 4rem var(--padding-x);

--- a/app/(site)/services/page.tsx
+++ b/app/(site)/services/page.tsx
@@ -50,12 +50,19 @@ export default async function ServicesPage() {
       {servicesSchema && <JsonLd data={servicesSchema} />}
 
       {/* Hero */}
-      <section className={styles.hero}>
-        <p className={styles.eyebrow}>Services</p>
-        <h1 className={styles.heroHeading}>{"Every Session,"}<br />{"Crafted for You"}</h1>
-        <p className={styles.heroSub}>
-          {"Packages designed to give you images you'll treasure for a lifetime. Choose the experience that fits your story."}
-        </p>
+      <section className={styles.hero} aria-label="Services">
+        <div className={styles.heroOverlay} />
+        <div className={styles.heroContent}>
+          <div className={styles.heroTextBox}>
+            <p className={styles.eyebrow}>Services</p>
+            <h1 className={styles.heroHeading}>{"Every Session,"}<br />{"Crafted for You"}</h1>
+          </div>
+          <div className={styles.heroDescBox}>
+            <p className={styles.heroSub}>
+              {"Packages designed to give you images you'll treasure for a lifetime. Choose the experience that fits your story."}
+            </p>
+          </div>
+        </div>
       </section>
 
       {/* How It Works */}


### PR DESCRIPTION
## Summary

Every public page now opens with a full-bleed hero image instead of a raw top padding or centered black box.

- **About** (`/about`): Added `heroFallback` CSS class - shows `/hero-background.jpg` when no headshot is loaded in Payload (fixes the completely black hero visible locally and in empty-state deploys). On Vercel with a real headshot uploaded, the actual photo shows as before.
- **Services** (`/services`): Replaced the text-only centered header with a full-bleed image hero matching the portfolio category layout - left title box (SERVICES eyebrow + bold heading) and right description box, both with backdrop-blur overlays.
- **Contact** (`/contact`): Added compact hero (`clamp(240px, 38vh, 420px)`) with "Let's Connect / Let's Create Something Beautiful" overlay. Removed the raw `8rem` top padding approach. The editorial + form split layout lives below the hero inside a `.content` wrapper. The `<h1>` moved into the hero; the editorial column now shows the eyebrow and body copy.
- **Book success** (`/book/success`): Replaced centered full-viewport layout with hero + content-below. "YOU'RE ON THE CALENDAR / Deposit Received." in the hero, confirmation text and CTAs in a readable content section.
- **Book cancel** (`/book/cancel`): Same treatment. "NO WORRIES / Payment Cancelled." in the hero.

## Test plan

- [ ] `/about` with no headshot in Payload: fallback hero image visible, "Tynnell Hollins" name renders over it
- [ ] `/about` on Vercel with headshot uploaded: real photo shows (hero fallback only applies when `headshotHeroUrl` is null)
- [ ] `/services`: hero image visible, title/description boxes with backdrop-blur, "How It Works" and service cards below
- [ ] `/contact`: hero with script heading, editorial column + form grid below, OOO banner shows when active
- [ ] `/book/success`: hero with "Deposit Received." + body copy and buttons in content section
- [ ] `/book/cancel`: hero with "Payment Cancelled." + body copy and buttons in content section
- [ ] All pages: mobile at 390px stacks correctly