### PR TITLE
fix(admin): add branded edit header to Projects (TYN-318, 4 of 4)

### DIFF
--- a/app/(payload)/admin/importMap.js
+++ b/app/(payload)/admin/importMap.js
@@ -15,6 +15,7 @@ import { SessionRowLabel as SessionRowLabel_c92e93eada15d796d5db9f3cea7a28dc } f
 import { PaymentRowLabel as PaymentRowLabel_bf02cf58a8eb4dc67bc7319e475295f5 } from '../../../collections/Projects/PaymentRowLabel'
 import { DocumentRowLabel as DocumentRowLabel_30f116d44c8626ae90f0b4f8f5e9927c } from '../../../collections/Projects/DocumentRowLabel'
 import { ProjectsKanbanView as ProjectsKanbanView_f170bd24e886f73d32f9a84f0a9ad5a0 } from '../../../components/admin/ProjectsKanbanView'
+import { ProjectsEditHeader as ProjectsEditHeader_d0e1f20314253647586970819a2b3c4d } from '../../../components/admin/ProjectsEditHeader'
 import { AboutViewOnSiteButton as AboutViewOnSiteButton_e4e233e4cbe47762c0d80a0c040deafe } from '../../../components/admin/AboutViewOnSiteButton'
 import { SiteConfigHeader as SiteConfigHeader_a1b2c3d4e5f60718293a4b5c6d7e8f90 } from '../../../components/admin/SiteConfigHeader'
 import { BookingSettingsHeader as BookingSettingsHeader_b2c3d4e5f60718293a4b5c6d7e8f9001 } from '../../../components/admin/BookingSettingsHeader'
@@ -74,6 +75,7 @@ export const importMap = {
   "./collections/Projects/PaymentRowLabel#PaymentRowLabel": PaymentRowLabel_bf02cf58a8eb4dc67bc7319e475295f5,
   "./collections/Projects/DocumentRowLabel#DocumentRowLabel": DocumentRowLabel_30f116d44c8626ae90f0b4f8f5e9927c,
   "./components/admin/ProjectsKanbanView#ProjectsKanbanView": ProjectsKanbanView_f170bd24e886f73d32f9a84f0a9ad5a0,
+  "./components/admin/ProjectsEditHeader#ProjectsEditHeader": ProjectsEditHeader_d0e1f20314253647586970819a2b3c4d,
   "./components/admin/AboutViewOnSiteButton#AboutViewOnSiteButton": AboutViewOnSiteButton_e4e233e4cbe47762c0d80a0c040deafe,
   "./components/admin/SiteConfigHeader#SiteConfigHeader": SiteConfigHeader_a1b2c3d4e5f60718293a4b5c6d7e8f90,
   "./components/admin/BookingSettingsHeader#BookingSettingsHeader": BookingSettingsHeader_b2c3d4e5f60718293a4b5c6d7e8f9001,

--- a/collections/Projects.ts
+++ b/collections/Projects.ts
@@ -22,6 +22,15 @@ export const Projects: CollectionConfig = {
   },
   fields: [
     {
+      name: 'editHeader',
+      type: 'ui',
+      admin: {
+        components: {
+          Field: './components/admin/ProjectsEditHeader#ProjectsEditHeader',
+        },
+      },
+    },
+    {
       name: 'title',
       type: 'text',
       label: 'Project Name',

--- a/components/admin/ProjectsEditHeader.tsx
+++ b/components/admin/ProjectsEditHeader.tsx
@@ -1,0 +1,131 @@
+'use client'
+import React from 'react'
+import { useDocumentInfo, useFormFields } from '@payloadcms/ui'
+
+const STATUS_LABELS: Record<string, string> = {
+  inquiry: 'Inquiry',
+  booked: 'Booked',
+  'post-production': 'Post-Production',
+  delivered: 'Delivered',
+  archived: 'Archived',
+}
+
+const STATUS_COLORS: Record<string, string> = {
+  inquiry: '#9b9a9a',
+  booked: '#60a5fa',
+  'post-production': '#e0b060',
+  delivered: '#7ed99a',
+  archived: '#6b6a6a',
+}
+
+const PROJECT_TYPE_LABELS: Record<string, string> = {
+  portrait: 'Portrait',
+  wedding: 'Wedding',
+  family: 'Family',
+  couples: 'Couples',
+  brand: 'Brand',
+}
+
+function fmtDate(iso: string): string {
+  return new Date(iso).toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric', timeZone: 'UTC' })
+}
+
+export function ProjectsEditHeader() {
+  const { id } = useDocumentInfo()
+  const title = useFormFields(([fields]) => fields.title?.value as string | undefined)
+  const clientName = useFormFields(([fields]) => fields.clientName?.value as string | undefined)
+  const clientEmail = useFormFields(([fields]) => fields.clientEmail?.value as string | undefined)
+  const status = useFormFields(([fields]) => fields.status?.value as string | undefined)
+  const projectType = useFormFields(([fields]) => fields.projectType?.value as string | undefined)
+  const projectDate = useFormFields(([fields]) => fields.projectDate?.value as string | undefined)
+  const sessions = useFormFields(([fields]) => fields.sessions?.value as unknown[] | undefined)
+  const payments = useFormFields(([fields]) => fields.payments?.value as unknown[] | undefined)
+  const documents = useFormFields(([fields]) => fields.documents?.value as unknown[] | undefined)
+
+  if (!id) return null
+
+  const sessionCount = Array.isArray(sessions) ? sessions.length : 0
+  const paymentCount = Array.isArray(payments) ? payments.length : 0
+  const documentCount = Array.isArray(documents) ? documents.length : 0
+
+  return (
+    <div
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        gap: '0.6rem',
+        background: '#161616',
+        border: '1px solid rgba(155,154,154,0.18)',
+        borderRadius: 8,
+        padding: '1.25rem',
+        marginBottom: '1.75rem',
+      }}
+    >
+      <div>
+        <div style={{ color: '#D6D1CE', fontSize: '1.1rem', fontWeight: 500, fontFamily: "'Archivo', sans-serif", letterSpacing: '-0.01em' }}>
+          {title || 'Untitled Project'}
+        </div>
+        {(clientName || clientEmail) && (
+          <div style={{ color: '#9B9A9A', fontSize: '0.82rem', marginTop: '0.3rem' }}>
+            {clientName}
+            {clientName && clientEmail ? ' · ' : ''}
+            {clientEmail && <span style={{ fontFamily: "'Roboto Mono', monospace" }}>{clientEmail}</span>}
+          </div>
+        )}
+      </div>
+
+      {/* Badges */}
+      <div style={{ display: 'flex', flexWrap: 'wrap', gap: '0.4rem', alignItems: 'center' }}>
+        {status && (
+          <span
+            style={{
+              fontSize: '0.7rem',
+              color: STATUS_COLORS[status] ?? '#9b9a9a',
+              background: 'rgba(255,255,255,0.05)',
+              borderRadius: 3,
+              padding: '0.15rem 0.5rem',
+            }}
+          >
+            {STATUS_LABELS[status] ?? status}
+          </span>
+        )}
+
+        {projectType && (
+          <span
+            style={{
+              fontSize: '0.72rem',
+              padding: '0.25rem 0.6rem',
+              borderRadius: 4,
+              border: '1px solid rgba(155,154,154,0.3)',
+              color: '#c8c3c0',
+            }}
+          >
+            {PROJECT_TYPE_LABELS[projectType] ?? projectType}
+          </span>
+        )}
+
+        {projectDate && (
+          <span style={{ fontSize: '0.72rem', color: '#6b6a6a' }}>{fmtDate(projectDate)}</span>
+        )}
+
+        {sessionCount > 0 && (
+          <span style={{ fontSize: '0.62rem', color: 'rgba(155,154,154,0.55)', fontFamily: "'Roboto Mono', monospace" }}>
+            {sessionCount} session{sessionCount !== 1 ? 's' : ''}
+          </span>
+        )}
+
+        {paymentCount > 0 && (
+          <span style={{ fontSize: '0.62rem', color: 'rgba(155,154,154,0.55)', fontFamily: "'Roboto Mono', monospace" }}>
+            {paymentCount} payment{paymentCount !== 1 ? 's' : ''}
+          </span>
+        )}
+
+        {documentCount > 0 && (
+          <span style={{ fontSize: '0.62rem', color: 'rgba(155,154,154,0.55)', fontFamily: "'Roboto Mono', monospace" }}>
+            {documentCount} document{documentCount !== 1 ? 's' : ''}
+          </span>
+        )}
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- Fourth and final of the TYN-318 collections. Confirmed via `next.config.mjs` and `ProjectsKanbanView.tsx`'s own links that Projects has no redirect/replacement page - its raw `/admin/collections/projects/:id` edit screen is the real one a user sees.
- Adds `ProjectsEditHeader` (new `components/admin/ProjectsEditHeader.tsx`) as a top `ui` field: project title, client name/email, pipeline status badge (reusing `ProjectsKanbanView`'s exact `STATUS_LABELS`/`STATUS_COLORS` maps and the kanban's own date formatter), project type, project date, and session/payment/document counts.
- Hand-patched `importMap.js`.
- Closes out TYN-318 - all four collections now have the same branded edit-header treatment already shipped for Photos and the five globals in earlier PRs (#45-#49).

## Test plan
- [x] `tsc --noEmit` passes clean
- [x] Production build (`next build`) succeeds
- [x] Verified live against a local production build: created a temporary test project, confirmed the header renders title/client/status badge correctly, then deleted the test record