### PR TITLE
feat(admin): add photo watermarking for gallery previews (TYN-322)

### DIFF
--- a/app/api/design/save/route.ts
+++ b/app/api/design/save/route.ts
@@ -11,6 +11,8 @@ export const dynamic = 'force-dynamic'
 const FIELDS = [
   'logoUrl',
   'faviconUrl',
+  'watermarkEnabled',
+  'watermarkUrl',
   'headingFont',
   'bodyFont',
   'colorBg',

--- a/app/api/photos/ingest/route.ts
+++ b/app/api/photos/ingest/route.ts
@@ -3,6 +3,8 @@ import { getPayload } from 'payload'
 import { headers } from 'next/headers'
 import config from '@payload-config'
 import { S3Client, GetObjectCommand, DeleteObjectCommand } from '@aws-sdk/client-s3'
+import { applyWatermarkIfEnabled } from '@/app/lib/watermark'
+import type { Photo } from '@/payload-types'
 
 export const dynamic = 'force-dynamic'
 // This function downloads a full-size DSLR file from R2, runs it through sharp
@@ -141,6 +143,16 @@ export async function POST(request: Request) {
       })
 
       console.log(`[photos/ingest] payload.create done for ${filename} in ${Date.now() - createStart}ms (total: ${Date.now() - requestStart}ms)`)
+
+      // Watermark the preview sizes if enabled (TYN-322) - best-effort,
+      // never fails the upload. The full original stays untouched.
+      try {
+        const watermarkStart = Date.now()
+        await applyWatermarkIfEnabled({ s3, bucket, sizes: (doc as Photo).sizes })
+        console.log(`[photos/ingest] watermark step for ${filename} took ${Date.now() - watermarkStart}ms`)
+      } catch (err) {
+        console.warn(`[photos/ingest] watermark step failed for ${filename} (non-fatal):`, err)
+      }
     } catch (err) {
       console.error(`[photos/ingest] payload.create failed for ${filename}:`, err)
       // Distinguish sharp format errors from other failures so we can surface them clearly

--- a/app/builder/DesignPanelShared.tsx
+++ b/app/builder/DesignPanelShared.tsx
@@ -109,6 +109,19 @@ export function DesignSections({
         <p style={{ color: '#6b6a6a', fontSize: 11, marginTop: 8 }}>Shown in the browser tab. Leave empty to use the site&apos;s default favicon.</p>
       </AccordionRow>
 
+      <AccordionRow label="Watermark" isOpen={open === 'watermark'} onToggle={() => setOpen(open === 'watermark' ? null : 'watermark')}>
+        <FieldLabel>Watermark image</FieldLabel>
+        <ImagePickerField value={theme.watermarkUrl} onChange={(v) => set('watermarkUrl', v)} />
+        <label style={{ display: 'flex', alignItems: 'center', gap: 8, color: '#e6e1de', fontSize: 13, cursor: 'pointer', marginTop: 12 }}>
+          <input type="checkbox" checked={theme.watermarkEnabled} onChange={(e) => set('watermarkEnabled', e.target.checked)} />
+          Apply watermark to gallery previews
+        </label>
+        <p style={{ color: '#6b6a6a', fontSize: 11, marginTop: 8 }}>
+          Applies to new uploads only, on gallery/portfolio preview images. Photos a client downloads through &quot;Allow Photo
+          Downloads&quot; are never watermarked.
+        </p>
+      </AccordionRow>
+
       <AccordionRow label="Fonts" isOpen={open === 'fonts'} onToggle={() => setOpen(open === 'fonts' ? null : 'fonts')}>
         <FieldLabel>Heading font</FieldLabel>
         <Select value={theme.headingFont} onChange={(v) => set('headingFont', v as SiteTheme['headingFont'])} options={FONT_OPTIONS} />

--- a/app/lib/siteDesign.ts
+++ b/app/lib/siteDesign.ts
@@ -25,6 +25,8 @@ export const getSiteDesign = cache(async (): Promise<SiteTheme> => {
     return {
       logoUrl: doc.logoUrl || DEFAULT_THEME.logoUrl,
       faviconUrl: doc.faviconUrl || DEFAULT_THEME.faviconUrl,
+      watermarkEnabled: doc.watermarkEnabled ?? false,
+      watermarkUrl: doc.watermarkUrl || DEFAULT_THEME.watermarkUrl,
       headingFont: doc.headingFont || DEFAULT_THEME.headingFont,
       bodyFont: doc.bodyFont || DEFAULT_THEME.bodyFont,
       colorBg: doc.colorBg || DEFAULT_THEME.colorBg,

--- a/app/lib/siteTheme.ts
+++ b/app/lib/siteTheme.ts
@@ -8,6 +8,8 @@
 export interface SiteTheme {
   logoUrl: string
   faviconUrl: string
+  watermarkEnabled: boolean
+  watermarkUrl: string
   headingFont: 'poppins' | 'tangerine' | 'abril'
   bodyFont: 'poppins' | 'tangerine' | 'abril'
   colorBg: string
@@ -24,6 +26,8 @@ export interface SiteTheme {
 export const DEFAULT_THEME: SiteTheme = {
   logoUrl: '',
   faviconUrl: '',
+  watermarkEnabled: false,
+  watermarkUrl: '',
   headingFont: 'poppins',
   bodyFont: 'poppins',
   colorBg: '#0C0C0C',

--- a/app/lib/watermark.ts
+++ b/app/lib/watermark.ts
@@ -1,0 +1,105 @@
+import sharp from 'sharp'
+import { S3Client, GetObjectCommand, PutObjectCommand } from '@aws-sdk/client-s3'
+import { getSiteDesign } from './siteDesign'
+
+// Watermarking (TYN-322): composites the site's configured watermark image
+// onto a newly-uploaded photo's thumbnail/card/hero preview sizes - the ones
+// actually rendered on public gallery/portfolio pages - overwriting them in
+// place at the same R2 key. The full original (served by
+// app/api/photos/[id]/download/route.ts for client downloads) is never
+// touched. New uploads only - existing photos are unaffected.
+//
+// Called as a best-effort post-process step after payload.create() in
+// app/api/photos/ingest/route.ts. Any failure here is logged and swallowed:
+// the Photo record already exists and should not be rolled back just
+// because the watermark step had a problem.
+
+type SizeSlot = { filename?: string | null; mimeType?: string | null } | null | undefined
+
+async function streamToBuffer(stream: AsyncIterable<Uint8Array>): Promise<Buffer> {
+  const chunks: Buffer[] = []
+  for await (const chunk of stream) {
+    chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk))
+  }
+  return Buffer.concat(chunks)
+}
+
+async function watermarkOneSize(params: {
+  s3: S3Client
+  bucket: string
+  watermarkBuffer: Buffer
+  slot: SizeSlot
+}): Promise<void> {
+  const { s3, bucket, watermarkBuffer, slot } = params
+  const key = slot?.filename
+  if (!key) return
+
+  const { Body } = await s3.send(new GetObjectCommand({ Bucket: bucket, Key: key }))
+  if (!Body) return
+  const original = await streamToBuffer(Body as AsyncIterable<Uint8Array>)
+
+  const baseImage = sharp(original)
+  const { width: baseWidth = 800 } = await baseImage.metadata()
+
+  // Watermark scaled to ~20% of the base image's width, with a small
+  // transparent margin on the bottom/right so it doesn't sit flush against
+  // the edge.
+  const targetWidth = Math.round(baseWidth * 0.2)
+  const margin = Math.round(baseWidth * 0.03)
+  const resizedWatermark = await sharp(watermarkBuffer)
+    .resize({ width: targetWidth })
+    .extend({ bottom: margin, right: margin, background: { r: 0, g: 0, b: 0, alpha: 0 } })
+    .toBuffer()
+
+  const composited = await baseImage
+    .composite([{ input: resizedWatermark, gravity: 'southeast' }])
+    .toBuffer()
+
+  await s3.send(
+    new PutObjectCommand({
+      Bucket: bucket,
+      Key: key,
+      Body: composited,
+      ContentType: slot?.mimeType ?? 'image/jpeg',
+    })
+  )
+}
+
+export async function applyWatermarkIfEnabled(params: {
+  s3: S3Client
+  bucket: string
+  sizes: { thumbnail?: SizeSlot; card?: SizeSlot; hero?: SizeSlot } | null | undefined
+}): Promise<void> {
+  const { s3, bucket, sizes } = params
+  if (!sizes) return
+
+  const theme = await getSiteDesign()
+  if (!theme.watermarkEnabled || !theme.watermarkUrl) return
+
+  let watermarkBuffer: Buffer
+  try {
+    const res = await fetch(theme.watermarkUrl)
+    if (!res.ok) {
+      console.warn(`[watermark] failed to fetch watermark image (${res.status}): ${theme.watermarkUrl}`)
+      return
+    }
+    watermarkBuffer = Buffer.from(await res.arrayBuffer())
+  } catch (err) {
+    console.warn('[watermark] failed to fetch watermark image:', err)
+    return
+  }
+
+  const slots: [string, SizeSlot][] = [
+    ['thumbnail', sizes.thumbnail],
+    ['card', sizes.card],
+    ['hero', sizes.hero],
+  ]
+
+  for (const [name, slot] of slots) {
+    try {
+      await watermarkOneSize({ s3, bucket, watermarkBuffer, slot })
+    } catch (err) {
+      console.warn(`[watermark] failed to watermark "${name}" size:`, err)
+    }
+  }
+}

--- a/globals/SiteDesign.ts
+++ b/globals/SiteDesign.ts
@@ -28,6 +28,17 @@ export const SiteDesign: GlobalConfig = {
       label: 'Favicon image URL',
     },
     {
+      name: 'watermarkEnabled',
+      type: 'checkbox',
+      label: 'Apply watermark to gallery previews',
+      defaultValue: false,
+    },
+    {
+      name: 'watermarkUrl',
+      type: 'text',
+      label: 'Watermark image URL',
+    },
+    {
       name: 'headingFont',
       type: 'select',
       label: 'Heading font',

--- a/payload-types.ts
+++ b/payload-types.ts
@@ -1034,6 +1034,8 @@ export interface SiteDesign {
   id: number;
   logoUrl?: string | null;
   faviconUrl?: string | null;
+  watermarkEnabled?: boolean | null;
+  watermarkUrl?: string | null;
   headingFont?: ('poppins' | 'tangerine' | 'abril') | null;
   bodyFont?: ('poppins' | 'tangerine' | 'abril') | null;
   colorBg?: string | null;
@@ -1173,6 +1175,8 @@ export interface SiteConfigSelect<T extends boolean = true> {
 export interface SiteDesignSelect<T extends boolean = true> {
   logoUrl?: T;
   faviconUrl?: T;
+  watermarkEnabled?: T;
+  watermarkUrl?: T;
   headingFont?: T;
   bodyFont?: T;
   colorBg?: T;

--- a/scripts/migrate-db.mjs
+++ b/scripts/migrate-db.mjs
@@ -616,6 +616,24 @@ async function run() {
     `)
 
     console.log('✓ site_design.favicon_url column ready')
+
+    // ------------------------------------------------------------------
+    // Migration 20260717_200000: site_design watermark columns (TYN-322)
+    // watermark_enabled/watermark_url control whether newly-uploaded photos
+    // get a watermark composited onto their thumbnail/card/hero preview
+    // sizes at ingest time. The full original (used by gallery downloads)
+    // is never watermarked. Existing photos are unaffected - new uploads
+    // only, per TYN-322's scope.
+    // ------------------------------------------------------------------
+
+    await client.query(`
+      ALTER TABLE "site_design" ADD COLUMN IF NOT EXISTS "watermark_enabled" boolean DEFAULT false
+    `)
+    await client.query(`
+      ALTER TABLE "site_design" ADD COLUMN IF NOT EXISTS "watermark_url" varchar
+    `)
+
+    console.log('✓ site_design watermark columns ready')
   } finally {
     client.release()
     await pool.end()


### PR DESCRIPTION
## Summary
- Adds a Watermark accordion to the /design editor: upload a watermark image and toggle "Apply watermark to gallery previews"
- New `applyWatermarkIfEnabled()` module composites the configured watermark (bottom-right, ~20% width, transparent margin) onto a photo's `thumbnail`/`card`/`hero` preview sizes right after upload, overwriting them in place on R2
- The full original file (and anything served through the download route) is never touched, so "Allow Photo Downloads" always serves a clean file
- New uploads only - existing library photos are not retroactively watermarked
- Best-effort: any failure in the watermark step is logged and swallowed, it never fails the underlying photo upload
- DB migration adds `site_design.watermark_enabled` / `site_design.watermark_url` columns (already run against production)

## Scope decisions (confirmed with Tynnell's rep)
- Watermark applies to on-site preview images only, not downloaded files
- New uploads only, no backfill of existing photos

## Test plan
- [x] Typecheck + production build pass
- [x] Verified end-to-end on a Vercel preview deployment: uploaded a real test photo with watermarking enabled, confirmed via pixel sampling that `card` (800x600) and `thumbnail` (400x300) sizes are watermarked while the full original (1200x900) stays clean
- [x] Checked Vercel runtime logs: watermark step completed in ~1.5s with no errors
- [x] Cleaned up test photo and reset watermark settings in the shared production DB after verification