### PR TITLE
Add site-wide Design theme editor with live preview

### DIFF
--- a/app/(site)/globals.css
+++ b/app/(site)/globals.css
@@ -74,6 +74,17 @@ a {
   }
 }
 
+/* ── Design editor "Enable animations" toggle ──────────────── */
+/* Same effect as the reduced-motion override above, but as an editorial
+   on/off switch (Design > Animations) rather than an accessibility
+   preference - set via a data-animations attribute on <html>. */
+[data-animations="off"] *, [data-animations="off"] *::before, [data-animations="off"] *::after {
+  animation-duration: 0.01ms !important;
+  animation-iteration-count: 1 !important;
+  transition-duration: 0.01ms !important;
+  scroll-behavior: auto !important;
+}
+
 /* ── Google Places autocomplete dropdown ───────────────────── */
 
 .pac-container {

--- a/app/(site)/layout.tsx
+++ b/app/(site)/layout.tsx
@@ -5,6 +5,8 @@ import './styles/tokens.css'
 import Navbar from '../components/Navbar/Navbar'
 import Footer from '../components/Footer/Footer'
 import { getBuilderNavLinks } from '@/app/lib/nav'
+import { getSiteDesign, themeToCssVars } from '@/app/lib/siteDesign'
+import { DesignPreviewBridge } from '../components/DesignPreviewBridge'
 import { Analytics } from '@vercel/analytics/next'
 import { SpeedInsights } from '@vercel/speed-insights/next'
 
@@ -72,15 +74,25 @@ export default async function RootLayout({
 }: {
   children: React.ReactNode
 }) {
-  const builderLinks = await getBuilderNavLinks()
+  const [builderLinks, theme] = await Promise.all([getBuilderNavLinks(), getSiteDesign()])
 
   return (
-    <html lang="en" className={`${tangerine.variable} ${poppinsHeading.variable} ${poppinsBody.variable} ${abrialFatface.variable}`}>
+    <html
+      lang="en"
+      className={`${tangerine.variable} ${poppinsHeading.variable} ${poppinsBody.variable} ${abrialFatface.variable}`}
+      data-animations={theme.animationsEnabled ? undefined : 'off'}
+    >
+      {/* Site-wide theme (TYN-314), read fresh on every request from the
+          Design editor's saved settings - layers on top of tokens.css's
+          hardcoded defaults so an unsaved/missing global never breaks
+          styling (getSiteDesign falls back to those same defaults). */}
+      <style dangerouslySetInnerHTML={{ __html: `:root {\n  ${themeToCssVars(theme)}\n}` }} />
       <body suppressHydrationWarning>
         <a href="#main-content" className="skipLink">Skip to content</a>
-        <Navbar builderLinks={builderLinks} />
+        <Navbar builderLinks={builderLinks} logoUrl={theme.logoUrl} />
         <div id="main-content" tabIndex={-1}>{children}</div>
         <Footer />
+        <DesignPreviewBridge />
         {/* No consent gate (TYN-27, investigated): Vercel Web Analytics and Speed
             Insights are cookieless by design - no persistent identifiers, no
             cross-site tracking, no PII collected - so no GDPR consent banner

--- a/app/(site)/styles/tokens.css
+++ b/app/(site)/styles/tokens.css
@@ -15,6 +15,7 @@
   --color-border-subtle:  rgba(214, 209, 206, 0.06);
   --color-border-solid:   #1e1e1e;
   --color-error:          #c87171;
+  --btn-radius:           2px;
 
   /* ── Colors: light mode override ─────────────────────────── */
   /* Overlay boxes (--color-bg-overlay) intentionally stay dark since they
@@ -34,8 +35,12 @@
   --font-mono:            var(--font-body);
 
   /* ── Spacing ──────────────────────────────────────────────── */
+  /* --space-scale (Design editor "Overall spacing": 0.75 compact / 1
+     normal / 1.35 spacious) multiplies both spacing tokens below, so a
+     single override retunes every consumer without touching each one. */
+  --space-scale:          1;
   --max-width:            1680px;
-  --padding-x:            max(1.25rem, 2.5vw);
-  --padding-block:        4vmax;
+  --padding-x:            calc(max(1.25rem, 2.5vw) * var(--space-scale));
+  --padding-block:        calc(4vmax * var(--space-scale));
 }
 

--- a/app/api/design/save/route.ts
+++ b/app/api/design/save/route.ts
@@ -1,0 +1,60 @@
+import { NextResponse } from 'next/server'
+import { revalidatePath } from 'next/cache'
+import { requireAdminUser } from '@/app/lib/builderAuth'
+
+// Persist the site-wide Design theme (TYN-314). Admin-only. The (site) root
+// layout reads this global fresh on every request, so publishing here takes
+// effect on the next page load - no separate cache invalidation needed beyond
+// revalidating the layout-level cache.
+export const dynamic = 'force-dynamic'
+
+const FIELDS = [
+  'logoUrl',
+  'headingFont',
+  'bodyFont',
+  'colorBg',
+  'colorBgAccent',
+  'colorHeading',
+  'colorBody',
+  'colorDetail',
+  'colorBtnBg',
+  'spacingScale',
+  'buttonStyle',
+  'animationsEnabled',
+] as const
+
+export async function POST(request: Request) {
+  const auth = await requireAdminUser()
+  if (auth instanceof NextResponse) return auth
+  const { payload } = auth
+
+  let body: Record<string, unknown>
+  try {
+    body = await request.json()
+  } catch {
+    return NextResponse.json({ error: 'Invalid request body' }, { status: 400 })
+  }
+
+  const data: Record<string, unknown> = {}
+  for (const key of FIELDS) {
+    if (key in body) data[key] = body[key]
+  }
+  if (Object.keys(data).length === 0) {
+    return NextResponse.json({ error: 'No valid fields provided' }, { status: 400 })
+  }
+
+  try {
+    await payload.updateGlobal({ slug: 'site-design', data })
+  } catch (err) {
+    console.error('[design/save] failed to save site design:', err)
+    return NextResponse.json({ error: 'Failed to save design' }, { status: 500 })
+  }
+
+  try {
+    revalidatePath('/', 'layout')
+  } catch {
+    // No-op outside a request scope.
+  }
+
+  return NextResponse.json({ ok: true })
+}

--- a/app/builder/puck.config.tsx
+++ b/app/builder/puck.config.tsx
@@ -16,13 +16,16 @@ import type { Config } from '@measured/puck'
 import { ImagePickerField } from './ImagePickerField'
 import { PhotoCarouselBlock } from './PhotoCarouselBlock'
 
+// CSS-var-backed (TYN-314) so page-builder content follows the site-wide
+// Design editor theme, not a fixed palette - fallbacks match tokens.css's
+// defaults for when the var isn't set (e.g. isolated tooling/tests).
 const C = {
-  bg: '#0C0C0C',
-  accent: '#131313',
-  heading: '#D6D1CE',
-  body: '#E6E1DE',
-  detail: '#9B9A9A',
-  btn: '#9B9A9A',
+  bg: 'var(--color-bg, #0C0C0C)',
+  accent: 'var(--color-bg-accent, #131313)',
+  heading: 'var(--color-heading, #D6D1CE)',
+  body: 'var(--color-body, #E6E1DE)',
+  detail: 'var(--color-detail, #9B9A9A)',
+  btn: 'var(--color-btn-bg, #9B9A9A)',
   border: 'rgba(155,154,154,0.18)',
 }
 const HEADING_FONT = "var(--font-heading, Archivo, sans-serif)"
@@ -134,6 +137,7 @@ function btnStyle(): React.CSSProperties {
     textTransform: 'uppercase',
     fontSize: '0.78rem',
     fontFamily: BODY_FONT,
+    borderRadius: 'var(--btn-radius, 2px)',
   }
 }
 
@@ -159,8 +163,8 @@ const bgField = {
   label: 'Background',
   options: [
     { label: 'None', value: 'transparent' },
-    { label: 'Dark', value: '#0C0C0C' },
-    { label: 'Accent', value: '#131313' },
+    { label: 'Dark', value: 'var(--color-bg, #0C0C0C)' },
+    { label: 'Accent', value: 'var(--color-bg-accent, #131313)' },
   ],
 }
 // Faded background photo (TYN-305): an optional user-picked image behind the
@@ -443,7 +447,7 @@ export const config: Config = {
         items: [
           { quote: 'Working with Tynnell was effortless. The photos feel like us.', name: 'Sarah & James' },
         ],
-        background: '#131313',
+        background: 'var(--color-bg-accent, #131313)',
         spacing: 'normal',
         ...responsiveDefaults,
       },
@@ -478,7 +482,7 @@ export const config: Config = {
         subtext: '',
         buttonText: 'Book a Session',
         buttonHref: '/contact',
-        background: '#131313',
+        background: 'var(--color-bg-accent, #131313)',
         spacing: 'spacious',
         ...responsiveDefaults,
       },

--- a/app/components/Contact/Contact.module.css
+++ b/app/components/Contact/Contact.module.css
@@ -1,5 +1,5 @@
 .section {
-  background-color: #0C0C0C;
+  background-color: var(--color-bg);
   padding: 8rem var(--padding-x);
   text-align: center;
 }
@@ -24,7 +24,7 @@
 .heading {
   font-family: var(--font-display);
   font-size: clamp(3.5rem, 7vw, 6.5rem);
-  color: #D6D1CE;
+  color: var(--color-heading);
   font-weight: 400;
   line-height: 1.05;
 }
@@ -49,8 +49,8 @@
   display: inline-flex;
   align-items: center;
   padding: 0.9rem 2.5rem;
-  background-color: #9B9A9A;
-  color: #0C0C0C;
+  background-color: var(--color-btn-bg);
+  color: var(--color-bg);
   font-family: var(--font-body);
   font-size: 0.7rem;
   letter-spacing: 0.18em;
@@ -58,10 +58,11 @@
   text-decoration: none;
   transition: background-color 0.2s ease;
   min-height: 44px;
+  border-radius: var(--btn-radius, 2px);
 }
 
 .btn:hover {
-  background-color: #D6D1CE;
+  background-color: var(--color-btn-hover);
 }
 
 .btnSecondary {
@@ -78,6 +79,7 @@
   text-decoration: none;
   transition: border-color 0.2s ease, color 0.2s ease;
   min-height: 44px;
+  border-radius: var(--btn-radius, 2px);
 }
 
 .btnSecondary:hover {

--- a/app/components/DesignPreviewBridge.tsx
+++ b/app/components/DesignPreviewBridge.tsx
@@ -1,0 +1,48 @@
+'use client'
+
+import { useEffect } from 'react'
+
+// Real-time live-preview listener for the /design editor (TYN-314). Mounted
+// unconditionally in the (site) root layout, but self-gates so it is a
+// complete no-op for every real visitor: it only ever does anything when the
+// page is loaded with the ?__designPreview=1 query param AND is either (a)
+// running inside an iframe (the editor's built-in preview pane) or (b) a
+// popped-out tab opened via the editor's "Preview" button (window.opener
+// set). Real top-level page loads never match either condition.
+//
+// On receiving a same-origin postMessage of draft (unsaved) theme values from
+// the /design page, it applies them directly as CSS custom-property
+// overrides on the document root - purely visual, nothing is persisted here.
+export function DesignPreviewBridge() {
+  useEffect(() => {
+    const isPreviewFrame = window.self !== window.top
+    const isPreviewPopup = window.opener != null
+    if (!isPreviewFrame && !isPreviewPopup) return
+    if (new URLSearchParams(window.location.search).get('__designPreview') !== '1') return
+
+    const target = isPreviewFrame ? window.parent : (window.opener as Window)
+
+    function handleMessage(event: MessageEvent) {
+      if (event.origin !== window.location.origin) return
+      const data = event.data as { type?: string; vars?: Record<string, string>; animationsEnabled?: boolean } | undefined
+      if (!data || data.type !== 'THP_DESIGN_PREVIEW') return
+      if (data.vars) {
+        for (const [key, value] of Object.entries(data.vars)) {
+          document.documentElement.style.setProperty(key, value)
+        }
+      }
+      if (typeof data.animationsEnabled === 'boolean') {
+        if (data.animationsEnabled) document.documentElement.removeAttribute('data-animations')
+        else document.documentElement.setAttribute('data-animations', 'off')
+      }
+    }
+
+    window.addEventListener('message', handleMessage)
+    // Tell the opener/parent we're ready so it can send the current draft
+    // state immediately after a (re)load, not just on the next edit.
+    target.postMessage({ type: 'THP_DESIGN_PREVIEW_READY' }, window.location.origin)
+    return () => window.removeEventListener('message', handleMessage)
+  }, [])
+
+  return null
+}

--- a/app/components/Hero/Hero.module.css
+++ b/app/components/Hero/Hero.module.css
@@ -78,6 +78,7 @@
   text-decoration: none;
   transition: background 0.2s ease;
   margin-top: 0.5rem;
+  border-radius: var(--btn-radius, 2px);
 }
 
 .ctaBtn:hover {

--- a/app/components/Navbar/Navbar.module.css
+++ b/app/components/Navbar/Navbar.module.css
@@ -31,6 +31,13 @@
   flex-shrink: 0;
 }
 
+.brandLogo {
+  display: block;
+  height: 40px;
+  width: auto;
+  object-fit: contain;
+}
+
 .brandLine {
   display: block;
   font-family: var(--font-heading);

--- a/app/components/Navbar/Navbar.tsx
+++ b/app/components/Navbar/Navbar.tsx
@@ -9,7 +9,7 @@ import styles from './Navbar.module.css'
 
 const ROW1 = ['Home', 'About', 'Portfolio', 'Services', 'Testimonials']
 
-export default function Navbar({ builderLinks = [] }: { builderLinks?: NavLink[] }) {
+export default function Navbar({ builderLinks = [], logoUrl }: { builderLinks?: NavLink[]; logoUrl?: string }) {
   const [scrolled, setScrolled] = useState(false)
   const [menuOpen, setMenuOpen] = useState(false)
   const [portfolioOpen, setPortfolioOpen] = useState(false)
@@ -81,9 +81,16 @@ export default function Navbar({ builderLinks = [] }: { builderLinks?: NavLink[]
     <>
       <nav className={navClass} aria-label="Main navigation">
         <Link href="/" className={styles.brand} aria-label="Tynnell Hollins Photography, home">
-          <span className={styles.brandLine}>Tynnell</span>
-          <span className={styles.brandLine}>Hollins</span>
-          <span className={styles.brandLine}>Photography</span>
+          {logoUrl ? (
+            // eslint-disable-next-line @next/next/no-img-element
+            <img src={logoUrl} alt="Tynnell Hollins Photography" className={styles.brandLogo} />
+          ) : (
+            <>
+              <span className={styles.brandLine}>Tynnell</span>
+              <span className={styles.brandLine}>Hollins</span>
+              <span className={styles.brandLine}>Photography</span>
+            </>
+          )}
         </Link>
 
         <div className={styles.linksWrapper}>

--- a/app/design/DesignClient.tsx
+++ b/app/design/DesignClient.tsx
@@ -1,0 +1,239 @@
+'use client'
+
+import { useCallback, useEffect, useRef, useState } from 'react'
+import Link from 'next/link'
+import { ImagePickerField } from '@/app/builder/ImagePickerField'
+import { themeToCssVarMap, type SiteTheme } from '@/app/lib/siteTheme'
+
+type Section = 'logo' | 'fonts' | 'colors' | 'animations' | 'spacing' | 'buttons'
+
+const FONT_OPTIONS: { label: string; value: SiteTheme['headingFont'] }[] = [
+  { label: 'Poppins', value: 'poppins' },
+  { label: 'Tangerine', value: 'tangerine' },
+  { label: 'Abril Fatface', value: 'abril' },
+]
+const SPACING_OPTIONS: { label: string; value: SiteTheme['spacingScale'] }[] = [
+  { label: 'Compact', value: 'compact' },
+  { label: 'Normal', value: 'normal' },
+  { label: 'Spacious', value: 'spacious' },
+]
+const BUTTON_OPTIONS: { label: string; value: SiteTheme['buttonStyle'] }[] = [
+  { label: 'Sharp', value: 'sharp' },
+  { label: 'Rounded', value: 'rounded' },
+  { label: 'Pill', value: 'pill' },
+]
+
+const COLOR_FIELDS: { key: keyof Pick<SiteTheme, 'colorBg' | 'colorBgAccent' | 'colorHeading' | 'colorBody' | 'colorDetail' | 'colorBtnBg'>; label: string }[] = [
+  { key: 'colorBg', label: 'Background color' },
+  { key: 'colorBgAccent', label: 'Accent background color' },
+  { key: 'colorHeading', label: 'Heading text color' },
+  { key: 'colorBody', label: 'Body text color' },
+  { key: 'colorDetail', label: 'Detail / muted text color' },
+  { key: 'colorBtnBg', label: 'Button color' },
+]
+
+export function DesignClient({ initialTheme }: { initialTheme: SiteTheme }) {
+  const [theme, setTheme] = useState<SiteTheme>(initialTheme)
+  const [open, setOpen] = useState<Section | null>('logo')
+  const [saving, setSaving] = useState(false)
+  const [saved, setSaved] = useState(false)
+  const iframeRef = useRef<HTMLIFrameElement>(null)
+  const previewWinRef = useRef<Window | null>(null)
+  const themeRef = useRef(theme)
+  themeRef.current = theme
+
+  const postToTarget = useCallback((win: Window | null | undefined) => {
+    if (!win) return
+    win.postMessage(
+      { type: 'THP_DESIGN_PREVIEW', vars: themeToCssVarMap(themeRef.current), animationsEnabled: themeRef.current.animationsEnabled },
+      window.location.origin,
+    )
+  }, [])
+
+  // Push the latest draft state to the live preview iframe (and an optional
+  // popped-out preview tab) on every change - this is what makes the editor
+  // feel like Pixieset's as-you-type preview, with nothing persisted yet.
+  useEffect(() => {
+    postToTarget(iframeRef.current?.contentWindow)
+    if (previewWinRef.current && !previewWinRef.current.closed) postToTarget(previewWinRef.current)
+  }, [theme, postToTarget])
+
+  // Answer the preview bridge's "ready" handshake (fires on iframe load and
+  // whenever a popped-out preview tab's bridge mounts) with the current draft.
+  useEffect(() => {
+    function handleReady(event: MessageEvent) {
+      if (event.origin !== window.location.origin) return
+      if ((event.data as { type?: string } | undefined)?.type !== 'THP_DESIGN_PREVIEW_READY') return
+      postToTarget(event.source as Window)
+    }
+    window.addEventListener('message', handleReady)
+    return () => window.removeEventListener('message', handleReady)
+  }, [postToTarget])
+
+  const set = <K extends keyof SiteTheme>(key: K, value: SiteTheme[K]) => {
+    setSaved(false)
+    setTheme((t) => ({ ...t, [key]: value }))
+  }
+
+  const openPreviewTab = () => {
+    const win = window.open('/?__designPreview=1', '_blank')
+    previewWinRef.current = win
+  }
+
+  const publish = async () => {
+    setSaving(true)
+    try {
+      const res = await fetch('/api/design/save', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(theme),
+      })
+      if (res.ok) setSaved(true)
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  return (
+    <div style={{ display: 'flex', height: '100vh', background: '#0a0a0a', fontFamily: "Inter, system-ui, -apple-system, 'Segoe UI', sans-serif" }}>
+      <aside style={{ width: 320, minWidth: 320, background: '#0f0f0f', borderRight: '1px solid #1e1e1e', display: 'flex', flexDirection: 'column', height: '100vh', overflowY: 'auto' }}>
+        <div style={{ padding: '18px 20px', borderBottom: '1px solid #1e1e1e', display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+          <Link href="/studio" style={{ color: '#9b9a9a', fontSize: 13, textDecoration: 'none' }}>&larr; Studio</Link>
+          <span style={{ color: '#e6e1de', fontWeight: 600, fontSize: 14 }}>Design</span>
+        </div>
+
+        <div style={{ padding: '18px 20px 8px' }}>
+          <p style={{ margin: '0 0 10px', color: '#6b6a6a', fontSize: 11, letterSpacing: '0.08em', textTransform: 'uppercase' }}>Template</p>
+          <div style={{ display: 'flex', alignItems: 'center', gap: 12, padding: 10, background: '#1a1a1a', borderRadius: 6, border: '1px solid #232323' }}>
+            <div style={{ width: 44, height: 44, borderRadius: 4, background: 'linear-gradient(135deg,#2dd4bf,#0ea5e9)', flexShrink: 0 }} />
+            <div>
+              <div style={{ color: '#e6e1de', fontSize: 13, fontWeight: 600 }}>Editorial</div>
+              <div style={{ color: '#6b6a6a', fontSize: 11 }}>Your site&apos;s current design</div>
+            </div>
+          </div>
+        </div>
+
+        <div style={{ padding: '10px 20px 20px', flex: 1 }}>
+          <p style={{ margin: '10px 0', color: '#6b6a6a', fontSize: 11, letterSpacing: '0.08em', textTransform: 'uppercase' }}>Template Options</p>
+
+          <AccordionRow label="Logo & Branding" isOpen={open === 'logo'} onToggle={() => setOpen(open === 'logo' ? null : 'logo')}>
+            <FieldLabel>Logo image</FieldLabel>
+            <ImagePickerField value={theme.logoUrl} onChange={(v) => set('logoUrl', v)} />
+            <p style={{ color: '#6b6a6a', fontSize: 11, marginTop: 8 }}>Leave empty to show the text wordmark instead of an image.</p>
+          </AccordionRow>
+
+          <AccordionRow label="Fonts" isOpen={open === 'fonts'} onToggle={() => setOpen(open === 'fonts' ? null : 'fonts')}>
+            <FieldLabel>Heading font</FieldLabel>
+            <Select value={theme.headingFont} onChange={(v) => set('headingFont', v as SiteTheme['headingFont'])} options={FONT_OPTIONS} />
+            <FieldLabel style={{ marginTop: 12 }}>Body font</FieldLabel>
+            <Select value={theme.bodyFont} onChange={(v) => set('bodyFont', v as SiteTheme['bodyFont'])} options={FONT_OPTIONS} />
+          </AccordionRow>
+
+          <AccordionRow label="Colors" isOpen={open === 'colors'} onToggle={() => setOpen(open === 'colors' ? null : 'colors')}>
+            {COLOR_FIELDS.map((f, i) => (
+              <div key={f.key} style={{ marginTop: i === 0 ? 0 : 12 }}>
+                <FieldLabel>{f.label}</FieldLabel>
+                <ColorInput value={theme[f.key]} onChange={(v) => set(f.key, v)} />
+              </div>
+            ))}
+          </AccordionRow>
+
+          <AccordionRow label="Animations" isOpen={open === 'animations'} onToggle={() => setOpen(open === 'animations' ? null : 'animations')}>
+            <label style={{ display: 'flex', alignItems: 'center', gap: 8, color: '#e6e1de', fontSize: 13, cursor: 'pointer' }}>
+              <input type="checkbox" checked={theme.animationsEnabled} onChange={(e) => set('animationsEnabled', e.target.checked)} />
+              Enable animations
+            </label>
+            <p style={{ color: '#6b6a6a', fontSize: 11, marginTop: 8 }}>Turns off decorative transitions/animations sitewide when unchecked.</p>
+          </AccordionRow>
+
+          <AccordionRow label="Spacing" isOpen={open === 'spacing'} onToggle={() => setOpen(open === 'spacing' ? null : 'spacing')}>
+            <FieldLabel>Overall spacing</FieldLabel>
+            <Select value={theme.spacingScale} onChange={(v) => set('spacingScale', v as SiteTheme['spacingScale'])} options={SPACING_OPTIONS} />
+          </AccordionRow>
+
+          <AccordionRow label="Buttons" isOpen={open === 'buttons'} onToggle={() => setOpen(open === 'buttons' ? null : 'buttons')}>
+            <FieldLabel>Button shape</FieldLabel>
+            <Select value={theme.buttonStyle} onChange={(v) => set('buttonStyle', v as SiteTheme['buttonStyle'])} options={BUTTON_OPTIONS} />
+          </AccordionRow>
+        </div>
+
+        <div style={{ padding: '16px 20px', borderTop: '1px solid #1e1e1e', display: 'flex', gap: 10 }}>
+          <button type="button" onClick={openPreviewTab} style={{ flex: 1, padding: '10px 0', borderRadius: 6, border: '1px solid #2a2a2a', background: 'transparent', color: '#e6e1de', fontSize: 13, cursor: 'pointer' }}>
+            Preview
+          </button>
+          <button
+            type="button"
+            onClick={publish}
+            disabled={saving}
+            style={{ flex: 1, padding: '10px 0', borderRadius: 6, border: 'none', background: '#2dd4bf', color: '#0a0a0a', fontSize: 13, fontWeight: 600, cursor: saving ? 'default' : 'pointer', opacity: saving ? 0.7 : 1 }}
+          >
+            {saving ? 'Publishing...' : saved ? 'Published' : 'Publish'}
+          </button>
+        </div>
+      </aside>
+
+      <main style={{ flex: 1, background: '#050505', display: 'flex', alignItems: 'stretch' }}>
+        <iframe
+          ref={iframeRef}
+          src="/?__designPreview=1"
+          title="Live site preview"
+          style={{ border: 'none', width: '100%', height: '100%' }}
+        />
+      </main>
+    </div>
+  )
+}
+
+function AccordionRow({ label, isOpen, onToggle, children }: { label: string; isOpen: boolean; onToggle: () => void; children: React.ReactNode }) {
+  return (
+    <div style={{ borderBottom: '1px solid #1a1a1a' }}>
+      <button
+        type="button"
+        onClick={onToggle}
+        aria-expanded={isOpen}
+        style={{ width: '100%', display: 'flex', alignItems: 'center', justifyContent: 'space-between', padding: '12px 4px', background: 'none', border: 'none', color: '#e6e1de', fontSize: 13.5, fontWeight: 500, cursor: 'pointer', textAlign: 'left' }}
+      >
+        {label}
+        <span style={{ color: '#6b6a6a', transform: isOpen ? 'rotate(180deg)' : 'none', transition: 'transform 0.15s' }}>&#9660;</span>
+      </button>
+      {isOpen && <div style={{ padding: '2px 4px 16px' }}>{children}</div>}
+    </div>
+  )
+}
+
+function FieldLabel({ children, style }: { children: React.ReactNode; style?: React.CSSProperties }) {
+  return <label style={{ display: 'block', color: '#9b9a9a', fontSize: 11.5, marginBottom: 6, ...style }}>{children}</label>
+}
+
+function Select<T extends string>({ value, onChange, options }: { value: T; onChange: (v: string) => void; options: { label: string; value: T }[] }) {
+  return (
+    <select
+      value={value}
+      onChange={(e) => onChange(e.target.value)}
+      style={{ width: '100%', background: '#1a1a1a', color: '#e6e1de', border: '1px solid #2a2a2a', borderRadius: 5, padding: '8px 10px', fontSize: 13 }}
+    >
+      {options.map((o) => (
+        <option key={o.value} value={o.value}>{o.label}</option>
+      ))}
+    </select>
+  )
+}
+
+function ColorInput({ value, onChange }: { value: string; onChange: (v: string) => void }) {
+  return (
+    <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+      <input
+        type="color"
+        value={/^#[0-9a-fA-F]{6}$/.test(value) ? value : '#000000'}
+        onChange={(e) => onChange(e.target.value)}
+        style={{ width: 36, height: 32, padding: 0, border: '1px solid #2a2a2a', borderRadius: 4, background: 'none', cursor: 'pointer' }}
+      />
+      <input
+        type="text"
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        style={{ flex: 1, background: '#1a1a1a', color: '#e6e1de', border: '1px solid #2a2a2a', borderRadius: 5, padding: '7px 10px', fontSize: 13, fontFamily: 'monospace' }}
+      />
+    </div>
+  )
+}

--- a/app/design/layout.tsx
+++ b/app/design/layout.tsx
@@ -1,0 +1,17 @@
+import type { ReactNode } from 'react'
+
+// Standalone root layout for /design (TYN-314), same pattern as the other
+// custom Studio routes (photo-library, studio, builder) that live outside
+// the (site)/(payload) route groups and so need their own <html>/<body>.
+// The editor's own chrome uses a plain system font stack (set inline in
+// DesignClient); the live-preview iframe loads the real (site) layout (and
+// its fonts) independently inside its own document.
+export default function DesignLayout({ children }: { children: ReactNode }) {
+  return (
+    <html lang="en">
+      <body style={{ margin: 0 }} suppressHydrationWarning>
+        {children}
+      </body>
+    </html>
+  )
+}

--- a/app/design/page.tsx
+++ b/app/design/page.tsx
@@ -1,0 +1,23 @@
+import { getPayload } from 'payload'
+import config from '@payload-config'
+import { headers } from 'next/headers'
+import { redirect } from 'next/navigation'
+import { getSiteDesign } from '@/app/lib/siteDesign'
+import { DesignClient } from './DesignClient'
+
+// Site-wide theme editor (TYN-314), modeled on Pixieset's Design page - admin
+// only, matching Site Config/Booking Settings/Availability's existing
+// isAdmin restriction (branding changes affect the whole public site).
+export const dynamic = 'force-dynamic'
+export const metadata = { title: 'Design' }
+
+export default async function DesignPage() {
+  const payload = await getPayload({ config })
+  const { user } = await payload.auth({ headers: await headers() })
+  if (!user) redirect('/admin/login')
+  if (user.role !== 'admin') redirect('/studio')
+
+  const theme = await getSiteDesign()
+
+  return <DesignClient initialTheme={theme} />
+}

--- a/app/lib/builderAuth.ts
+++ b/app/lib/builderAuth.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server'
 import { getPayload, type Payload } from 'payload'
 import { headers } from 'next/headers'
 import payloadConfig from '@payload-config'
+import type { User } from '@/payload-types'
 
 // Shared auth gate for the builder API routes (TYN-216+). Returns the
 // authenticated Payload instance, or a 401 NextResponse the caller returns
@@ -16,4 +17,19 @@ export async function requireBuilderUser(): Promise<{ payload: Payload } | NextR
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
   }
   return { payload }
+}
+
+// Same as requireBuilderUser, but also enforces the admin role - for routes
+// backing admin-only globals (Site Design, matching SiteConfig/BookingSettings/
+// Availability's existing isAdmin access restriction).
+export async function requireAdminUser(): Promise<{ payload: Payload; user: User } | NextResponse> {
+  const payload = await getPayload({ config: payloadConfig })
+  const { user } = await payload.auth({ headers: await headers() })
+  if (!user) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+  if (user.role !== 'admin') {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+  }
+  return { payload, user }
 }

--- a/app/lib/siteDesign.ts
+++ b/app/lib/siteDesign.ts
@@ -1,0 +1,37 @@
+import { getPayload } from 'payload'
+import config from '@payload-config'
+import type { SiteDesign } from '@/payload-types'
+import { DEFAULT_THEME, type SiteTheme } from './siteTheme'
+
+export type { SiteTheme } from './siteTheme'
+export { DEFAULT_THEME, themeToCssVarMap, themeToCssVars } from './siteTheme'
+
+// Server-only: reads the SiteDesign global (TYN-314) for the (site) root
+// layout's per-request <style> override. Falls back to tokens.css's hardcoded
+// defaults on any DB hiccup or before the global is ever saved, so a
+// missing/broken SiteDesign doc never takes down the public site. Kept in
+// its own module (not app/lib/siteTheme.ts) because getPayload/@payload-config
+// pull in server-only code that breaks the /design editor's client bundle if
+// imported from a 'use client' component - see siteTheme.ts's header comment.
+export async function getSiteDesign(): Promise<SiteTheme> {
+  try {
+    const payload = await getPayload({ config })
+    const doc = (await payload.findGlobal({ slug: 'site-design' })) as SiteDesign
+    return {
+      logoUrl: doc.logoUrl || DEFAULT_THEME.logoUrl,
+      headingFont: doc.headingFont || DEFAULT_THEME.headingFont,
+      bodyFont: doc.bodyFont || DEFAULT_THEME.bodyFont,
+      colorBg: doc.colorBg || DEFAULT_THEME.colorBg,
+      colorBgAccent: doc.colorBgAccent || DEFAULT_THEME.colorBgAccent,
+      colorHeading: doc.colorHeading || DEFAULT_THEME.colorHeading,
+      colorBody: doc.colorBody || DEFAULT_THEME.colorBody,
+      colorDetail: doc.colorDetail || DEFAULT_THEME.colorDetail,
+      colorBtnBg: doc.colorBtnBg || DEFAULT_THEME.colorBtnBg,
+      spacingScale: doc.spacingScale || DEFAULT_THEME.spacingScale,
+      buttonStyle: doc.buttonStyle || DEFAULT_THEME.buttonStyle,
+      animationsEnabled: doc.animationsEnabled ?? true,
+    }
+  } catch {
+    return DEFAULT_THEME
+  }
+}

--- a/app/lib/siteTheme.ts
+++ b/app/lib/siteTheme.ts
@@ -1,0 +1,80 @@
+// Client-safe theme utilities (TYN-314): the SiteTheme shape, its defaults,
+// and pure CSS-var mapping. Deliberately has NO imports from 'payload' or
+// '@payload-config' - those pull in server-only code (next/cache's
+// revalidatePath, used by several collection hooks) transitively through
+// payload.config.ts, which breaks the client bundle for /design's
+// 'use client' editor if it's imported from the same module as
+// getSiteDesign() (see app/lib/siteDesign.ts, the server-only counterpart).
+export interface SiteTheme {
+  logoUrl: string
+  headingFont: 'poppins' | 'tangerine' | 'abril'
+  bodyFont: 'poppins' | 'tangerine' | 'abril'
+  colorBg: string
+  colorBgAccent: string
+  colorHeading: string
+  colorBody: string
+  colorDetail: string
+  colorBtnBg: string
+  spacingScale: 'compact' | 'normal' | 'spacious'
+  buttonStyle: 'sharp' | 'rounded' | 'pill'
+  animationsEnabled: boolean
+}
+
+export const DEFAULT_THEME: SiteTheme = {
+  logoUrl: '',
+  headingFont: 'poppins',
+  bodyFont: 'poppins',
+  colorBg: '#0C0C0C',
+  colorBgAccent: '#131313',
+  colorHeading: '#D6D1CE',
+  colorBody: '#E6E1DE',
+  colorDetail: '#9B9A9A',
+  colorBtnBg: '#9B9A9A',
+  spacingScale: 'normal',
+  buttonStyle: 'sharp',
+  animationsEnabled: true,
+}
+
+const FONT_ROLE_VAR: Record<'tangerine' | 'abril', string> = {
+  tangerine: 'var(--font-display)',
+  abril: 'var(--font-display-bold)',
+}
+
+const SPACE_SCALE: Record<SiteTheme['spacingScale'], number> = {
+  compact: 0.75,
+  normal: 1,
+  spacious: 1.35,
+}
+
+const BTN_RADIUS: Record<SiteTheme['buttonStyle'], string> = {
+  sharp: '2px',
+  rounded: '8px',
+  pill: '999px',
+}
+
+// Maps theme values to concrete CSS custom-property values. Shared by the
+// server-rendered <style> override (themeToCssVars) and the client-side live
+// preview bridge (DesignClient/DesignPreviewBridge), so both stay in sync.
+export function themeToCssVarMap(theme: SiteTheme): Record<string, string> {
+  const map: Record<string, string> = {
+    '--color-bg': theme.colorBg,
+    '--color-bg-accent': theme.colorBgAccent,
+    '--color-heading': theme.colorHeading,
+    '--color-body': theme.colorBody,
+    '--color-detail': theme.colorDetail,
+    '--color-btn-bg': theme.colorBtnBg,
+    '--space-scale': String(SPACE_SCALE[theme.spacingScale]),
+    '--btn-radius': BTN_RADIUS[theme.buttonStyle],
+  }
+  if (theme.headingFont !== 'poppins') map['--font-heading'] = FONT_ROLE_VAR[theme.headingFont]
+  if (theme.bodyFont !== 'poppins') map['--font-body'] = FONT_ROLE_VAR[theme.bodyFont]
+  return map
+}
+
+// Builds the `:root{...}` declaration body (no selector wrapper) for the
+// server-rendered <style> tag in the (site) root layout.
+export function themeToCssVars(theme: SiteTheme): string {
+  return Object.entries(themeToCssVarMap(theme))
+    .map(([k, v]) => `${k}: ${v};`)
+    .join('\n  ')
+}

--- a/app/studio/StudioClient.tsx
+++ b/app/studio/StudioClient.tsx
@@ -464,6 +464,7 @@ export function StudioClient({ userName, userRole, galleries, photos }: Props) {
       icon: <WebsiteIcon />,
       links: [
         { label: 'Edit Website', href: '/builder' },
+        { label: 'Design', href: '/design', adminOnly: true },
         { label: 'Availability / OOO', href: '/availability', adminOnly: true },
         { label: 'View Website', href: 'https://tynnellhollinsphotography.com', external: true },
       ],

--- a/globals/SiteDesign.ts
+++ b/globals/SiteDesign.ts
@@ -1,0 +1,112 @@
+import type { GlobalConfig } from 'payload'
+import { isAdmin } from '@/app/lib/access'
+
+// Site-wide theme (TYN-314): logo, fonts, colors, spacing, button style, and
+// animations, editable from the custom /design Studio page (Pixieset-style
+// live-preview editor) rather than Payload's own admin UI - hidden from the
+// Payload nav entirely, same pattern as the `pages` collection (managed via
+// /builder instead of /admin/collections/pages).
+export const SiteDesign: GlobalConfig = {
+  slug: 'site-design',
+  label: 'Site Design',
+  access: {
+    read: isAdmin,
+    update: isAdmin,
+  },
+  admin: {
+    hidden: true,
+  },
+  fields: [
+    {
+      name: 'logoUrl',
+      type: 'text',
+      label: 'Logo image URL',
+    },
+    {
+      name: 'headingFont',
+      type: 'select',
+      label: 'Heading font',
+      defaultValue: 'poppins',
+      options: [
+        { label: 'Poppins', value: 'poppins' },
+        { label: 'Tangerine', value: 'tangerine' },
+        { label: 'Abril Fatface', value: 'abril' },
+      ],
+    },
+    {
+      name: 'bodyFont',
+      type: 'select',
+      label: 'Body font',
+      defaultValue: 'poppins',
+      options: [
+        { label: 'Poppins', value: 'poppins' },
+        { label: 'Tangerine', value: 'tangerine' },
+        { label: 'Abril Fatface', value: 'abril' },
+      ],
+    },
+    {
+      name: 'colorBg',
+      type: 'text',
+      label: 'Background color',
+      defaultValue: '#0C0C0C',
+    },
+    {
+      name: 'colorBgAccent',
+      type: 'text',
+      label: 'Accent background color',
+      defaultValue: '#131313',
+    },
+    {
+      name: 'colorHeading',
+      type: 'text',
+      label: 'Heading text color',
+      defaultValue: '#D6D1CE',
+    },
+    {
+      name: 'colorBody',
+      type: 'text',
+      label: 'Body text color',
+      defaultValue: '#E6E1DE',
+    },
+    {
+      name: 'colorDetail',
+      type: 'text',
+      label: 'Detail/muted text color',
+      defaultValue: '#9B9A9A',
+    },
+    {
+      name: 'colorBtnBg',
+      type: 'text',
+      label: 'Button color',
+      defaultValue: '#9B9A9A',
+    },
+    {
+      name: 'spacingScale',
+      type: 'select',
+      label: 'Overall spacing',
+      defaultValue: 'normal',
+      options: [
+        { label: 'Compact', value: 'compact' },
+        { label: 'Normal', value: 'normal' },
+        { label: 'Spacious', value: 'spacious' },
+      ],
+    },
+    {
+      name: 'buttonStyle',
+      type: 'select',
+      label: 'Button shape',
+      defaultValue: 'sharp',
+      options: [
+        { label: 'Sharp', value: 'sharp' },
+        { label: 'Rounded', value: 'rounded' },
+        { label: 'Pill', value: 'pill' },
+      ],
+    },
+    {
+      name: 'animationsEnabled',
+      type: 'checkbox',
+      label: 'Enable animations',
+      defaultValue: true,
+    },
+  ],
+}

--- a/payload-types.ts
+++ b/payload-types.ts
@@ -103,6 +103,7 @@ export interface Config {
     'hero-slides': HeroSlide;
     'about-page': AboutPage;
     'site-config': SiteConfig;
+    'site-design': SiteDesign;
     'booking-settings': BookingSetting;
     availability: Availability;
   };
@@ -110,6 +111,7 @@ export interface Config {
     'hero-slides': HeroSlidesSelect<false> | HeroSlidesSelect<true>;
     'about-page': AboutPageSelect<false> | AboutPageSelect<true>;
     'site-config': SiteConfigSelect<false> | SiteConfigSelect<true>;
+    'site-design': SiteDesignSelect<false> | SiteDesignSelect<true>;
     'booking-settings': BookingSettingsSelect<false> | BookingSettingsSelect<true>;
     availability: AvailabilitySelect<false> | AvailabilitySelect<true>;
   };
@@ -1025,6 +1027,27 @@ export interface SiteConfig {
   createdAt?: string | null;
 }
 /**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "site-design".
+ */
+export interface SiteDesign {
+  id: number;
+  logoUrl?: string | null;
+  headingFont?: ('poppins' | 'tangerine' | 'abril') | null;
+  bodyFont?: ('poppins' | 'tangerine' | 'abril') | null;
+  colorBg?: string | null;
+  colorBgAccent?: string | null;
+  colorHeading?: string | null;
+  colorBody?: string | null;
+  colorDetail?: string | null;
+  colorBtnBg?: string | null;
+  spacingScale?: ('compact' | 'normal' | 'spacious') | null;
+  buttonStyle?: ('sharp' | 'rounded' | 'pill') | null;
+  animationsEnabled?: boolean | null;
+  updatedAt?: string | null;
+  createdAt?: string | null;
+}
+/**
  * Controls how far in advance clients can request sessions. Changes take effect immediately — no code change needed.
  *
  * This interface was referenced by `Config`'s JSON-Schema
@@ -1138,6 +1161,27 @@ export interface SiteConfigSelect<T extends boolean = true> {
   facebookUrl?: T;
   tiktokUrl?: T;
   pinterestUrl?: T;
+  updatedAt?: T;
+  createdAt?: T;
+  globalType?: T;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "site-design_select".
+ */
+export interface SiteDesignSelect<T extends boolean = true> {
+  logoUrl?: T;
+  headingFont?: T;
+  bodyFont?: T;
+  colorBg?: T;
+  colorBgAccent?: T;
+  colorHeading?: T;
+  colorBody?: T;
+  colorDetail?: T;
+  colorBtnBg?: T;
+  spacingScale?: T;
+  buttonStyle?: T;
+  animationsEnabled?: T;
   updatedAt?: T;
   createdAt?: T;
   globalType?: T;

--- a/payload.config.ts
+++ b/payload.config.ts
@@ -16,6 +16,7 @@ import { Posts } from './collections/Posts'
 import { HeroSlides } from './globals/HeroSlides'
 import { AboutPage } from './globals/AboutPage'
 import { SiteConfig } from './globals/SiteConfig'
+import { SiteDesign } from './globals/SiteDesign'
 import { BookingSettings } from './globals/BookingSettings'
 import { Availability } from './globals/Availability'
 import { Pages } from './collections/Pages'
@@ -117,7 +118,7 @@ export default buildConfig({
   },
   sharp,
   collections: [Users, Photos, Galleries, Testimonials, Services, Posts, Pages, Projects],
-  globals: [HeroSlides, AboutPage, SiteConfig, BookingSettings, Availability],
+  globals: [HeroSlides, AboutPage, SiteConfig, SiteDesign, BookingSettings, Availability],
   editor: lexicalEditor(),
   secret: process.env.PAYLOAD_SECRET || '',
   typescript: {

--- a/scripts/migrate-db.mjs
+++ b/scripts/migrate-db.mjs
@@ -573,6 +573,36 @@ async function run() {
     `)
 
     console.log('✓ users.role ready')
+
+    // ------------------------------------------------------------------
+    // Migration 20260715_100000: site_design global table (TYN-314)
+    // Site-wide theme (logo, fonts, colors, spacing, button style,
+    // animations) edited from the /design Studio page. Defaults match
+    // tokens.css's existing hardcoded values so publishing for the first
+    // time is a no-op visually until something is actually changed.
+    // ------------------------------------------------------------------
+
+    await client.query(`
+      CREATE TABLE IF NOT EXISTS "site_design" (
+        "id"                  serial  PRIMARY KEY NOT NULL,
+        "logo_url"            varchar,
+        "heading_font"        varchar DEFAULT 'poppins',
+        "body_font"           varchar DEFAULT 'poppins',
+        "color_bg"            varchar DEFAULT '#0C0C0C',
+        "color_bg_accent"     varchar DEFAULT '#131313',
+        "color_heading"       varchar DEFAULT '#D6D1CE',
+        "color_body"          varchar DEFAULT '#E6E1DE',
+        "color_detail"        varchar DEFAULT '#9B9A9A',
+        "color_btn_bg"        varchar DEFAULT '#9B9A9A',
+        "spacing_scale"       varchar DEFAULT 'normal',
+        "button_style"        varchar DEFAULT 'sharp',
+        "animations_enabled"  boolean DEFAULT true,
+        "updated_at"          timestamp(3) with time zone DEFAULT now() NOT NULL,
+        "created_at"          timestamp(3) with time zone DEFAULT now() NOT NULL
+      )
+    `)
+
+    console.log('✓ site_design table ready')
   } finally {
     client.release()
     await pool.end()


### PR DESCRIPTION
## Summary
- **TYN-314:** new `/design` Studio page (admin-only), modeled directly on Pixieset's Design editor - Logo & Branding, Fonts, Colors, Animations, Spacing, and Buttons controls in a left sidebar, with a live WYSIWYG preview of the real site that updates in real time (postMessage, nothing persisted until Publish) on the right.
- New `SiteDesign` global + `site_design` table (migration already run against the DB, confirmed live).
- Colors apply site-wide, including previously-hardcoded page-builder (Puck) content - refactored its color constants onto the same CSS vars the editor controls.
- Logo upload replaces the Navbar's text wordmark when set.
- Fixed two pre-existing hardcoded-hex bugs in `Contact.module.css` found along the way.

## Scope notes
- Fonts: limited to reassigning which of the 4 already-bundled font faces (Poppins/Tangerine/Abril Fatface) plays the heading/body role - not arbitrary Google Fonts selection.
- Buttons/Spacing: new CSS vars applied to the most prominent consumers (Hero, Contact, Puck builder), not retrofitted onto every single button/spacing rule sitewide.
- No literal multi-"Template" switcher - the Template card is a static label, matching the visual layout without building a second full template system.

## Test plan
- [x] `tsc --noEmit` and `npm run build` both clean
- [x] Verified live in a local production build: editor renders all sections, no console errors
- [x] Live preview confirmed working - changed a color field, watched the iframe update instantly with nothing saved
- [x] Publish confirmed working end-to-end: persists to DB, real public homepage reflects it on next load
- [x] Confirmed a published Puck-builder page also picks up the new theme (test accent color applied correctly)
- [x] Migration (`site_design` table) already run against the database

🤖 Generated with [Claude Code](https://claude.com/claude-code)