### PR TITLE
Embed the real Design panel in the Website hub, matching Pixieset

### DIFF
--- a/app/builder/DesignPanelShared.tsx
+++ b/app/builder/DesignPanelShared.tsx
@@ -1,0 +1,188 @@
+'use client'
+
+import { useCallback, useEffect, useRef } from 'react'
+import { themeToCssVarMap, type SiteTheme } from '@/app/lib/siteTheme'
+
+// Shared pieces between the standalone /design editor (DesignClient.tsx) and
+// the embedded Design tab inside the /builder Website hub (SiteEditorClient.tsx),
+// so both present the exact same controls instead of two diverging copies.
+
+export const FONT_OPTIONS: { label: string; value: SiteTheme['headingFont'] }[] = [
+  { label: 'Poppins', value: 'poppins' },
+  { label: 'Tangerine', value: 'tangerine' },
+  { label: 'Abril Fatface', value: 'abril' },
+]
+export const SPACING_OPTIONS: { label: string; value: SiteTheme['spacingScale'] }[] = [
+  { label: 'Compact', value: 'compact' },
+  { label: 'Normal', value: 'normal' },
+  { label: 'Spacious', value: 'spacious' },
+]
+export const BUTTON_OPTIONS: { label: string; value: SiteTheme['buttonStyle'] }[] = [
+  { label: 'Sharp', value: 'sharp' },
+  { label: 'Rounded', value: 'rounded' },
+  { label: 'Pill', value: 'pill' },
+]
+
+export const COLOR_FIELDS: { key: keyof Pick<SiteTheme, 'colorBg' | 'colorBgAccent' | 'colorHeading' | 'colorBody' | 'colorDetail' | 'colorBtnBg'>; label: string }[] = [
+  { key: 'colorBg', label: 'Background color' },
+  { key: 'colorBgAccent', label: 'Accent background color' },
+  { key: 'colorHeading', label: 'Heading text color' },
+  { key: 'colorBody', label: 'Body text color' },
+  { key: 'colorDetail', label: 'Detail / muted text color' },
+  { key: 'colorBtnBg', label: 'Button color' },
+]
+
+export function AccordionRow({ label, isOpen, onToggle, children }: { label: string; isOpen: boolean; onToggle: () => void; children: React.ReactNode }) {
+  return (
+    <div style={{ borderBottom: '1px solid #1a1a1a' }}>
+      <button
+        type="button"
+        onClick={onToggle}
+        aria-expanded={isOpen}
+        style={{ width: '100%', display: 'flex', alignItems: 'center', justifyContent: 'space-between', padding: '12px 4px', background: 'none', border: 'none', color: '#e6e1de', fontSize: 13.5, fontWeight: 500, cursor: 'pointer', textAlign: 'left' }}
+      >
+        {label}
+        <span style={{ color: '#6b6a6a', transform: isOpen ? 'rotate(180deg)' : 'none', transition: 'transform 0.15s' }}>&#9660;</span>
+      </button>
+      {isOpen && <div style={{ padding: '2px 4px 16px' }}>{children}</div>}
+    </div>
+  )
+}
+
+export function FieldLabel({ children, style }: { children: React.ReactNode; style?: React.CSSProperties }) {
+  return <label style={{ display: 'block', color: '#9b9a9a', fontSize: 11.5, marginBottom: 6, ...style }}>{children}</label>
+}
+
+export function Select<T extends string>({ value, onChange, options }: { value: T; onChange: (v: string) => void; options: { label: string; value: T }[] }) {
+  return (
+    <select
+      value={value}
+      onChange={(e) => onChange(e.target.value)}
+      style={{ width: '100%', background: '#1a1a1a', color: '#e6e1de', border: '1px solid #2a2a2a', borderRadius: 5, padding: '8px 10px', fontSize: 13 }}
+    >
+      {options.map((o) => (
+        <option key={o.value} value={o.value}>{o.label}</option>
+      ))}
+    </select>
+  )
+}
+
+export function ColorInput({ value, onChange }: { value: string; onChange: (v: string) => void }) {
+  return (
+    <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+      <input
+        type="color"
+        value={/^#[0-9a-fA-F]{6}$/.test(value) ? value : '#000000'}
+        onChange={(e) => onChange(e.target.value)}
+        style={{ width: 36, height: 32, padding: 0, border: '1px solid #2a2a2a', borderRadius: 4, background: 'none', cursor: 'pointer' }}
+      />
+      <input
+        type="text"
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        style={{ flex: 1, background: '#1a1a1a', color: '#e6e1de', border: '1px solid #2a2a2a', borderRadius: 5, padding: '7px 10px', fontSize: 13, fontFamily: 'monospace' }}
+      />
+    </div>
+  )
+}
+
+// Renders the full set of accordion sections (Logo & Branding, Fonts, Colors,
+// Animations, Spacing, Buttons) for a given theme + setter, so both consumers
+// share one implementation of "what the controls look like."
+export function DesignSections({
+  theme, set, open, setOpen, ImagePickerField,
+}: {
+  theme: SiteTheme
+  set: <K extends keyof SiteTheme>(key: K, value: SiteTheme[K]) => void
+  open: string | null
+  setOpen: (s: string | null) => void
+  ImagePickerField: React.ComponentType<{ value?: string; onChange: (v: string) => void }>
+}) {
+  return (
+    <>
+      <AccordionRow label="Logo & Branding" isOpen={open === 'logo'} onToggle={() => setOpen(open === 'logo' ? null : 'logo')}>
+        <FieldLabel>Logo image</FieldLabel>
+        <ImagePickerField value={theme.logoUrl} onChange={(v) => set('logoUrl', v)} />
+        <p style={{ color: '#6b6a6a', fontSize: 11, marginTop: 8 }}>Leave empty to show the text wordmark instead of an image.</p>
+      </AccordionRow>
+
+      <AccordionRow label="Fonts" isOpen={open === 'fonts'} onToggle={() => setOpen(open === 'fonts' ? null : 'fonts')}>
+        <FieldLabel>Heading font</FieldLabel>
+        <Select value={theme.headingFont} onChange={(v) => set('headingFont', v as SiteTheme['headingFont'])} options={FONT_OPTIONS} />
+        <FieldLabel style={{ marginTop: 12 }}>Body font</FieldLabel>
+        <Select value={theme.bodyFont} onChange={(v) => set('bodyFont', v as SiteTheme['bodyFont'])} options={FONT_OPTIONS} />
+      </AccordionRow>
+
+      <AccordionRow label="Colors" isOpen={open === 'colors'} onToggle={() => setOpen(open === 'colors' ? null : 'colors')}>
+        {COLOR_FIELDS.map((f, i) => (
+          <div key={f.key} style={{ marginTop: i === 0 ? 0 : 12 }}>
+            <FieldLabel>{f.label}</FieldLabel>
+            <ColorInput value={theme[f.key]} onChange={(v) => set(f.key, v)} />
+          </div>
+        ))}
+      </AccordionRow>
+
+      <AccordionRow label="Animations" isOpen={open === 'animations'} onToggle={() => setOpen(open === 'animations' ? null : 'animations')}>
+        <label style={{ display: 'flex', alignItems: 'center', gap: 8, color: '#e6e1de', fontSize: 13, cursor: 'pointer' }}>
+          <input type="checkbox" checked={theme.animationsEnabled} onChange={(e) => set('animationsEnabled', e.target.checked)} />
+          Enable animations
+        </label>
+        <p style={{ color: '#6b6a6a', fontSize: 11, marginTop: 8 }}>Turns off decorative transitions/animations sitewide when unchecked.</p>
+      </AccordionRow>
+
+      <AccordionRow label="Spacing" isOpen={open === 'spacing'} onToggle={() => setOpen(open === 'spacing' ? null : 'spacing')}>
+        <FieldLabel>Overall spacing</FieldLabel>
+        <Select value={theme.spacingScale} onChange={(v) => set('spacingScale', v as SiteTheme['spacingScale'])} options={SPACING_OPTIONS} />
+      </AccordionRow>
+
+      <AccordionRow label="Buttons" isOpen={open === 'buttons'} onToggle={() => setOpen(open === 'buttons' ? null : 'buttons')}>
+        <FieldLabel>Button shape</FieldLabel>
+        <Select value={theme.buttonStyle} onChange={(v) => set('buttonStyle', v as SiteTheme['buttonStyle'])} options={BUTTON_OPTIONS} />
+      </AccordionRow>
+    </>
+  )
+}
+
+// Real-time live-preview sync: posts the current theme to a preview target
+// (an iframe's contentWindow, and/or a popped-out tab) on every change, and
+// answers the DesignPreviewBridge's ready handshake so a (re)mounted preview
+// gets the current draft immediately, not just on the next edit.
+export function useDesignPreviewSync(theme: SiteTheme, active: boolean) {
+  const iframeRef = useRef<HTMLIFrameElement>(null)
+  const previewWinRef = useRef<Window | null>(null)
+  const themeRef = useRef(theme)
+  themeRef.current = theme
+
+  const postToTarget = useCallback((win: Window | null | undefined) => {
+    if (!win) return
+    win.postMessage(
+      { type: 'THP_DESIGN_PREVIEW', vars: themeToCssVarMap(themeRef.current), animationsEnabled: themeRef.current.animationsEnabled },
+      window.location.origin,
+    )
+  }, [])
+
+  useEffect(() => {
+    if (!active) return
+    postToTarget(iframeRef.current?.contentWindow)
+    if (previewWinRef.current && !previewWinRef.current.closed) postToTarget(previewWinRef.current)
+  }, [theme, active, postToTarget])
+
+  useEffect(() => {
+    if (!active) return
+    function handleReady(event: MessageEvent) {
+      if (event.origin !== window.location.origin) return
+      if ((event.data as { type?: string } | undefined)?.type !== 'THP_DESIGN_PREVIEW_READY') return
+      postToTarget(event.source as Window)
+    }
+    window.addEventListener('message', handleReady)
+    return () => window.removeEventListener('message', handleReady)
+  }, [active, postToTarget])
+
+  const openPreviewTab = useCallback((href: string) => {
+    const sep = href.includes('?') ? '&' : '?'
+    const win = window.open(`${href}${sep}__designPreview=1`, '_blank')
+    previewWinRef.current = win
+  }, [])
+
+  return { iframeRef, openPreviewTab }
+}

--- a/app/builder/SiteEditorClient.tsx
+++ b/app/builder/SiteEditorClient.tsx
@@ -1,6 +1,9 @@
 'use client'
 import { useState, useCallback, useRef, useEffect } from 'react'
 import { PortfolioTab } from './PortfolioTab'
+import { ImagePickerField } from './ImagePickerField'
+import { DesignSections, useDesignPreviewSync } from './DesignPanelShared'
+import type { SiteTheme } from '@/app/lib/siteTheme'
 
 // System font stack matches Pixieset's clean UI look
 const ui = "Inter, system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif"
@@ -552,7 +555,7 @@ function ProductSwitcher({ onClose, anchorRef }: { onClose: () => void; anchorRe
 type Tab = 'pages' | 'design' | 'blog' | 'settings'
 type Product = 'portfolio' | 'website'
 
-export function SiteEditorClient({ initialPages, initialProduct = 'website' }: { initialPages: SitePage[]; initialProduct?: Product }) {
+export function SiteEditorClient({ initialPages, initialProduct = 'website', initialTheme }: { initialPages: SitePage[]; initialProduct?: Product; initialTheme: SiteTheme }) {
   const [pages, setPages] = useState<SitePage[]>(initialPages)
   const [activeTab, setActiveTab] = useState<Tab>('pages')
   const [product, setProduct] = useState<Product>(initialProduct)
@@ -560,6 +563,35 @@ export function SiteEditorClient({ initialPages, initialProduct = 'website' }: {
   const [publishing, setPublishing] = useState(false)
   const [showSwitcher, setShowSwitcher] = useState(false)
   const switcherBtnRef = useRef<HTMLButtonElement>(null)
+
+  // Design tab (TYN-314/TYN-315): embedded here so it matches Pixieset's
+  // unified editor - controls on the left, the SAME live preview pane on the
+  // right updates in real time, no separate page navigation.
+  const [theme, setTheme] = useState<SiteTheme>(initialTheme)
+  const [designOpen, setDesignOpen] = useState<string | null>('logo')
+  const [designSaving, setDesignSaving] = useState(false)
+  const [designSaved, setDesignSaved] = useState(false)
+  const isDesignTab = activeTab === 'design'
+  const { iframeRef: designIframeRef, openPreviewTab: openDesignPreviewTab } = useDesignPreviewSync(theme, isDesignTab)
+
+  const setThemeField = <K extends keyof SiteTheme>(key: K, value: SiteTheme[K]) => {
+    setDesignSaved(false)
+    setTheme((t) => ({ ...t, [key]: value }))
+  }
+
+  const publishDesign = async () => {
+    setDesignSaving(true)
+    try {
+      const res = await fetch('/api/design/save', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(theme),
+      })
+      if (res.ok) setDesignSaved(true)
+    } finally {
+      setDesignSaving(false)
+    }
+  }
 
   const switchProduct = (p: Product) => {
     setProduct(p)
@@ -778,21 +810,24 @@ export function SiteEditorClient({ initialPages, initialProduct = 'website' }: {
             </>
           )}
 
-          {/* Design tab (TYN-314) */}
-          {activeTab === 'design' && (
-            <div style={{ flex: 1, padding: '1.25rem 1rem', display: 'flex', flexDirection: 'column', gap: '0.5rem' }}>
+          {/* Design tab (TYN-314/TYN-315) - embedded, matching Pixieset's
+              unified layout: controls here, live preview in the shared pane
+              to the right, no separate page navigation. */}
+          {isDesignTab && (
+            <div style={{ flex: 1, overflowY: 'auto', padding: '1.25rem 1rem' }}>
               <p style={{ margin: '0 0 0.75rem', fontFamily: ui, fontSize: '0.9rem', fontWeight: 600, color: '#e0dcd8' }}>Design</p>
-              {/* eslint-disable-next-line @next/next/no-html-link-for-pages */}
-              <a href="/design"
-                style={{ display: 'block', padding: '0.55rem 0.75rem', background: 'rgba(255,255,255,0.03)', border: '1px solid rgba(255,255,255,0.07)', borderRadius: 7, color: '#c4bfb9', textDecoration: 'none', fontFamily: ui, fontSize: '0.83rem' }}
-                onMouseEnter={e => { (e.currentTarget as HTMLElement).style.background = 'rgba(255,255,255,0.06)' }}
-                onMouseLeave={e => { (e.currentTarget as HTMLElement).style.background = 'rgba(255,255,255,0.03)' }}
-              >
-                Open Design Editor
-              </a>
-              <p style={{ margin: '0.5rem 0 0', fontFamily: ui, fontSize: '0.78rem', color: '#6b6b6b', lineHeight: 1.6 }}>
-                Logo, fonts, colors, spacing, buttons, and animations, with a live preview of the real site.
-              </p>
+
+              <p style={{ margin: '0 0 0.5rem', fontFamily: mono, fontSize: '0.58rem', letterSpacing: '0.12em', color: '#4a4a4a', textTransform: 'uppercase' }}>Template</p>
+              <div style={{ display: 'flex', alignItems: 'center', gap: 10, padding: 10, background: 'rgba(255,255,255,0.03)', borderRadius: 7, border: '1px solid rgba(255,255,255,0.07)', marginBottom: '0.5rem' }}>
+                <div style={{ width: 38, height: 38, borderRadius: 4, background: 'linear-gradient(135deg,#2dd4bf,#0ea5e9)', flexShrink: 0 }} />
+                <div>
+                  <div style={{ color: '#e0dcd8', fontSize: 12.5, fontWeight: 600 }}>Editorial</div>
+                  <div style={{ color: '#6b6663', fontSize: 10.5 }}>Your site&apos;s current design</div>
+                </div>
+              </div>
+
+              <p style={{ margin: '1rem 0 0.25rem', fontFamily: mono, fontSize: '0.58rem', letterSpacing: '0.12em', color: '#4a4a4a', textTransform: 'uppercase' }}>Template Options</p>
+              <DesignSections theme={theme} set={setThemeField} open={designOpen} setOpen={setDesignOpen} ImagePickerField={ImagePickerField} />
             </div>
           )}
 
@@ -840,23 +875,35 @@ export function SiteEditorClient({ initialPages, initialProduct = 'website' }: {
 
           {/* ---- Bottom: Preview + Publish ---- */}
           <div style={{ borderTop: '1px solid rgba(255,255,255,0.07)', padding: '0.75rem', display: 'flex', gap: '0.5rem' }}>
-            <a
-              href="https://tynnellhollinsphotography.com" target="_blank" rel="noopener noreferrer"
-              style={{ flex: 1, display: 'flex', alignItems: 'center', justifyContent: 'center', padding: '0.6rem', background: 'none', border: '1px solid rgba(255,255,255,0.14)', borderRadius: 7, color: '#9b9a9a', fontSize: '0.82rem', fontFamily: ui, textDecoration: 'none', fontWeight: 500, transition: 'border-color 0.12s, color 0.12s' }}
-              onMouseEnter={e => { const el = e.currentTarget as HTMLElement; el.style.borderColor = 'rgba(255,255,255,0.28)'; el.style.color = '#d4d0cc' }}
-              onMouseLeave={e => { const el = e.currentTarget as HTMLElement; el.style.borderColor = 'rgba(255,255,255,0.14)'; el.style.color = '#9b9a9a' }}
-            >
-              Preview
-            </a>
+            {isDesignTab ? (
+              <button
+                type="button"
+                onClick={() => openDesignPreviewTab(previewHref)}
+                style={{ flex: 1, display: 'flex', alignItems: 'center', justifyContent: 'center', padding: '0.6rem', background: 'none', border: '1px solid rgba(255,255,255,0.14)', borderRadius: 7, color: '#9b9a9a', fontSize: '0.82rem', fontFamily: ui, fontWeight: 500, cursor: 'pointer', transition: 'border-color 0.12s, color 0.12s' }}
+                onMouseEnter={e => { const el = e.currentTarget as HTMLElement; el.style.borderColor = 'rgba(255,255,255,0.28)'; el.style.color = '#d4d0cc' }}
+                onMouseLeave={e => { const el = e.currentTarget as HTMLElement; el.style.borderColor = 'rgba(255,255,255,0.14)'; el.style.color = '#9b9a9a' }}
+              >
+                Preview
+              </button>
+            ) : (
+              <a
+                href="https://tynnellhollinsphotography.com" target="_blank" rel="noopener noreferrer"
+                style={{ flex: 1, display: 'flex', alignItems: 'center', justifyContent: 'center', padding: '0.6rem', background: 'none', border: '1px solid rgba(255,255,255,0.14)', borderRadius: 7, color: '#9b9a9a', fontSize: '0.82rem', fontFamily: ui, textDecoration: 'none', fontWeight: 500, transition: 'border-color 0.12s, color 0.12s' }}
+                onMouseEnter={e => { const el = e.currentTarget as HTMLElement; el.style.borderColor = 'rgba(255,255,255,0.28)'; el.style.color = '#d4d0cc' }}
+                onMouseLeave={e => { const el = e.currentTarget as HTMLElement; el.style.borderColor = 'rgba(255,255,255,0.14)'; el.style.color = '#9b9a9a' }}
+              >
+                Preview
+              </a>
+            )}
             <button
               type="button"
-              onClick={() => void publishAll()}
-              disabled={publishing} aria-busy={publishing}
-              style={{ flex: 1, padding: '0.6rem', background: teal, border: 'none', borderRadius: 7, color: '#fff', fontSize: '0.82rem', fontFamily: ui, fontWeight: 600, cursor: publishing ? 'wait' : 'pointer', opacity: publishing ? 0.7 : 1, transition: 'opacity 0.12s' }}
-              onMouseEnter={e => { if (!publishing) (e.currentTarget as HTMLElement).style.filter = 'brightness(1.1)' }}
+              onClick={() => void (isDesignTab ? publishDesign() : publishAll())}
+              disabled={isDesignTab ? designSaving : publishing} aria-busy={isDesignTab ? designSaving : publishing}
+              style={{ flex: 1, padding: '0.6rem', background: teal, border: 'none', borderRadius: 7, color: '#fff', fontSize: '0.82rem', fontFamily: ui, fontWeight: 600, cursor: (isDesignTab ? designSaving : publishing) ? 'wait' : 'pointer', opacity: (isDesignTab ? designSaving : publishing) ? 0.7 : 1, transition: 'opacity 0.12s' }}
+              onMouseEnter={e => { if (!(isDesignTab ? designSaving : publishing)) (e.currentTarget as HTMLElement).style.filter = 'brightness(1.1)' }}
               onMouseLeave={e => { (e.currentTarget as HTMLElement).style.filter = 'none' }}
             >
-              {publishing ? 'Publishing...' : 'Publish'}
+              {isDesignTab ? (designSaving ? 'Publishing...' : designSaved ? 'Published' : 'Publish') : (publishing ? 'Publishing...' : 'Publish')}
             </button>
           </div>
         </div>
@@ -878,10 +925,14 @@ export function SiteEditorClient({ initialPages, initialProduct = 'website' }: {
             </a>
           </div>
 
-          {/* Live preview iframe - key changes force a reload when page changes */}
+          {/* Live preview iframe - key changes force a reload when the page
+              (or design-preview mode) changes. When the Design tab is active,
+              ?__designPreview=1 activates DesignPreviewBridge on the loaded
+              page so it listens for and applies the live draft theme. */}
           <iframe
-            key={previewHref}
-            src={previewHref}
+            key={isDesignTab ? `design:${previewHref}` : previewHref}
+            ref={isDesignTab ? designIframeRef : undefined}
+            src={isDesignTab ? `${previewHref}${previewHref.includes('?') ? '&' : '?'}__designPreview=1` : previewHref}
             style={{ position: 'absolute', top: 36, left: 0, right: 0, bottom: 0, width: '100%', height: 'calc(100% - 36px)', border: 'none' }}
             title={`Preview: ${previewLabel}`}
           />

--- a/app/builder/page.tsx
+++ b/app/builder/page.tsx
@@ -3,6 +3,7 @@ import config from '@payload-config'
 import { headers } from 'next/headers'
 import { redirect } from 'next/navigation'
 import { SiteEditorClient, type SitePage } from './SiteEditorClient'
+import { getSiteDesign } from '@/app/lib/siteDesign'
 
 export const dynamic = 'force-dynamic'
 export const metadata = { title: 'Studio' }
@@ -38,5 +39,7 @@ export default async function BuilderHome({
     updatedAt: p.updatedAt,
   }))
 
-  return <SiteEditorClient initialPages={pages} initialProduct={initialProduct} />
+  const initialTheme = await getSiteDesign()
+
+  return <SiteEditorClient initialPages={pages} initialProduct={initialProduct} initialTheme={initialTheme} />
 }

--- a/app/design/DesignClient.tsx
+++ b/app/design/DesignClient.tsx
@@ -1,83 +1,21 @@
 'use client'
 
-import { useCallback, useEffect, useRef, useState } from 'react'
+import { useState } from 'react'
 import Link from 'next/link'
 import { ImagePickerField } from '@/app/builder/ImagePickerField'
-import { themeToCssVarMap, type SiteTheme } from '@/app/lib/siteTheme'
-
-type Section = 'logo' | 'fonts' | 'colors' | 'animations' | 'spacing' | 'buttons'
-
-const FONT_OPTIONS: { label: string; value: SiteTheme['headingFont'] }[] = [
-  { label: 'Poppins', value: 'poppins' },
-  { label: 'Tangerine', value: 'tangerine' },
-  { label: 'Abril Fatface', value: 'abril' },
-]
-const SPACING_OPTIONS: { label: string; value: SiteTheme['spacingScale'] }[] = [
-  { label: 'Compact', value: 'compact' },
-  { label: 'Normal', value: 'normal' },
-  { label: 'Spacious', value: 'spacious' },
-]
-const BUTTON_OPTIONS: { label: string; value: SiteTheme['buttonStyle'] }[] = [
-  { label: 'Sharp', value: 'sharp' },
-  { label: 'Rounded', value: 'rounded' },
-  { label: 'Pill', value: 'pill' },
-]
-
-const COLOR_FIELDS: { key: keyof Pick<SiteTheme, 'colorBg' | 'colorBgAccent' | 'colorHeading' | 'colorBody' | 'colorDetail' | 'colorBtnBg'>; label: string }[] = [
-  { key: 'colorBg', label: 'Background color' },
-  { key: 'colorBgAccent', label: 'Accent background color' },
-  { key: 'colorHeading', label: 'Heading text color' },
-  { key: 'colorBody', label: 'Body text color' },
-  { key: 'colorDetail', label: 'Detail / muted text color' },
-  { key: 'colorBtnBg', label: 'Button color' },
-]
+import { DesignSections, useDesignPreviewSync } from '@/app/builder/DesignPanelShared'
+import type { SiteTheme } from '@/app/lib/siteTheme'
 
 export function DesignClient({ initialTheme }: { initialTheme: SiteTheme }) {
   const [theme, setTheme] = useState<SiteTheme>(initialTheme)
-  const [open, setOpen] = useState<Section | null>('logo')
+  const [open, setOpen] = useState<string | null>('logo')
   const [saving, setSaving] = useState(false)
   const [saved, setSaved] = useState(false)
-  const iframeRef = useRef<HTMLIFrameElement>(null)
-  const previewWinRef = useRef<Window | null>(null)
-  const themeRef = useRef(theme)
-  themeRef.current = theme
-
-  const postToTarget = useCallback((win: Window | null | undefined) => {
-    if (!win) return
-    win.postMessage(
-      { type: 'THP_DESIGN_PREVIEW', vars: themeToCssVarMap(themeRef.current), animationsEnabled: themeRef.current.animationsEnabled },
-      window.location.origin,
-    )
-  }, [])
-
-  // Push the latest draft state to the live preview iframe (and an optional
-  // popped-out preview tab) on every change - this is what makes the editor
-  // feel like Pixieset's as-you-type preview, with nothing persisted yet.
-  useEffect(() => {
-    postToTarget(iframeRef.current?.contentWindow)
-    if (previewWinRef.current && !previewWinRef.current.closed) postToTarget(previewWinRef.current)
-  }, [theme, postToTarget])
-
-  // Answer the preview bridge's "ready" handshake (fires on iframe load and
-  // whenever a popped-out preview tab's bridge mounts) with the current draft.
-  useEffect(() => {
-    function handleReady(event: MessageEvent) {
-      if (event.origin !== window.location.origin) return
-      if ((event.data as { type?: string } | undefined)?.type !== 'THP_DESIGN_PREVIEW_READY') return
-      postToTarget(event.source as Window)
-    }
-    window.addEventListener('message', handleReady)
-    return () => window.removeEventListener('message', handleReady)
-  }, [postToTarget])
+  const { iframeRef, openPreviewTab } = useDesignPreviewSync(theme, true)
 
   const set = <K extends keyof SiteTheme>(key: K, value: SiteTheme[K]) => {
     setSaved(false)
     setTheme((t) => ({ ...t, [key]: value }))
-  }
-
-  const openPreviewTab = () => {
-    const win = window.open('/?__designPreview=1', '_blank')
-    previewWinRef.current = win
   }
 
   const publish = async () => {
@@ -115,50 +53,11 @@ export function DesignClient({ initialTheme }: { initialTheme: SiteTheme }) {
 
         <div style={{ padding: '10px 20px 20px', flex: 1 }}>
           <p style={{ margin: '10px 0', color: '#6b6a6a', fontSize: 11, letterSpacing: '0.08em', textTransform: 'uppercase' }}>Template Options</p>
-
-          <AccordionRow label="Logo & Branding" isOpen={open === 'logo'} onToggle={() => setOpen(open === 'logo' ? null : 'logo')}>
-            <FieldLabel>Logo image</FieldLabel>
-            <ImagePickerField value={theme.logoUrl} onChange={(v) => set('logoUrl', v)} />
-            <p style={{ color: '#6b6a6a', fontSize: 11, marginTop: 8 }}>Leave empty to show the text wordmark instead of an image.</p>
-          </AccordionRow>
-
-          <AccordionRow label="Fonts" isOpen={open === 'fonts'} onToggle={() => setOpen(open === 'fonts' ? null : 'fonts')}>
-            <FieldLabel>Heading font</FieldLabel>
-            <Select value={theme.headingFont} onChange={(v) => set('headingFont', v as SiteTheme['headingFont'])} options={FONT_OPTIONS} />
-            <FieldLabel style={{ marginTop: 12 }}>Body font</FieldLabel>
-            <Select value={theme.bodyFont} onChange={(v) => set('bodyFont', v as SiteTheme['bodyFont'])} options={FONT_OPTIONS} />
-          </AccordionRow>
-
-          <AccordionRow label="Colors" isOpen={open === 'colors'} onToggle={() => setOpen(open === 'colors' ? null : 'colors')}>
-            {COLOR_FIELDS.map((f, i) => (
-              <div key={f.key} style={{ marginTop: i === 0 ? 0 : 12 }}>
-                <FieldLabel>{f.label}</FieldLabel>
-                <ColorInput value={theme[f.key]} onChange={(v) => set(f.key, v)} />
-              </div>
-            ))}
-          </AccordionRow>
-
-          <AccordionRow label="Animations" isOpen={open === 'animations'} onToggle={() => setOpen(open === 'animations' ? null : 'animations')}>
-            <label style={{ display: 'flex', alignItems: 'center', gap: 8, color: '#e6e1de', fontSize: 13, cursor: 'pointer' }}>
-              <input type="checkbox" checked={theme.animationsEnabled} onChange={(e) => set('animationsEnabled', e.target.checked)} />
-              Enable animations
-            </label>
-            <p style={{ color: '#6b6a6a', fontSize: 11, marginTop: 8 }}>Turns off decorative transitions/animations sitewide when unchecked.</p>
-          </AccordionRow>
-
-          <AccordionRow label="Spacing" isOpen={open === 'spacing'} onToggle={() => setOpen(open === 'spacing' ? null : 'spacing')}>
-            <FieldLabel>Overall spacing</FieldLabel>
-            <Select value={theme.spacingScale} onChange={(v) => set('spacingScale', v as SiteTheme['spacingScale'])} options={SPACING_OPTIONS} />
-          </AccordionRow>
-
-          <AccordionRow label="Buttons" isOpen={open === 'buttons'} onToggle={() => setOpen(open === 'buttons' ? null : 'buttons')}>
-            <FieldLabel>Button shape</FieldLabel>
-            <Select value={theme.buttonStyle} onChange={(v) => set('buttonStyle', v as SiteTheme['buttonStyle'])} options={BUTTON_OPTIONS} />
-          </AccordionRow>
+          <DesignSections theme={theme} set={set} open={open} setOpen={setOpen} ImagePickerField={ImagePickerField} />
         </div>
 
         <div style={{ padding: '16px 20px', borderTop: '1px solid #1e1e1e', display: 'flex', gap: 10 }}>
-          <button type="button" onClick={openPreviewTab} style={{ flex: 1, padding: '10px 0', borderRadius: 6, border: '1px solid #2a2a2a', background: 'transparent', color: '#e6e1de', fontSize: 13, cursor: 'pointer' }}>
+          <button type="button" onClick={() => openPreviewTab('/')} style={{ flex: 1, padding: '10px 0', borderRadius: 6, border: '1px solid #2a2a2a', background: 'transparent', color: '#e6e1de', fontSize: 13, cursor: 'pointer' }}>
             Preview
           </button>
           <button
@@ -180,60 +79,6 @@ export function DesignClient({ initialTheme }: { initialTheme: SiteTheme }) {
           style={{ border: 'none', width: '100%', height: '100%' }}
         />
       </main>
-    </div>
-  )
-}
-
-function AccordionRow({ label, isOpen, onToggle, children }: { label: string; isOpen: boolean; onToggle: () => void; children: React.ReactNode }) {
-  return (
-    <div style={{ borderBottom: '1px solid #1a1a1a' }}>
-      <button
-        type="button"
-        onClick={onToggle}
-        aria-expanded={isOpen}
-        style={{ width: '100%', display: 'flex', alignItems: 'center', justifyContent: 'space-between', padding: '12px 4px', background: 'none', border: 'none', color: '#e6e1de', fontSize: 13.5, fontWeight: 500, cursor: 'pointer', textAlign: 'left' }}
-      >
-        {label}
-        <span style={{ color: '#6b6a6a', transform: isOpen ? 'rotate(180deg)' : 'none', transition: 'transform 0.15s' }}>&#9660;</span>
-      </button>
-      {isOpen && <div style={{ padding: '2px 4px 16px' }}>{children}</div>}
-    </div>
-  )
-}
-
-function FieldLabel({ children, style }: { children: React.ReactNode; style?: React.CSSProperties }) {
-  return <label style={{ display: 'block', color: '#9b9a9a', fontSize: 11.5, marginBottom: 6, ...style }}>{children}</label>
-}
-
-function Select<T extends string>({ value, onChange, options }: { value: T; onChange: (v: string) => void; options: { label: string; value: T }[] }) {
-  return (
-    <select
-      value={value}
-      onChange={(e) => onChange(e.target.value)}
-      style={{ width: '100%', background: '#1a1a1a', color: '#e6e1de', border: '1px solid #2a2a2a', borderRadius: 5, padding: '8px 10px', fontSize: 13 }}
-    >
-      {options.map((o) => (
-        <option key={o.value} value={o.value}>{o.label}</option>
-      ))}
-    </select>
-  )
-}
-
-function ColorInput({ value, onChange }: { value: string; onChange: (v: string) => void }) {
-  return (
-    <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
-      <input
-        type="color"
-        value={/^#[0-9a-fA-F]{6}$/.test(value) ? value : '#000000'}
-        onChange={(e) => onChange(e.target.value)}
-        style={{ width: 36, height: 32, padding: 0, border: '1px solid #2a2a2a', borderRadius: 4, background: 'none', cursor: 'pointer' }}
-      />
-      <input
-        type="text"
-        value={value}
-        onChange={(e) => onChange(e.target.value)}
-        style={{ flex: 1, background: '#1a1a1a', color: '#e6e1de', border: '1px solid #2a2a2a', borderRadius: 5, padding: '7px 10px', fontSize: 13, fontFamily: 'monospace' }}
-      />
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- **TYN-315 follow-up:** the earlier fix just linked out to `/design`. That's not what Pixieset does - it embeds the Template + accordion controls directly in the Website hub sidebar, with the live preview already visible alongside it, no navigation to a separate page.
- `/builder` -> Website -> Design tab now renders the same Template card + accordion sections (Logo & Branding, Fonts, Colors, Animations, Spacing, Buttons) inline, sharing implementation with the standalone `/design` editor via a new `DesignPanelShared.tsx`.
- The hub's existing persistent live-preview iframe now gets real-time postMessage updates when the Design tab is active - same live-preview mechanic as the standalone editor, unified into the one view.
- Preview/Publish now branch per active tab (Design publishes the theme; other tabs keep the original page-publish behavior).

## Test plan
- [x] `tsc --noEmit` and `npm run build` clean
- [x] Verified in a local production build: Design tab shows full controls inline (no separate page), changing a color updates the shared preview pane in real time, Publish persists via `/api/design/save`, switching to/from Pages/Blog/Settings tabs still works correctly
- [x] Reset test theme values back to defaults after verification (shared production DB)

🤖 Generated with [Claude Code](https://claude.com/claude-code)