### PR TITLE
feat(portfolio/weddings): add 3-photo preview strip to album cards

### DIFF
--- a/app/(site)/portfolio/weddings/page.tsx
+++ b/app/(site)/portfolio/weddings/page.tsx
@@ -93,6 +93,13 @@ export default async function WeddingsPage() {
               const coverUrl = cover?.sizes?.card?.url ?? cover?.url ?? null
               const photoCount = Array.isArray(gallery.photos) ? gallery.photos.length : 0
 
+              const previewUrls = (Array.isArray(gallery.photos) ? gallery.photos.slice(0, 5) : [])
+                .map(item => {
+                  const p = typeof item.photo === 'object' && item.photo !== null ? item.photo as Photo : null
+                  return p?.sizes?.card?.url ?? p?.url ?? null
+                })
+                .filter((u): u is string => u !== null)
+
               return (
                 <Link key={gallery.id} href={`/portfolio/${gallery.slug}`} className={albumStyles.albumCard}>
                   <div className={albumStyles.albumCover}>
@@ -108,6 +115,21 @@ export default async function WeddingsPage() {
                       <div className={albumStyles.noCover} />
                     )}
                   </div>
+                  {previewUrls.length > 0 && (
+                    <div className={albumStyles.albumPreviews}>
+                      {previewUrls.slice(0, 3).map((url, i) => (
+                        <div key={i} className={albumStyles.albumPreview}>
+                          <ProtectedImage
+                            src={url}
+                            alt=""
+                            fill
+                            sizes="(max-width: 640px) 33vw, (max-width: 1024px) 17vw, 11vw"
+                            className={albumStyles.albumImg}
+                          />
+                        </div>
+                      ))}
+                    </div>
+                  )}
                   <div className={albumStyles.albumFooter}>
                     <span className={albumStyles.albumTitle}>{gallery.title}</span>
                     <span className={albumStyles.albumMeta}>{photoCount} photos</span>

--- a/app/(site)/portfolio/weddings/weddings.module.css
+++ b/app/(site)/portfolio/weddings/weddings.module.css
@@ -47,6 +47,21 @@
   background: var(--color-bg-card);
 }
 
+.albumPreviews {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 2px;
+  background: var(--color-bg);
+  padding: 2px 0 0;
+}
+
+.albumPreview {
+  position: relative;
+  aspect-ratio: 1 / 1;
+  overflow: hidden;
+  background: var(--color-bg-accent);
+}
+
 .albumFooter {
   display: flex;
   align-items: baseline;


### PR DESCRIPTION
## Summary
- Each wedding album card on `/portfolio/weddings` now shows a row of up to 3 preview thumbnails below the cover image
- Preview photos come from the first 3 entries of the gallery's ordered `photos[]` array (already fetched at `depth: 1`)
- Graceful fallbacks: strip hidden when no photos exist, cover image still shown if no preview photos, no-cover placeholder unchanged

## Test plan
- [ ] Visit `/portfolio/weddings` on a Vercel preview deploy with at least one gallery that has photos
- [ ] Verify 3 square thumbnails appear below the cover image on each card
- [ ] Verify cards with no photos show only cover + footer (no broken layout)
- [ ] Verify cards with fewer than 3 photos show only the photos that exist
- [ ] Verify clicking the card navigates to the full gallery
- [ ] Check responsive layout at mobile and tablet breakpoints

Closes TYN-9