### PR TITLE
Fix CSP blocking all photo uploads (R2 presigned PUT)

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -16,7 +16,11 @@ const csp = [
   `style-src 'self' 'unsafe-inline' https://fonts.googleapis.com`,
   `font-src 'self' https://fonts.gstatic.com`,
   `img-src 'self' data: https://pub-db2dd9a6665142e4adcd4f822fbe2683.r2.dev https://media.tynnellhollinsphotography.com`,
-  `connect-src 'self' https://va.vercel-scripts.com`,
+  // R2 uploads PUT directly from the browser to a presigned URL on Cloudflare's
+  // S3-compatible endpoint (app/lib/uploadPhoto.ts) - without this, every photo
+  // upload sitewide (Photo Library, galleries, blog covers, builder/Design
+  // image pickers) is silently blocked by the browser as a CSP violation.
+  `connect-src 'self' https://va.vercel-scripts.com https://c5edbede1b4e1c8723a363615b47bb4c.r2.cloudflarestorage.com`,
   `frame-src 'self'`,
   `frame-ancestors 'self'`,
   `object-src 'none'`,


### PR DESCRIPTION
## Summary
- **TYN-316 (urgent):** CSP `connect-src` never allowed the Cloudflare R2 upload endpoint, so every photo upload sitewide (Photo Library, galleries, blog covers, builder/Design image pickers) has been silently blocked by the browser since the TYN-301 CSP hardening pass. Likely the true root cause behind the original "can't upload photos" report - TYN-310 fixed reaching Photo Library, but any actual upload would still hit this.
- Added the R2 account's S3-API endpoint to `connect-src`.

## Test plan
- [x] `npm run build` clean
- [x] Verified the served CSP header now includes the R2 endpoint
- [x] Ran the full presign -> R2 PUT -> ingest pipeline directly against the real bucket/database post-fix: PUT succeeded (previously blocked), Photo record created, then deleted as cleanup (throwaway test file)

🤖 Generated with [Claude Code](https://claude.com/claude-code)