### PR TITLE
fix(admin): de-chrome AboutPage and Availability globals (TYN-320/321)

### DIFF
--- a/app/(payload)/admin/importMap.js
+++ b/app/(payload)/admin/importMap.js
@@ -19,6 +19,8 @@ import { AboutViewOnSiteButton as AboutViewOnSiteButton_e4e233e4cbe47762c0d80a0c
 import { SiteConfigHeader as SiteConfigHeader_a1b2c3d4e5f60718293a4b5c6d7e8f90 } from '../../../components/admin/SiteConfigHeader'
 import { BookingSettingsHeader as BookingSettingsHeader_b2c3d4e5f60718293a4b5c6d7e8f9001 } from '../../../components/admin/BookingSettingsHeader'
 import { HeroSlidesHeader as HeroSlidesHeader_c3d4e5f60718293a4b5c6d7e8f900112 } from '../../../components/admin/HeroSlidesHeader'
+import { AboutPageHeader as AboutPageHeader_d4e5f60718293a4b5c6d7e8f90011223 } from '../../../components/admin/AboutPageHeader'
+import { AvailabilityHeader as AvailabilityHeader_e5f60718293a4b5c6d7e8f9001122334 } from '../../../components/admin/AvailabilityHeader'
 import { RscEntryLexicalCell as RscEntryLexicalCell_44fe37237e0ebf4470c9990d8cb7b07e } from '@payloadcms/richtext-lexical/rsc'
 import { RscEntryLexicalField as RscEntryLexicalField_44fe37237e0ebf4470c9990d8cb7b07e } from '@payloadcms/richtext-lexical/rsc'
 import { LexicalDiffComponent as LexicalDiffComponent_44fe37237e0ebf4470c9990d8cb7b07e } from '@payloadcms/richtext-lexical/rsc'
@@ -76,6 +78,8 @@ export const importMap = {
   "./components/admin/SiteConfigHeader#SiteConfigHeader": SiteConfigHeader_a1b2c3d4e5f60718293a4b5c6d7e8f90,
   "./components/admin/BookingSettingsHeader#BookingSettingsHeader": BookingSettingsHeader_b2c3d4e5f60718293a4b5c6d7e8f9001,
   "./components/admin/HeroSlidesHeader#HeroSlidesHeader": HeroSlidesHeader_c3d4e5f60718293a4b5c6d7e8f900112,
+  "./components/admin/AboutPageHeader#AboutPageHeader": AboutPageHeader_d4e5f60718293a4b5c6d7e8f90011223,
+  "./components/admin/AvailabilityHeader#AvailabilityHeader": AvailabilityHeader_e5f60718293a4b5c6d7e8f9001122334,
   "@payloadcms/richtext-lexical/rsc#RscEntryLexicalCell": RscEntryLexicalCell_44fe37237e0ebf4470c9990d8cb7b07e,
   "@payloadcms/richtext-lexical/rsc#RscEntryLexicalField": RscEntryLexicalField_44fe37237e0ebf4470c9990d8cb7b07e,
   "@payloadcms/richtext-lexical/rsc#LexicalDiffComponent": LexicalDiffComponent_44fe37237e0ebf4470c9990d8cb7b07e,

--- a/components/admin/AboutPageHeader.tsx
+++ b/components/admin/AboutPageHeader.tsx
@@ -1,0 +1,13 @@
+'use client'
+import React from 'react'
+import { GlobalEditHeader } from './GlobalEditHeader'
+
+export function AboutPageHeader() {
+  return (
+    <GlobalEditHeader
+      icon="▣"
+      title="About Page"
+      description="Your headshot, bio, tagline, and values - shown on your About page and the about preview on your homepage."
+    />
+  )
+}

--- a/components/admin/AvailabilityHeader.tsx
+++ b/components/admin/AvailabilityHeader.tsx
@@ -1,0 +1,13 @@
+'use client'
+import React from 'react'
+import { GlobalEditHeader } from './GlobalEditHeader'
+
+export function AvailabilityHeader() {
+  return (
+    <GlobalEditHeader
+      icon="◷"
+      title="Availability"
+      description="Block out dates when you're unavailable. Clients requesting sessions during these windows see your custom message instead."
+    />
+  )
+}

--- a/globals/AboutPage.ts
+++ b/globals/AboutPage.ts
@@ -25,6 +25,15 @@ export const AboutPage: GlobalConfig = {
   },
   fields: [
     {
+      name: 'editHeader',
+      type: 'ui',
+      admin: {
+        components: {
+          Field: './components/admin/AboutPageHeader#AboutPageHeader',
+        },
+      },
+    },
+    {
       name: 'viewOnSite',
       type: 'ui',
       admin: {

--- a/globals/Availability.ts
+++ b/globals/Availability.ts
@@ -27,6 +27,15 @@ export const Availability: GlobalConfig = {
   },
   fields: [
     {
+      name: 'editHeader',
+      type: 'ui',
+      admin: {
+        components: {
+          Field: './components/admin/AvailabilityHeader#AvailabilityHeader',
+        },
+      },
+    },
+    {
       name: 'blockedRanges',
       type: 'array',
       label: 'Blocked Date Ranges',


### PR DESCRIPTION
## Summary
- Extends the GlobalEditHeader treatment (already shipped in #45 for SiteConfig/BookingSettings/HeroSlides) to `AboutPage` and `Availability`, the two remaining globals identified as only having a partial custom component (a single sidebar/inline ui field) while the rest of the edit screen was stock Payload chrome.
- `AboutPage` keeps its existing `AboutViewOnSiteButton` sidebar field; `Availability` keeps its existing `OooWarnings` field. Both now also show the branded icon/title/description header above the fields.
- Hand-patched `importMap.js` (generate:importmap CLI still broken on Node v24).

## Test plan
- [x] `tsc --noEmit` passes clean
- [x] Production build (`next build`) succeeds
- [x] Verified both edit screens (`/admin/globals/about-page`, `/admin/globals/availability`) render the new header alongside existing custom fields, against a local production build