### PR TITLE
feat(admin): Google SSO on Payload login page

### DIFF
--- a/app/(payload)/admin/importMap.js
+++ b/app/(payload)/admin/importMap.js
@@ -40,6 +40,7 @@ import { AboutViewOnSiteButton as AboutViewOnSiteButton_e4e233e4cbe47762c0d80a0c
 import { OooWarnings as OooWarnings_24882b9d221e8df452e06e4f5a939af9 } from '../../../components/admin/OooWarnings'
 import { AdminIcon as AdminIcon_a9476a6fd6a5c40a275ff80f24127c7c } from '../../../components/admin/AdminIcon'
 import { AdminLogo as AdminLogo_56b58cfdfd9d12efeac26d6201d62c94 } from '../../../components/admin/AdminLogo'
+import { GoogleSignInButton as GoogleSignInButton_61e8baa09a72c73bfc7f6c4c790b8986 } from '../../../components/admin/GoogleSignInButton'
 import { ForcePasswordChange as ForcePasswordChange_81ef321150d17489172d7270011dd4ba } from '../../../components/admin/ForcePasswordChange'
 import { S3ClientUploadHandler as S3ClientUploadHandler_f97aa6c64367fa259c5bc0567239ef24 } from '@payloadcms/storage-s3/client'
 import { Dashboard as Dashboard_f0f8d4a7080efd2cd25bb6be37c094c0 } from '../../../components/admin/Dashboard'
@@ -89,6 +90,7 @@ export const importMap = {
   "./components/admin/OooWarnings#OooWarnings": OooWarnings_24882b9d221e8df452e06e4f5a939af9,
   "./components/admin/AdminIcon#AdminIcon": AdminIcon_a9476a6fd6a5c40a275ff80f24127c7c,
   "./components/admin/AdminLogo#AdminLogo": AdminLogo_56b58cfdfd9d12efeac26d6201d62c94,
+  "./components/admin/GoogleSignInButton#GoogleSignInButton": GoogleSignInButton_61e8baa09a72c73bfc7f6c4c790b8986,
   "./components/admin/ForcePasswordChange#ForcePasswordChange": ForcePasswordChange_81ef321150d17489172d7270011dd4ba,
   "@payloadcms/storage-s3/client#S3ClientUploadHandler": S3ClientUploadHandler_f97aa6c64367fa259c5bc0567239ef24,
   "./components/admin/Dashboard#Dashboard": Dashboard_f0f8d4a7080efd2cd25bb6be37c094c0,

--- a/app/api/auth/google/callback/route.ts
+++ b/app/api/auth/google/callback/route.ts
@@ -1,0 +1,115 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { getPayload } from 'payload'
+import config from '@payload-config'
+import { SignJWT } from 'jose'
+
+export const runtime = 'nodejs'
+
+const ALLOWED_EMAILS = new Set([
+  'hello@tynnellhollinsphotography.com',
+  'xandermv2@gmail.com',
+])
+
+export async function GET(request: NextRequest) {
+  const { searchParams } = request.nextUrl
+  const code = searchParams.get('code')
+  const state = searchParams.get('state')
+  const storedState = request.cookies.get('google_oauth_state')?.value
+  const origin = request.nextUrl.origin
+
+  const fail = (reason: string) =>
+    NextResponse.redirect(new URL(`/admin?sso_error=${reason}`, origin))
+
+  if (!code || !state || !storedState || state !== storedState) {
+    return fail('invalid_state')
+  }
+
+  try {
+    // Exchange code for tokens
+    const tokenRes = await fetch('https://oauth2.googleapis.com/token', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      body: new URLSearchParams({
+        code,
+        client_id: process.env.GOOGLE_CLIENT_ID ?? '',
+        client_secret: process.env.GOOGLE_CLIENT_SECRET ?? '',
+        redirect_uri: `${origin}/api/auth/google/callback`,
+        grant_type: 'authorization_code',
+      }),
+    })
+
+    const tokenData = await tokenRes.json() as { id_token?: string; error?: string }
+
+    if (!tokenRes.ok || !tokenData.id_token) {
+      console.error('Google token exchange failed:', tokenData)
+      return fail('token_exchange_failed')
+    }
+
+    // Verify id_token with Google's tokeninfo endpoint
+    const infoRes = await fetch(
+      `https://oauth2.googleapis.com/tokeninfo?id_token=${tokenData.id_token}`
+    )
+    const userInfo = await infoRes.json() as {
+      email?: string
+      aud?: string
+      email_verified?: string
+    }
+
+    if (
+      !infoRes.ok ||
+      userInfo.aud !== process.env.GOOGLE_CLIENT_ID ||
+      userInfo.email_verified !== 'true'
+    ) {
+      return fail('invalid_token')
+    }
+
+    const email = (userInfo.email ?? '').toLowerCase()
+
+    if (!ALLOWED_EMAILS.has(email)) {
+      return fail('unauthorized')
+    }
+
+    // Find the Payload user by email
+    const payload = await getPayload({ config })
+    const { docs } = await payload.find({
+      collection: 'users',
+      where: { email: { equals: email } },
+      limit: 1,
+    })
+
+    if (!docs.length) {
+      return fail('user_not_found')
+    }
+
+    const user = docs[0]
+
+    // Sign a JWT in the same format Payload uses internally
+    const secret = new TextEncoder().encode(process.env.PAYLOAD_SECRET ?? '')
+    const token = await new SignJWT({
+      id: user.id,
+      collection: 'users',
+      email: user.email,
+    })
+      .setProtectedHeader({ alg: 'HS256' })
+      .setIssuedAt()
+      .setExpirationTime('2h')
+      .sign(secret)
+
+    const response = NextResponse.redirect(new URL('/admin', origin))
+
+    response.cookies.set('payload-token', token, {
+      httpOnly: true,
+      secure: process.env.NODE_ENV === 'production',
+      maxAge: 60 * 60 * 2, // 2 hours
+      path: '/',
+      sameSite: 'lax',
+    })
+
+    response.cookies.delete('google_oauth_state')
+
+    return response
+  } catch (err) {
+    console.error('Google SSO callback error:', err)
+    return fail('server_error')
+  }
+}

--- a/app/api/auth/google/route.ts
+++ b/app/api/auth/google/route.ts
@@ -1,0 +1,32 @@
+import { NextRequest, NextResponse } from 'next/server'
+
+export const runtime = 'nodejs'
+
+export async function GET(request: NextRequest) {
+  const origin = request.nextUrl.origin
+  const state = crypto.randomUUID()
+
+  const params = new URLSearchParams({
+    client_id: process.env.GOOGLE_CLIENT_ID ?? '',
+    redirect_uri: `${origin}/api/auth/google/callback`,
+    response_type: 'code',
+    scope: 'openid email profile',
+    state,
+    access_type: 'online',
+    prompt: 'select_account',
+  })
+
+  const response = NextResponse.redirect(
+    `https://accounts.google.com/o/oauth2/v2/auth?${params}`
+  )
+
+  response.cookies.set('google_oauth_state', state, {
+    httpOnly: true,
+    secure: process.env.NODE_ENV === 'production',
+    maxAge: 60 * 10,
+    path: '/',
+    sameSite: 'lax',
+  })
+
+  return response
+}

--- a/components/admin/GoogleSignInButton.tsx
+++ b/components/admin/GoogleSignInButton.tsx
@@ -37,6 +37,7 @@ export function GoogleSignInButton() {
         </p>
       )}
 
+      {/* eslint-disable-next-line @next/next/no-html-link-for-pages */}
       <a
         href="/api/auth/google"
         style={{

--- a/components/admin/GoogleSignInButton.tsx
+++ b/components/admin/GoogleSignInButton.tsx
@@ -1,0 +1,127 @@
+'use client'
+
+// Rendered by Payload's beforeLogin slot - appears above the email/password form
+export function GoogleSignInButton() {
+  const ssoError =
+    typeof window !== 'undefined'
+      ? new URLSearchParams(window.location.search).get('sso_error')
+      : null
+
+  const errorMessages: Record<string, string> = {
+    unauthorized: 'That Google account is not authorized to access this admin.',
+    user_not_found: 'No admin account found for that Google email.',
+    invalid_token: 'Google sign-in failed. Please try again.',
+    token_exchange_failed: 'Could not reach Google. Please try again.',
+    invalid_state: 'Sign-in was interrupted. Please try again.',
+    server_error: 'Something went wrong. Please try again.',
+  }
+
+  return (
+    <div style={{ marginBottom: '1.5rem' }}>
+      {ssoError && (
+        <p
+          role="alert"
+          style={{
+            marginBottom: '1rem',
+            padding: '0.75rem 1rem',
+            background: 'rgba(220, 38, 38, 0.12)',
+            border: '1px solid rgba(220, 38, 38, 0.35)',
+            borderRadius: '3px',
+            color: '#fca5a5',
+            fontSize: '0.8125rem',
+            fontFamily: 'var(--font-body, sans-serif)',
+            lineHeight: '1.5',
+          }}
+        >
+          {errorMessages[ssoError] ?? errorMessages.server_error}
+        </p>
+      )}
+
+      <a
+        href="/api/auth/google"
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          gap: '0.625rem',
+          width: '100%',
+          padding: '0.75rem 1rem',
+          background: '#fff',
+          color: '#1f1f1f',
+          fontSize: '0.875rem',
+          fontFamily: 'var(--font-body, sans-serif)',
+          fontWeight: 500,
+          textDecoration: 'none',
+          borderRadius: '3px',
+          border: '1px solid #e0e0e0',
+          transition: 'background 0.15s ease, box-shadow 0.15s ease',
+        }}
+        onMouseEnter={(e) => {
+          const el = e.currentTarget
+          el.style.background = '#f5f5f5'
+          el.style.boxShadow = '0 1px 3px rgba(0,0,0,0.12)'
+        }}
+        onMouseLeave={(e) => {
+          const el = e.currentTarget
+          el.style.background = '#fff'
+          el.style.boxShadow = 'none'
+        }}
+      >
+        <GoogleLogo />
+        Sign in with Google
+      </a>
+
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: '0.75rem',
+          margin: '1.25rem 0 0',
+        }}
+      >
+        <hr style={{ flex: 1, border: 'none', borderTop: '1px solid rgba(255,255,255,0.1)' }} />
+        <span
+          style={{
+            fontSize: '0.7rem',
+            color: 'rgba(255,255,255,0.4)',
+            fontFamily: 'var(--font-body, sans-serif)',
+            letterSpacing: '0.08em',
+            textTransform: 'uppercase',
+          }}
+        >
+          or sign in with email
+        </span>
+        <hr style={{ flex: 1, border: 'none', borderTop: '1px solid rgba(255,255,255,0.1)' }} />
+      </div>
+    </div>
+  )
+}
+
+function GoogleLogo() {
+  return (
+    <svg
+      aria-hidden="true"
+      width="18"
+      height="18"
+      viewBox="0 0 18 18"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M17.64 9.2c0-.637-.057-1.251-.164-1.84H9v3.481h4.844c-.209 1.125-.843 2.078-1.796 2.717v2.258h2.908c1.702-1.567 2.684-3.875 2.684-6.615z"
+        fill="#4285F4"
+      />
+      <path
+        d="M9 18c2.43 0 4.467-.806 5.956-2.18l-2.908-2.259c-.806.54-1.837.86-3.048.86-2.344 0-4.328-1.584-5.036-3.711H.957v2.332A8.997 8.997 0 0 0 9 18z"
+        fill="#34A853"
+      />
+      <path
+        d="M3.964 10.71A5.41 5.41 0 0 1 3.682 9c0-.593.102-1.17.282-1.71V4.958H.957A8.996 8.996 0 0 0 0 9c0 1.452.348 2.827.957 4.042l3.007-2.332z"
+        fill="#FBBC05"
+      />
+      <path
+        d="M9 3.58c1.321 0 2.508.454 3.44 1.345l2.582-2.58C13.463.891 11.426 0 9 0A8.997 8.997 0 0 0 .957 4.958L3.964 6.29C4.672 4.163 6.656 3.58 9 3.58z"
+        fill="#EA4335"
+      />
+    </svg>
+  )
+}

--- a/payload.config.ts
+++ b/payload.config.ts
@@ -102,6 +102,7 @@ export default buildConfig({
     },
     components: {
       providers: ['./components/admin/ForcePasswordChange#ForcePasswordChange'],
+      beforeLogin: ['./components/admin/GoogleSignInButton#GoogleSignInButton'],
       graphics: {
         Logo: './components/admin/AdminLogo#AdminLogo',
         Icon: './components/admin/AdminIcon#AdminIcon',


### PR DESCRIPTION
## Summary
- Adds a "Sign in with Google" button above the email/password form on /admin
- OAuth flow: /api/auth/google (initiate) -> Google -> /api/auth/google/callback (verify + session)
- Allowlist restricts SSO to the two known admin emails only; all other Google accounts get an error
- CSRF protected with a short-lived state cookie
- Signs a Payload-compatible JWT (HS256, PAYLOAD_SECRET) and sets payload-token cookie
- Password login stays intact as the fallback below the divider
- Error messages surface on the login page via ?sso_error= query param

## Env vars needed in Vercel before this is live
- GOOGLE_CLIENT_ID
- GOOGLE_CLIENT_SECRET

## Google Cloud Console setup (must be done before merging)
1. APIs & Services -> Credentials -> Create OAuth 2.0 Client ID (Web application)
2. Authorized redirect URIs:
   - https://tynnellhollinsphotography.com/api/auth/google/callback
   - http://localhost:3000/api/auth/google/callback
3. Add the Client ID and Secret to Vercel env vars

## Test plan
- [ ] Merge only after GOOGLE_CLIENT_ID and GOOGLE_CLIENT_SECRET are in Vercel
- [ ] Click Sign in with Google on /admin - should redirect to Google picker
- [ ] Sign in as xandermv2@gmail.com - should land on /admin dashboard
- [ ] Sign in as Hello@TynnellHollinsPhotography.com - should land on /admin dashboard
- [ ] Sign in with an unauthorized Google account - should show error message on login page
- [ ] Password login still works normally