### PR TITLE
fix(admin): de-chrome SiteConfig, BookingSettings, HeroSlides globals (TYN-317/318/319)

### DIFF
--- a/app/(payload)/admin/importMap.js
+++ b/app/(payload)/admin/importMap.js
@@ -16,6 +16,9 @@ import { PaymentRowLabel as PaymentRowLabel_bf02cf58a8eb4dc67bc7319e475295f5 } f
 import { DocumentRowLabel as DocumentRowLabel_30f116d44c8626ae90f0b4f8f5e9927c } from '../../../collections/Projects/DocumentRowLabel'
 import { ProjectsKanbanView as ProjectsKanbanView_f170bd24e886f73d32f9a84f0a9ad5a0 } from '../../../components/admin/ProjectsKanbanView'
 import { AboutViewOnSiteButton as AboutViewOnSiteButton_e4e233e4cbe47762c0d80a0c040deafe } from '../../../components/admin/AboutViewOnSiteButton'
+import { SiteConfigHeader as SiteConfigHeader_a1b2c3d4e5f60718293a4b5c6d7e8f90 } from '../../../components/admin/SiteConfigHeader'
+import { BookingSettingsHeader as BookingSettingsHeader_b2c3d4e5f60718293a4b5c6d7e8f9001 } from '../../../components/admin/BookingSettingsHeader'
+import { HeroSlidesHeader as HeroSlidesHeader_c3d4e5f60718293a4b5c6d7e8f900112 } from '../../../components/admin/HeroSlidesHeader'
 import { RscEntryLexicalCell as RscEntryLexicalCell_44fe37237e0ebf4470c9990d8cb7b07e } from '@payloadcms/richtext-lexical/rsc'
 import { RscEntryLexicalField as RscEntryLexicalField_44fe37237e0ebf4470c9990d8cb7b07e } from '@payloadcms/richtext-lexical/rsc'
 import { LexicalDiffComponent as LexicalDiffComponent_44fe37237e0ebf4470c9990d8cb7b07e } from '@payloadcms/richtext-lexical/rsc'
@@ -70,6 +73,9 @@ export const importMap = {
   "./collections/Projects/DocumentRowLabel#DocumentRowLabel": DocumentRowLabel_30f116d44c8626ae90f0b4f8f5e9927c,
   "./components/admin/ProjectsKanbanView#ProjectsKanbanView": ProjectsKanbanView_f170bd24e886f73d32f9a84f0a9ad5a0,
   "./components/admin/AboutViewOnSiteButton#AboutViewOnSiteButton": AboutViewOnSiteButton_e4e233e4cbe47762c0d80a0c040deafe,
+  "./components/admin/SiteConfigHeader#SiteConfigHeader": SiteConfigHeader_a1b2c3d4e5f60718293a4b5c6d7e8f90,
+  "./components/admin/BookingSettingsHeader#BookingSettingsHeader": BookingSettingsHeader_b2c3d4e5f60718293a4b5c6d7e8f9001,
+  "./components/admin/HeroSlidesHeader#HeroSlidesHeader": HeroSlidesHeader_c3d4e5f60718293a4b5c6d7e8f900112,
   "@payloadcms/richtext-lexical/rsc#RscEntryLexicalCell": RscEntryLexicalCell_44fe37237e0ebf4470c9990d8cb7b07e,
   "@payloadcms/richtext-lexical/rsc#RscEntryLexicalField": RscEntryLexicalField_44fe37237e0ebf4470c9990d8cb7b07e,
   "@payloadcms/richtext-lexical/rsc#LexicalDiffComponent": LexicalDiffComponent_44fe37237e0ebf4470c9990d8cb7b07e,

--- a/components/admin/BookingSettingsHeader.tsx
+++ b/components/admin/BookingSettingsHeader.tsx
@@ -1,0 +1,15 @@
+'use client'
+import React from 'react'
+import { GlobalEditHeader } from './GlobalEditHeader'
+
+export function BookingSettingsHeader() {
+  return (
+    <GlobalEditHeader
+      icon="▤"
+      title="Booking Settings"
+      description="Controls how far in advance clients can request sessions on your Book page. Changes take effect immediately."
+      viewOnSiteUrl="https://tynnellhollinsphotography.com/book"
+      viewOnSiteLabel="View Book Page on Site"
+    />
+  )
+}

--- a/components/admin/GlobalEditHeader.tsx
+++ b/components/admin/GlobalEditHeader.tsx
@@ -1,0 +1,106 @@
+'use client'
+import React from 'react'
+
+/**
+ * Shared branded header strip for global settings edit screens (SiteConfig,
+ * BookingSettings, HeroSlides). Sits above Payload's stock form as a `ui`
+ * field, same additive pattern as PhotoEditHeader - Payload still owns the
+ * breadcrumb, save bar, and field rendering underneath.
+ */
+export function GlobalEditHeader({
+  icon,
+  title,
+  description,
+  viewOnSiteUrl,
+  viewOnSiteLabel = 'View on Site',
+}: {
+  icon: string
+  title: string
+  description: string
+  viewOnSiteUrl?: string
+  viewOnSiteLabel?: string
+}) {
+  return (
+    <div
+      style={{
+        display: 'flex',
+        alignItems: 'flex-start',
+        gap: '1rem',
+        background: '#161616',
+        border: '1px solid rgba(155,154,154,0.18)',
+        borderRadius: 8,
+        padding: '1.25rem',
+        marginBottom: '1.75rem',
+      }}
+    >
+      <div
+        style={{
+          flex: '0 0 auto',
+          width: 44,
+          height: 44,
+          borderRadius: 8,
+          background: 'rgba(214,209,206,0.08)',
+          border: '1px solid rgba(155,154,154,0.18)',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          fontSize: '1.3rem',
+        }}
+        aria-hidden="true"
+      >
+        {icon}
+      </div>
+
+      <div style={{ flex: '1 1 auto', minWidth: 0 }}>
+        <div
+          style={{
+            color: '#D6D1CE',
+            fontSize: '1.1rem',
+            fontWeight: 500,
+            fontFamily: "'Archivo', sans-serif",
+            letterSpacing: '-0.01em',
+          }}
+        >
+          {title}
+        </div>
+        <p
+          style={{
+            margin: '0.35rem 0 0',
+            color: '#9B9A9A',
+            fontSize: '0.82rem',
+            lineHeight: 1.5,
+          }}
+        >
+          {description}
+        </p>
+
+        {viewOnSiteUrl && (
+          <a
+            href={viewOnSiteUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            style={{
+              display: 'inline-flex',
+              alignItems: 'center',
+              gap: '0.35rem',
+              marginTop: '0.75rem',
+              fontSize: '0.72rem',
+              fontFamily: "'Roboto Mono', monospace",
+              letterSpacing: '0.05em',
+              color: '#9B9A9A',
+              textDecoration: 'none',
+              padding: '0.4rem 0.7rem',
+              border: '1px solid rgba(155,154,154,0.3)',
+              borderRadius: 4,
+              background: 'transparent',
+              width: 'fit-content',
+            }}
+          >
+            {viewOnSiteLabel}
+            <span aria-hidden="true" style={{ fontSize: '0.68rem', opacity: 0.7 }}>↗</span>
+          </a>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/components/admin/HeroSlidesHeader.tsx
+++ b/components/admin/HeroSlidesHeader.tsx
@@ -1,0 +1,15 @@
+'use client'
+import React from 'react'
+import { GlobalEditHeader } from './GlobalEditHeader'
+
+export function HeroSlidesHeader() {
+  return (
+    <GlobalEditHeader
+      icon="▦"
+      title="Hero Slides"
+      description="The full-screen photo carousel on your homepage. Add, remove, or reorder slides below."
+      viewOnSiteUrl="https://tynnellhollinsphotography.com/"
+      viewOnSiteLabel="View Homepage on Site"
+    />
+  )
+}

--- a/components/admin/SiteConfigHeader.tsx
+++ b/components/admin/SiteConfigHeader.tsx
@@ -1,0 +1,13 @@
+'use client'
+import React from 'react'
+import { GlobalEditHeader } from './GlobalEditHeader'
+
+export function SiteConfigHeader() {
+  return (
+    <GlobalEditHeader
+      icon="⚙"
+      title="Site Settings"
+      description="Your business name, contact info, and social media links - shown across your site's header, footer, and contact page."
+    />
+  )
+}

--- a/globals/BookingSettings.ts
+++ b/globals/BookingSettings.ts
@@ -26,6 +26,15 @@ export const BookingSettings: GlobalConfig = {
   hooks: { afterChange: [revalidateBooking] },
   fields: [
     {
+      name: 'editHeader',
+      type: 'ui',
+      admin: {
+        components: {
+          Field: './components/admin/BookingSettingsHeader#BookingSettingsHeader',
+        },
+      },
+    },
+    {
       name: 'minLeadTimeHours',
       type: 'number',
       label: 'Minimum Lead Time (hours)',

--- a/globals/HeroSlides.ts
+++ b/globals/HeroSlides.ts
@@ -24,6 +24,15 @@ export const HeroSlides: GlobalConfig = {
   },
   fields: [
     {
+      name: 'editHeader',
+      type: 'ui',
+      admin: {
+        components: {
+          Field: './components/admin/HeroSlidesHeader#HeroSlidesHeader',
+        },
+      },
+    },
+    {
       name: 'slides',
       type: 'array',
       label: 'Slides',

--- a/globals/SiteConfig.ts
+++ b/globals/SiteConfig.ts
@@ -15,6 +15,15 @@ export const SiteConfig: GlobalConfig = {
   },
   fields: [
     {
+      name: 'editHeader',
+      type: 'ui',
+      admin: {
+        components: {
+          Field: './components/admin/SiteConfigHeader#SiteConfigHeader',
+        },
+      },
+    },
+    {
       name: 'title',
       type: 'text',
       label: 'Business Name',


### PR DESCRIPTION
## Summary
- Adds a shared `GlobalEditHeader` component (same additive pattern as `PhotoEditHeader`): branded icon, title, description, and an optional View on Site link, rendered above Payload's stock form fields.
- Wires it into `SiteConfig`, `BookingSettings`, and `HeroSlides` globals - the three globals identified as having zero custom admin treatment and being linked directly as navigation destinations from Studio/builder pages (StudioClient, StudioManagerClient, AvailabilityEditorClient, GalleryIndexClient, SiteEditorClient, Dashboard).
- Regenerated `importMap.js` by hand (generate:importmap CLI is broken on Node v24, same known issue as generate:types).

## Test plan
- [x] `tsc --noEmit` passes clean
- [x] Production build (`next build`) succeeds
- [x] Verified all three edit screens (`/admin/globals/site-config`, `/admin/globals/booking-settings`, `/admin/globals/hero-slides`) render the new header + fields correctly against a local production build