### PR TITLE
Hide admin-only Studio dashboard links from editor role

### DIFF
--- a/app/studio/StudioClient.tsx
+++ b/app/studio/StudioClient.tsx
@@ -27,6 +27,7 @@ interface Photo {
 
 interface Props {
   userName: string
+  userRole: string
   galleries: Gallery[]
   photos: Photo[]
 }
@@ -39,6 +40,11 @@ interface ProductLink {
   label: string
   href: string
   external?: boolean
+  // Areas an editor account is blocked from (Users, Site Config, Booking
+  // Settings, Availability - see TYN-302's access control). Filtered out
+  // of a non-admin's product cards rather than left in as dead links that
+  // would just 403.
+  adminOnly?: boolean
 }
 
 interface Product {
@@ -437,8 +443,10 @@ function RecentPhotos({ photos }: { photos: Photo[] }) {
 // Main component
 // ---------------------------------------------------------------------------
 
-export function StudioClient({ userName, galleries, photos }: Props) {
-  const PRODUCTS: Product[] = [
+export function StudioClient({ userName, userRole, galleries, photos }: Props) {
+  const isAdmin = userRole === 'admin'
+
+  const ALL_PRODUCTS: Product[] = [
     {
       label: 'Portfolio',
       color: '#0d9488',
@@ -456,7 +464,7 @@ export function StudioClient({ userName, galleries, photos }: Props) {
       icon: <WebsiteIcon />,
       links: [
         { label: 'Edit Website', href: '/builder' },
-        { label: 'Availability / OOO', href: '/availability' },
+        { label: 'Availability / OOO', href: '/availability', adminOnly: true },
         { label: 'View Website', href: 'https://tynnellhollinsphotography.com', external: true },
       ],
     },
@@ -486,7 +494,7 @@ export function StudioClient({ userName, galleries, photos }: Props) {
       color: '#e11d48',
       icon: <BookingsIcon />,
       links: [
-        { label: 'Booking Settings', href: '/admin/globals/booking-settings' },
+        { label: 'Booking Settings', href: '/admin/globals/booking-settings', adminOnly: true },
         { label: 'View Payments', href: '/studio-manager' },
         { label: 'Book a Session', href: 'https://tynnellhollinsphotography.com/book', external: true },
       ],
@@ -496,13 +504,17 @@ export function StudioClient({ userName, galleries, photos }: Props) {
       color: '#b45309',
       icon: <SettingsIcon />,
       links: [
-        { label: 'Site Config', href: '/admin/globals/site-config' },
+        { label: 'Site Config', href: '/admin/globals/site-config', adminOnly: true },
         { label: 'Hero Slides', href: '/admin/globals/hero-slides' },
         { label: 'About Page', href: '/admin/globals/about-page' },
         { label: 'Admin Panel', href: '/admin' },
       ],
     },
   ]
+
+  const PRODUCTS: Product[] = isAdmin
+    ? ALL_PRODUCTS
+    : ALL_PRODUCTS.map(p => ({ ...p, links: p.links.filter(link => !link.adminOnly) }))
 
   return (
     <div style={{ minHeight: '100vh', background: '#111', display: 'flex', flexDirection: 'column' }}>

--- a/app/studio/page.tsx
+++ b/app/studio/page.tsx
@@ -41,6 +41,7 @@ export default async function StudioPage() {
   return (
     <StudioClient
       userName={user.email ?? ''}
+      userRole={user.role}
       galleries={galleries}
       photos={photos}
     />


### PR DESCRIPTION
## Summary
- The editor role added in TYN-302 previously still saw links to Site Config, Booking Settings, and Availability/OOO on the Studio dashboard - they just 403'd if clicked, since the underlying access control was already correct.
- Filtered those out of the product cards for non-admins so the dashboard only shows what an editor can actually use. No visual/layout change for the admin experience, still matches the existing Pixieset-style card grid.
- Role is resolved server-side (`payload.auth()` in `app/studio/page.tsx`) and passed down, so there's no client-side flash of admin-only links before the role is known.

Note: I initially edited `components/admin/Dashboard.tsx` (Payload's registered `admin.components.views.dashboard`), but `middleware.ts` unconditionally redirects bare `/admin` to `/studio`, so that component is unreachable dead code. Reverted that and made the real change in `app/studio/StudioClient.tsx`, which is what actually renders.

## Test plan
- [x] `tsc --noEmit` clean
- [x] `eslint` clean
- [x] Full test suite passing (141/141)
- [x] Verified live against a production build: admin view unchanged (Availability/OOO, Booking Settings, Site Config all visible)
- [x] Verified live with a throwaway editor test account created/deleted against the DB: Availability/OOO, Booking Settings, and Site Config are gone from the dashboard; Portfolio, Studio Manager, Blog, Recent Collections, and Recent Uploads all remain intact

🤖 Generated with [Claude Code](https://claude.com/claude-code)