### PR TITLE
fix(studio): product-switcher dropdown off-screen + dead chevron button

### DIFF
--- a/app/builder/PortfolioTab.tsx
+++ b/app/builder/PortfolioTab.tsx
@@ -317,8 +317,10 @@ export function PortfolioTab({ initialGalleries = [] }: { initialGalleries?: Gal
               New Collection
             </button>
             <button
-              type="button" aria-label="More collection options"
+              type="button" aria-label="More collection options" onClick={openModal}
               style={{ padding: '0.42rem 0.5rem', background: '#0b8078', border: 'none', borderLeft: '1px solid rgba(255,255,255,0.15)', color: '#fff', cursor: 'pointer', display: 'flex', alignItems: 'center' }}
+              onMouseEnter={e => { (e.currentTarget as HTMLElement).style.filter = 'brightness(1.1)' }}
+              onMouseLeave={e => { (e.currentTarget as HTMLElement).style.filter = 'none' }}
             >
               <ChevronDown size={13} />
             </button>

--- a/app/builder/SiteEditorClient.tsx
+++ b/app/builder/SiteEditorClient.tsx
@@ -434,12 +434,12 @@ const SWITCHER_ITEMS = [
 
 function ProductSwitcher({ onClose, anchorRef }: { onClose: () => void; anchorRef: React.RefObject<HTMLButtonElement | null> }) {
   const ref = useRef<HTMLDivElement>(null)
-  const [pos, setPos] = useState({ top: 52, left: 12 })
+  const [pos, setPos] = useState({ top: 52, right: 12 })
 
   useEffect(() => {
     if (anchorRef.current) {
       const r = anchorRef.current.getBoundingClientRect()
-      setPos({ top: r.bottom + 6, left: r.left })
+      setPos({ top: r.bottom + 6, right: window.innerWidth - r.right })
     }
     const handler = (e: MouseEvent) => {
       if (ref.current && !ref.current.contains(e.target as Node) &&
@@ -452,7 +452,7 @@ function ProductSwitcher({ onClose, anchorRef }: { onClose: () => void; anchorRe
   return (
     <div
       ref={ref}
-      style={{ position: 'fixed', top: pos.top, left: pos.left, zIndex: 500, background: '#1c1c1c', border: '1px solid rgba(255,255,255,0.1)', borderRadius: 10, padding: '0.5rem', width: 240, boxShadow: '0 12px 40px rgba(0,0,0,0.7)' }}
+      style={{ position: 'fixed', top: pos.top, right: pos.right, zIndex: 500, background: '#1c1c1c', border: '1px solid rgba(255,255,255,0.1)', borderRadius: 10, padding: '0.5rem', width: 240, boxShadow: '0 12px 40px rgba(0,0,0,0.7)' }}
     >
       {SWITCHER_ITEMS.map(item => (
         // eslint-disable-next-line @next/next/no-html-link-for-pages


### PR DESCRIPTION
## Root cause
Two bugs:

1. **Dropdown off-screen**: `ProductSwitcher` was positioned with `left: r.left` (button's left edge). Since the `...` button sits at the far right of the 1200px+ header, the 240px dropdown extended past the right edge of the viewport and was invisible. Fixed by switching to `right: window.innerWidth - r.right` to anchor the dropdown's right edge to the button's right edge.

2. **Dead chevron button**: The "New Collection" split button's chevron had no `onClick` handler - visually implied a dropdown but did nothing. Wired it to `openModal()` same as the primary button.

## Test plan
- [ ] Go to `/builder?product=portfolio` on a Vercel preview deploy
- [ ] Click the `...` button in the top-right - dropdown should appear anchored to the right edge, fully on-screen
- [ ] Verify all items in the dropdown are clickable and navigate correctly
- [ ] Click the chevron `v` on the "New Collection" split button - should open the New Collection modal

Fixes TYN-276