### PR TITLE
feat(admin): add favicon management to Design editor (TYN-321)

### DIFF
--- a/app/(site)/layout.tsx
+++ b/app/(site)/layout.tsx
@@ -41,28 +41,38 @@ const abrialFatface = Abril_Fatface({
   display: 'swap',
 })
 
-export const metadata: Metadata = {
-  metadataBase: new URL('https://tynnellhollinsphotography.com'),
-  title: {
-    default: 'Tynnell Hollins Photography',
-    template: '%s | Tynnell Hollins Photography',
-  },
-  description:
-    'Albuquerque, New Mexico wedding and portrait photographer. Tynnell Hollins captures authentic, timeless moments for couples, families, and engagements.',
-  openGraph: {
-    type: 'website',
-    siteName: 'Tynnell Hollins Photography',
-    locale: 'en_US',
-    images: [{ url: '/og-image.jpg', width: 1200, height: 630, alt: 'Tynnell Hollins Photography' }],
-  },
-  twitter: {
-    card: 'summary_large_image',
-    images: ['/og-image.jpg'],
-  },
-  robots: {
-    index: true,
-    follow: true,
-  },
+// Favicon (TYN-321) is the one piece of metadata that depends on the
+// SiteDesign global, so this can't stay a static `metadata` export - Next.js
+// only allows one or the other per layout. getSiteDesign() is wrapped in
+// React's cache(), so this and the layout body's own call share one DB read.
+export async function generateMetadata(): Promise<Metadata> {
+  const theme = await getSiteDesign()
+  return {
+    metadataBase: new URL('https://tynnellhollinsphotography.com'),
+    title: {
+      default: 'Tynnell Hollins Photography',
+      template: '%s | Tynnell Hollins Photography',
+    },
+    description:
+      'Albuquerque, New Mexico wedding and portrait photographer. Tynnell Hollins captures authentic, timeless moments for couples, families, and engagements.',
+    openGraph: {
+      type: 'website',
+      siteName: 'Tynnell Hollins Photography',
+      locale: 'en_US',
+      images: [{ url: '/og-image.jpg', width: 1200, height: 630, alt: 'Tynnell Hollins Photography' }],
+    },
+    twitter: {
+      card: 'summary_large_image',
+      images: ['/og-image.jpg'],
+    },
+    robots: {
+      index: true,
+      follow: true,
+    },
+    // Falls back to the app/favicon.ico file convention when no custom
+    // favicon has been set - only override when a real value exists.
+    ...(theme.faviconUrl ? { icons: { icon: theme.faviconUrl } } : {}),
+  }
 }
 
 export const viewport: Viewport = {

--- a/app/api/design/save/route.ts
+++ b/app/api/design/save/route.ts
@@ -10,6 +10,7 @@ export const dynamic = 'force-dynamic'
 
 const FIELDS = [
   'logoUrl',
+  'faviconUrl',
   'headingFont',
   'bodyFont',
   'colorBg',

--- a/app/builder/DesignPanelShared.tsx
+++ b/app/builder/DesignPanelShared.tsx
@@ -104,6 +104,9 @@ export function DesignSections({
         <FieldLabel>Logo image</FieldLabel>
         <ImagePickerField value={theme.logoUrl} onChange={(v) => set('logoUrl', v)} />
         <p style={{ color: '#6b6a6a', fontSize: 11, marginTop: 8 }}>Leave empty to show the text wordmark instead of an image.</p>
+        <FieldLabel style={{ marginTop: 16 }}>Favicon</FieldLabel>
+        <ImagePickerField value={theme.faviconUrl} onChange={(v) => set('faviconUrl', v)} />
+        <p style={{ color: '#6b6a6a', fontSize: 11, marginTop: 8 }}>Shown in the browser tab. Leave empty to use the site&apos;s default favicon.</p>
       </AccordionRow>
 
       <AccordionRow label="Fonts" isOpen={open === 'fonts'} onToggle={() => setOpen(open === 'fonts' ? null : 'fonts')}>

--- a/app/lib/siteDesign.ts
+++ b/app/lib/siteDesign.ts
@@ -1,3 +1,4 @@
+import { cache } from 'react'
 import { getPayload } from 'payload'
 import config from '@payload-config'
 import type { SiteDesign } from '@/payload-types'
@@ -13,12 +14,17 @@ export { DEFAULT_THEME, themeToCssVarMap, themeToCssVars } from './siteTheme'
 // its own module (not app/lib/siteTheme.ts) because getPayload/@payload-config
 // pull in server-only code that breaks the /design editor's client bundle if
 // imported from a 'use client' component - see siteTheme.ts's header comment.
-export async function getSiteDesign(): Promise<SiteTheme> {
+//
+// Wrapped in React's cache() (TYN-321) so generateMetadata's favicon lookup
+// and the layout body's <style> lookup share one DB read per request instead
+// of two - both call this same function independently within one request.
+export const getSiteDesign = cache(async (): Promise<SiteTheme> => {
   try {
     const payload = await getPayload({ config })
     const doc = (await payload.findGlobal({ slug: 'site-design' })) as SiteDesign
     return {
       logoUrl: doc.logoUrl || DEFAULT_THEME.logoUrl,
+      faviconUrl: doc.faviconUrl || DEFAULT_THEME.faviconUrl,
       headingFont: doc.headingFont || DEFAULT_THEME.headingFont,
       bodyFont: doc.bodyFont || DEFAULT_THEME.bodyFont,
       colorBg: doc.colorBg || DEFAULT_THEME.colorBg,
@@ -34,4 +40,4 @@ export async function getSiteDesign(): Promise<SiteTheme> {
   } catch {
     return DEFAULT_THEME
   }
-}
+})

--- a/app/lib/siteTheme.ts
+++ b/app/lib/siteTheme.ts
@@ -7,6 +7,7 @@
 // getSiteDesign() (see app/lib/siteDesign.ts, the server-only counterpart).
 export interface SiteTheme {
   logoUrl: string
+  faviconUrl: string
   headingFont: 'poppins' | 'tangerine' | 'abril'
   bodyFont: 'poppins' | 'tangerine' | 'abril'
   colorBg: string
@@ -22,6 +23,7 @@ export interface SiteTheme {
 
 export const DEFAULT_THEME: SiteTheme = {
   logoUrl: '',
+  faviconUrl: '',
   headingFont: 'poppins',
   bodyFont: 'poppins',
   colorBg: '#0C0C0C',

--- a/app/site-settings/SiteSettingsClient.tsx
+++ b/app/site-settings/SiteSettingsClient.tsx
@@ -143,6 +143,30 @@ export function SiteSettingsClient({ initial }: { initial: SiteSettingsData }) {
           name, tagline, contact info, and social links from hardcoded values in the code instead. See TYN-326 to connect them.
         </div>
 
+        <Section title="Branding">
+          <p style={{ margin: '0 0 1rem', color: '#9B9A9A', fontSize: '0.82rem', lineHeight: 1.5 }}>
+            Logo and favicon are managed from the Design editor, alongside your site&apos;s colors and fonts.
+          </p>
+          {/* eslint-disable-next-line @next/next/no-html-link-for-pages -- cross-root-layout link, /design has its own root layout */}
+          <a
+            href="/design"
+            style={{
+              display: 'inline-flex',
+              alignItems: 'center',
+              gap: '0.4rem',
+              padding: '0.5rem 0.9rem',
+              borderRadius: 6,
+              border: '1px solid rgba(155,154,154,0.3)',
+              color: '#D6D1CE',
+              fontSize: '0.82rem',
+              fontFamily: ui,
+              textDecoration: 'none',
+            }}
+          >
+            Open Design Editor &rarr;
+          </a>
+        </Section>
+
         <Section title="Business Info">
           <Field
             label="Business Name"

--- a/globals/SiteDesign.ts
+++ b/globals/SiteDesign.ts
@@ -23,6 +23,11 @@ export const SiteDesign: GlobalConfig = {
       label: 'Logo image URL',
     },
     {
+      name: 'faviconUrl',
+      type: 'text',
+      label: 'Favicon image URL',
+    },
+    {
       name: 'headingFont',
       type: 'select',
       label: 'Heading font',

--- a/payload-types.ts
+++ b/payload-types.ts
@@ -1033,6 +1033,7 @@ export interface SiteConfig {
 export interface SiteDesign {
   id: number;
   logoUrl?: string | null;
+  faviconUrl?: string | null;
   headingFont?: ('poppins' | 'tangerine' | 'abril') | null;
   bodyFont?: ('poppins' | 'tangerine' | 'abril') | null;
   colorBg?: string | null;
@@ -1171,6 +1172,7 @@ export interface SiteConfigSelect<T extends boolean = true> {
  */
 export interface SiteDesignSelect<T extends boolean = true> {
   logoUrl?: T;
+  faviconUrl?: T;
   headingFont?: T;
   bodyFont?: T;
   colorBg?: T;

--- a/scripts/migrate-db.mjs
+++ b/scripts/migrate-db.mjs
@@ -603,6 +603,19 @@ async function run() {
     `)
 
     console.log('✓ site_design table ready')
+
+    // ------------------------------------------------------------------
+    // Migration 20260717_100000: site_design.favicon_url column (TYN-321)
+    // Optional custom favicon shown in the browser tab, set from the
+    // /design editor's Logo & Branding section. Falls back to the
+    // app/favicon.ico file convention when null.
+    // ------------------------------------------------------------------
+
+    await client.query(`
+      ALTER TABLE "site_design" ADD COLUMN IF NOT EXISTS "favicon_url" varchar
+    `)
+
+    console.log('✓ site_design.favicon_url column ready')
   } finally {
     client.release()
     await pool.end()


### PR DESCRIPTION
## Summary
- Adds a **Favicon** field to the Design editor's existing "Logo & Branding" section (`globals/SiteDesign.ts`, `/api/design/save`, `DesignPanelShared.tsx`), reusing the same `ImagePickerField` pattern as the existing logo.
- Wired into the public site's `<head>` via a new `generateMetadata()` in `app/(site)/layout.tsx` (previously a static `metadata` export - Next.js only allows one or the other per layout). Falls back to the existing `app/favicon.ico` file convention when no custom favicon is set.
- `getSiteDesign()` wrapped in React's `cache()` since `generateMetadata` and the layout body now both call it independently per request - dedupes to one DB read instead of two.
- DB migration: `site_design.favicon_url` column added via `scripts/migrate-db.mjs` (ran locally against the live DB ahead of this deploy, per usual pre-build pipeline convention).

## Scope decisions (from TYN-321's own open questions)
- **Domain / Custom Domain** (from the Pixieset reference) - not applicable, this is a single-tenant site already on its own custom domain.
- **Logo location** - reconciled to stay in `/design` (already live and working since TYN-314; migrating to Site Settings would be pure churn with no functional gain). Added a lightweight "Branding" section on `/site-settings` that links over to `/design` instead of duplicating the field.

## Test plan
- [x] `tsc --noEmit` passes clean
- [x] Production build succeeds; confirmed ISR-dependent routes (`/`, `/about`, `/blog`, `/portfolio`) stayed static after the `generateMetadata` conversion (no accidental opt-out of ISR)
- [x] Verified against a local production build with the real migration applied: set a favicon URL in `/design`, confirmed it persisted via `/api/globals/site-design`, confirmed the `<link rel="icon">` tag renders correctly in the homepage `<head>` (as the last icon link, which browsers use over the file-convention fallback), then cleared and re-published to restore the original empty state
- [x] Confirmed the new "Branding" section on `/site-settings` renders and links to `/design`