### PR TITLE
fix(admin): add branded edit header to Users (TYN-318, 3 of 4)

### DIFF
--- a/app/(payload)/admin/importMap.js
+++ b/app/(payload)/admin/importMap.js
@@ -1,4 +1,5 @@
 import { UsersGridView as UsersGridView_e52e18109dd25c5262c4d2e001ae4a87 } from '../../../components/admin/UsersGridView'
+import { UsersEditHeader as UsersEditHeader_c9d0e1f20314253647586970819a2b3c } from '../../../components/admin/UsersEditHeader'
 import { PhotoEditHeader as PhotoEditHeader_994fa1cc565775730944a666ddd8cc75 } from '../../../components/admin/PhotoEditHeader'
 import { PhotoViewInPortfolioButton as PhotoViewInPortfolioButton_1bb693b5c948f71970f946083efd7d93 } from '../../../components/admin/PhotoViewInPortfolioButton'
 import { PhotoGridView as PhotoGridView_416d697f5d1039cfdf395a457f2fc19a } from '../../../components/admin/PhotoGridView'
@@ -58,6 +59,7 @@ import { CollectionCards as CollectionCards_f9c02e79a4aed9a3924487c0cd4cafb1 } f
 /** @type import('payload').ImportMap */
 export const importMap = {
   "./components/admin/UsersGridView#UsersGridView": UsersGridView_e52e18109dd25c5262c4d2e001ae4a87,
+  "./components/admin/UsersEditHeader#UsersEditHeader": UsersEditHeader_c9d0e1f20314253647586970819a2b3c,
   "./components/admin/PhotoEditHeader#PhotoEditHeader": PhotoEditHeader_994fa1cc565775730944a666ddd8cc75,
   "./components/admin/PhotoViewInPortfolioButton#PhotoViewInPortfolioButton": PhotoViewInPortfolioButton_1bb693b5c948f71970f946083efd7d93,
   "./components/admin/PhotoGridView#PhotoGridView": PhotoGridView_416d697f5d1039cfdf395a457f2fc19a,

--- a/collections/Users.ts
+++ b/collections/Users.ts
@@ -32,6 +32,15 @@ export const Users: CollectionConfig = {
   },
   fields: [
     {
+      name: 'editHeader',
+      type: 'ui',
+      admin: {
+        components: {
+          Field: './components/admin/UsersEditHeader#UsersEditHeader',
+        },
+      },
+    },
+    {
       name: 'name',
       type: 'text',
       label: 'Full Name',

--- a/components/admin/UsersEditHeader.tsx
+++ b/components/admin/UsersEditHeader.tsx
@@ -1,0 +1,104 @@
+'use client'
+import React from 'react'
+import { useDocumentInfo, useFormFields } from '@payloadcms/ui'
+
+const ROLE_LABELS: Record<string, string> = {
+  admin: 'Admin',
+  editor: 'Content Editor',
+}
+
+function initialsOf(name: string | undefined, email: string | undefined): string {
+  if (name) return name.split(' ').map((p) => p[0]).join('').toUpperCase().slice(0, 2)
+  return email?.[0]?.toUpperCase() ?? '?'
+}
+
+export function UsersEditHeader() {
+  const { id } = useDocumentInfo()
+  const name = useFormFields(([fields]) => fields.name?.value as string | undefined)
+  const email = useFormFields(([fields]) => fields.email?.value as string | undefined)
+  const role = useFormFields(([fields]) => fields.role?.value as string | undefined)
+  const mustChangePassword = useFormFields(([fields]) => fields.mustChangePassword?.value as boolean | undefined)
+
+  if (!id) return null
+
+  return (
+    <div
+      style={{
+        display: 'flex',
+        flexWrap: 'wrap',
+        gap: '1.25rem',
+        alignItems: 'center',
+        background: '#161616',
+        border: '1px solid rgba(155,154,154,0.18)',
+        borderRadius: 8,
+        padding: '1.25rem',
+        marginBottom: '1.75rem',
+      }}
+    >
+      {/* Avatar */}
+      <div
+        style={{
+          flexShrink: 0,
+          width: 56,
+          height: 56,
+          borderRadius: '50%',
+          background: 'linear-gradient(135deg,#1db48e,#0d9488)',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          fontSize: '1.1rem',
+          fontWeight: 700,
+          color: '#0c0c0c',
+        }}
+      >
+        {initialsOf(name, email)}
+      </div>
+
+      {/* Meta */}
+      <div style={{ flex: '1 1 220px', minWidth: 0, display: 'flex', flexDirection: 'column', gap: '0.5rem' }}>
+        <div>
+          <div style={{ color: '#D6D1CE', fontSize: '1.1rem', fontWeight: 500, fontFamily: "'Archivo', sans-serif", letterSpacing: '-0.01em' }}>
+            {name || '<No Full Name>'}
+          </div>
+          {email && (
+            <div style={{ color: '#6b6a6a', fontSize: '0.78rem', marginTop: '0.15rem', fontFamily: "'Roboto Mono', monospace" }}>
+              {email}
+            </div>
+          )}
+        </div>
+
+        {/* Badges */}
+        <div style={{ display: 'flex', flexWrap: 'wrap', gap: '0.4rem', alignItems: 'center' }}>
+          <span
+            style={{
+              fontSize: '0.72rem',
+              padding: '0.25rem 0.6rem',
+              borderRadius: 4,
+              border: '1px solid rgba(155,154,154,0.3)',
+              color: '#c8c3c0',
+            }}
+          >
+            {role ? (ROLE_LABELS[role] ?? role) : 'No role'}
+          </span>
+
+          {mustChangePassword && (
+            <span
+              style={{
+                padding: '0.1rem 0.4rem',
+                background: 'rgba(251,146,60,0.12)',
+                border: '1px solid rgba(251,146,60,0.3)',
+                borderRadius: 3,
+                fontSize: '0.58rem',
+                letterSpacing: '0.06em',
+                textTransform: 'uppercase',
+                color: '#fb923c',
+              }}
+            >
+              Password reset pending
+            </span>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- Third of the four TYN-318 collections. Confirmed via `next.config.mjs` and `UsersGridView.tsx`'s own links that Users has no redirect/replacement page - its raw `/admin/collections/users/:id` edit screen is the real one an admin sees.
- Adds `UsersEditHeader` (new `components/admin/UsersEditHeader.tsx`) as a top `ui` field: initials avatar (reusing `UsersGridView`'s exact gradient circle), name/email, role badge (Admin/Content Editor), and a "Password reset pending" badge reusing the grid's exact orange styling when `mustChangePassword` is set.
- Hand-patched `importMap.js`.

## Test plan
- [x] `tsc --noEmit` passes clean
- [x] Production build (`next build`) succeeds
- [x] Verified live against a local production build using a real existing account (not a temporary test user, since this collection touches auth data) - confirmed the header renders name, email, and role badge correctly