### PR TITLE
fix(admin): add branded edit header to Services (TYN-318, 2 of 4)

### DIFF
--- a/app/(payload)/admin/importMap.js
+++ b/app/(payload)/admin/importMap.js
@@ -11,6 +11,7 @@ import { GalleryPhotoArranger as GalleryPhotoArranger_4f7a56c3214650ac93f2acac36
 import { GalleryGridView as GalleryGridView_694fcc37683b7c53f35803e850250b41 } from '../../../components/admin/GalleryGridView'
 import { TestimonialsGridView as TestimonialsGridView_9bf27bfb5cd9841095b9fe844bb8c4e3 } from '../../../components/admin/TestimonialsGridView'
 import { ServicesGridView as ServicesGridView_f8436fdecdb227662e953e6db61537d6 } from '../../../components/admin/ServicesGridView'
+import { ServicesEditHeader as ServicesEditHeader_b8c9d0e1f20314253647586970819a2b } from '../../../components/admin/ServicesEditHeader'
 import { SessionRowLabel as SessionRowLabel_c92e93eada15d796d5db9f3cea7a28dc } from '../../../collections/Projects/SessionRowLabel'
 import { PaymentRowLabel as PaymentRowLabel_bf02cf58a8eb4dc67bc7319e475295f5 } from '../../../collections/Projects/PaymentRowLabel'
 import { DocumentRowLabel as DocumentRowLabel_30f116d44c8626ae90f0b4f8f5e9927c } from '../../../collections/Projects/DocumentRowLabel'
@@ -70,6 +71,7 @@ export const importMap = {
   "./components/admin/GalleryGridView#GalleryGridView": GalleryGridView_694fcc37683b7c53f35803e850250b41,
   "./components/admin/TestimonialsGridView#TestimonialsGridView": TestimonialsGridView_9bf27bfb5cd9841095b9fe844bb8c4e3,
   "./components/admin/ServicesGridView#ServicesGridView": ServicesGridView_f8436fdecdb227662e953e6db61537d6,
+  "./components/admin/ServicesEditHeader#ServicesEditHeader": ServicesEditHeader_b8c9d0e1f20314253647586970819a2b,
   "./collections/Projects/SessionRowLabel#SessionRowLabel": SessionRowLabel_c92e93eada15d796d5db9f3cea7a28dc,
   "./collections/Projects/PaymentRowLabel#PaymentRowLabel": PaymentRowLabel_bf02cf58a8eb4dc67bc7319e475295f5,
   "./collections/Projects/DocumentRowLabel#DocumentRowLabel": DocumentRowLabel_30f116d44c8626ae90f0b4f8f5e9927c,

--- a/collections/Services.ts
+++ b/collections/Services.ts
@@ -35,6 +35,15 @@ export const Services: CollectionConfig = {
   },
   fields: [
     {
+      name: 'editHeader',
+      type: 'ui',
+      admin: {
+        components: {
+          Field: './components/admin/ServicesEditHeader#ServicesEditHeader',
+        },
+      },
+    },
+    {
       name: 'title',
       type: 'text',
       label: 'Service Name',

--- a/components/admin/ServicesEditHeader.tsx
+++ b/components/admin/ServicesEditHeader.tsx
@@ -1,0 +1,118 @@
+'use client'
+import React from 'react'
+import { useDocumentInfo, useFormFields } from '@payloadcms/ui'
+
+type FeatureRow = { feature?: string }
+
+export function ServicesEditHeader() {
+  const { id } = useDocumentInfo()
+  const title = useFormFields(([fields]) => fields.title?.value as string | undefined)
+  const eyebrow = useFormFields(([fields]) => fields.eyebrow?.value as string | undefined)
+  const description = useFormFields(([fields]) => fields.description?.value as string | undefined)
+  const price = useFormFields(([fields]) => fields.price?.value as string | undefined)
+  const depositAmount = useFormFields(([fields]) => fields.depositAmount?.value as number | undefined)
+  const displayOrder = useFormFields(([fields]) => fields.displayOrder?.value as number | undefined)
+  const features = useFormFields(([fields]) => fields.features?.value as FeatureRow[] | undefined)
+
+  if (!id) return null
+
+  const featureCount = Array.isArray(features) ? features.length : 0
+
+  return (
+    <div
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        gap: '0.6rem',
+        background: '#161616',
+        border: '1px solid rgba(155,154,154,0.18)',
+        borderRadius: 8,
+        padding: '1.25rem',
+        marginBottom: '1.75rem',
+      }}
+    >
+      <div>
+        {eyebrow && (
+          <div
+            style={{
+              color: '#9B9A9A',
+              fontSize: '0.68rem',
+              letterSpacing: '0.1em',
+              textTransform: 'uppercase',
+              marginBottom: '0.25rem',
+            }}
+          >
+            {eyebrow}
+          </div>
+        )}
+        <div style={{ color: '#D6D1CE', fontSize: '1.1rem', fontWeight: 500, fontFamily: "'Archivo', sans-serif", letterSpacing: '-0.01em' }}>
+          {title || 'Untitled Service'}
+        </div>
+        {description && (
+          <div
+            style={{
+              color: '#9B9A9A',
+              fontSize: '0.82rem',
+              lineHeight: 1.5,
+              marginTop: '0.4rem',
+              display: '-webkit-box',
+              WebkitLineClamp: 2,
+              WebkitBoxOrient: 'vertical',
+              overflow: 'hidden',
+            }}
+          >
+            {description}
+          </div>
+        )}
+      </div>
+
+      {/* Badges */}
+      <div style={{ display: 'flex', flexWrap: 'wrap', gap: '0.4rem', alignItems: 'center' }}>
+        {price && (
+          <span
+            style={{
+              padding: '0.16rem 0.55rem',
+              background: 'rgba(155,154,154,0.1)',
+              border: '1px solid rgba(155,154,154,0.2)',
+              borderRadius: 3,
+              fontSize: '0.72rem',
+              color: '#d6d1ce',
+              fontWeight: 500,
+              whiteSpace: 'nowrap',
+            }}
+          >
+            {price}
+          </span>
+        )}
+
+        {depositAmount != null && (
+          <span
+            style={{
+              padding: '0.16rem 0.55rem',
+              background: 'rgba(16,185,129,0.08)',
+              border: '1px solid rgba(16,185,129,0.2)',
+              borderRadius: 3,
+              fontSize: '0.68rem',
+              color: 'rgba(16,185,129,0.85)',
+              whiteSpace: 'nowrap',
+            }}
+          >
+            Bookable &middot; ${depositAmount} deposit
+          </span>
+        )}
+
+        {featureCount > 0 && (
+          <span style={{ fontSize: '0.62rem', color: 'rgba(155,154,154,0.55)', fontFamily: "'Roboto Mono', monospace" }}>
+            {featureCount} item{featureCount !== 1 ? 's' : ''}
+          </span>
+        )}
+
+        {displayOrder != null && (
+          <span style={{ fontSize: '0.62rem', color: 'rgba(155,154,154,0.4)', fontFamily: "'Roboto Mono', monospace" }}>
+            #{displayOrder}
+          </span>
+        )}
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- Second of the four TYN-318 collections. Confirmed via `next.config.mjs` (and `ServicesGridView.tsx`'s own links) that Services has no redirect/replacement page - its raw `/admin/collections/services/:id` edit screen is the real one a user sees.
- Adds `ServicesEditHeader` (new `components/admin/ServicesEditHeader.tsx`) as a top `ui` field: eyebrow/title, description excerpt (2-line clamp), price badge and bookable-deposit badge (colors matched to `ServicesGridView`'s existing convention), feature item count, display order.
- No photo field on this collection, so no image preview box - simpler, text-only header than Photos/Galleries/Testimonials.
- Hand-patched `importMap.js`.

## Test plan
- [x] `tsc --noEmit` passes clean
- [x] Production build (`next build`) succeeds
- [x] Verified live against a local production build: created a temporary test service with price + deposit set, confirmed the header renders all fields/badges correctly, then deleted the test record