### PR TITLE
feat(admin): add Gallery Presets for new-gallery defaults (TYN-323)

### DIFF
--- a/app/api/gallery-presets/save/route.ts
+++ b/app/api/gallery-presets/save/route.ts
@@ -1,0 +1,48 @@
+import { NextResponse } from 'next/server'
+import { requireAdminUser } from '@/app/lib/builderAuth'
+
+// Persist Gallery Presets (TYN-323). Admin-only. These only affect galleries
+// created from this point forward via the Galleries collection's create hook
+// (collections/Galleries.ts) - no public page reads this, so no revalidation
+// is needed.
+export const dynamic = 'force-dynamic'
+
+const FIELDS = [
+  'defaultCategory',
+  'defaultStatus',
+  'defaultTapedStyle',
+  'defaultFeatured',
+  'defaultAllowDownload',
+] as const
+
+export async function POST(request: Request) {
+  const auth = await requireAdminUser()
+  if (auth instanceof NextResponse) return auth
+  const { payload } = auth
+
+  let body: Record<string, unknown>
+  try {
+    body = await request.json()
+  } catch {
+    return NextResponse.json({ error: 'Invalid request body' }, { status: 400 })
+  }
+
+  const data: Record<string, unknown> = {}
+  for (const key of FIELDS) {
+    if (key in body) data[key] = body[key]
+  }
+  if (Object.keys(data).length === 0) {
+    return NextResponse.json({ error: 'No valid fields provided' }, { status: 400 })
+  }
+  // An empty string means "no default category" - store as null, not ''.
+  if (data.defaultCategory === '') data.defaultCategory = null
+
+  try {
+    await payload.updateGlobal({ slug: 'gallery-presets', data })
+  } catch (err) {
+    console.error('[gallery-presets/save] failed to save presets:', err)
+    return NextResponse.json({ error: 'Failed to save settings' }, { status: 500 })
+  }
+
+  return NextResponse.json({ ok: true })
+}

--- a/app/builder/PortfolioTab.tsx
+++ b/app/builder/PortfolioTab.tsx
@@ -131,6 +131,18 @@ function NewCollectionModal({ onClose, onCreated }: { onClose: () => void; onCre
   const [creating, setCreating] = useState(false)
   const [error, setError] = useState('')
 
+  // Pre-select the Gallery Presets default category (TYN-323), if one is set.
+  // Status/tapedStyle/featured/allowDownload are applied server-side by the
+  // Galleries collection's create hook, so they don't need a value here.
+  useEffect(() => {
+    fetch('/api/globals/gallery-presets', { credentials: 'include' })
+      .then(r => r.json())
+      .then((d: { defaultCategory?: string | null }) => {
+        if (d.defaultCategory) setCategory(d.defaultCategory)
+      })
+      .catch(() => {})
+  }, [])
+
   const create = async () => {
     if (!title.trim()) return
     setCreating(true); setError('')
@@ -138,7 +150,7 @@ function NewCollectionModal({ onClose, onCreated }: { onClose: () => void; onCre
       const res = await fetch('/api/galleries', {
         method: 'POST', credentials: 'include',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ title: title.trim(), category, status: 'draft' }),
+        body: JSON.stringify({ title: title.trim(), category }),
       })
       if (res.ok) {
         const data = await res.json() as { doc?: { id: number } }

--- a/app/gallery-editor/[id]/GalleryEditorClient.tsx
+++ b/app/gallery-editor/[id]/GalleryEditorClient.tsx
@@ -143,6 +143,22 @@ export function GalleryEditorClient({
     }
   }
 
+  // Pre-select the Gallery Presets default category (TYN-323), if one is set.
+  // Status/tapedStyle/featured/allowDownload are applied server-side by the
+  // Galleries collection's create hook, so they don't need a value here.
+  const openNewGalleryModal = () => {
+    setNewTitle('')
+    setNewCategory('portraits')
+    setCreateError('')
+    setShowNewModal(true)
+    fetch('/api/globals/gallery-presets', { credentials: 'include' })
+      .then(r => r.json())
+      .then((d: { defaultCategory?: string | null }) => {
+        if (d.defaultCategory) setNewCategory(d.defaultCategory)
+      })
+      .catch(() => {})
+  }
+
   const createGallery = async () => {
     if (!newTitle.trim()) return
     setCreating(true)
@@ -152,7 +168,7 @@ export function GalleryEditorClient({
         method: 'POST',
         credentials: 'include',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ title: newTitle.trim(), category: newCategory, status: 'draft' }),
+        body: JSON.stringify({ title: newTitle.trim(), category: newCategory }),
       })
       if (res.ok) {
         const data = await res.json() as { doc?: { id: number } }
@@ -692,7 +708,7 @@ export function GalleryEditorClient({
                 <span style={{ fontSize: '0.67rem', fontWeight: 700, letterSpacing: '0.08em', textTransform: 'uppercase', color: '#3a3a3a', fontFamily: ui }}>{allGalleries.length} Galleries</span>
                 <button
                   type="button"
-                  onClick={() => { setNewTitle(''); setCreateError(''); setShowNewModal(true) }}
+                  onClick={openNewGalleryModal}
                   style={{ background: 'none', border: 'none', color: '#1db954', fontSize: '0.78rem', fontWeight: 600, cursor: 'pointer', fontFamily: ui, display: 'flex', alignItems: 'center', gap: '0.2rem', padding: '0.1rem 0.25rem' }}
                   aria-label="New gallery"
                 >

--- a/app/site-settings/SiteSettingsClient.tsx
+++ b/app/site-settings/SiteSettingsClient.tsx
@@ -13,6 +13,28 @@ type SiteSettingsData = {
   pinterestUrl: string
 }
 
+type GalleryPresetsData = {
+  defaultCategory: string
+  defaultStatus: string
+  defaultTapedStyle: boolean
+  defaultFeatured: boolean
+  defaultAllowDownload: boolean
+}
+
+const CATEGORY_OPTIONS = [
+  { value: '', label: 'No default (always choose manually)' },
+  { value: 'weddings', label: 'Weddings' },
+  { value: 'portraits', label: 'Portraits' },
+  { value: 'families', label: 'Families' },
+  { value: 'couples', label: 'Couples' },
+  { value: 'brands', label: 'Brands' },
+]
+
+const STATUS_OPTIONS = [
+  { value: 'draft', label: 'Draft' },
+  { value: 'published', label: 'Published' },
+]
+
 const ui = "'Archivo', sans-serif"
 
 function Field({
@@ -61,6 +83,77 @@ function Field({
   )
 }
 
+function SelectField({
+  label,
+  description,
+  value,
+  onChange,
+  options,
+}: {
+  label: string
+  description: string
+  value: string
+  onChange: (v: string) => void
+  options: { value: string; label: string }[]
+}) {
+  return (
+    <div style={{ marginBottom: '1.5rem' }}>
+      <label style={{ display: 'block', color: '#D6D1CE', fontSize: '0.85rem', fontWeight: 600, fontFamily: ui, marginBottom: '0.5rem' }}>
+        {label}
+      </label>
+      <select
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        style={{
+          width: '100%',
+          maxWidth: 480,
+          padding: '0.65rem 0.85rem',
+          background: '#1a1a1a',
+          border: '1px solid rgba(155,154,154,0.25)',
+          borderRadius: 6,
+          color: '#E6E1DE',
+          fontSize: '0.9rem',
+          fontFamily: ui,
+          outline: 'none',
+          boxSizing: 'border-box',
+          cursor: 'pointer',
+        }}
+      >
+        {options.map((o) => (
+          <option key={o.value} value={o.value}>{o.label}</option>
+        ))}
+      </select>
+      <p style={{ margin: '0.5rem 0 0', color: '#6b6a6a', fontSize: '0.78rem', lineHeight: 1.5, maxWidth: 480 }}>
+        {description}
+      </p>
+    </div>
+  )
+}
+
+function CheckboxField({
+  label,
+  description,
+  checked,
+  onChange,
+}: {
+  label: string
+  description: string
+  checked: boolean
+  onChange: (v: boolean) => void
+}) {
+  return (
+    <div style={{ marginBottom: '1.5rem' }}>
+      <label style={{ display: 'flex', alignItems: 'center', gap: 8, color: '#D6D1CE', fontSize: '0.85rem', fontWeight: 600, fontFamily: ui, cursor: 'pointer' }}>
+        <input type="checkbox" checked={checked} onChange={(e) => onChange(e.target.checked)} />
+        {label}
+      </label>
+      <p style={{ margin: '0.5rem 0 0', color: '#6b6a6a', fontSize: '0.78rem', lineHeight: 1.5, maxWidth: 480 }}>
+        {description}
+      </p>
+    </div>
+  )
+}
+
 function Section({ title, children }: { title: string; children: React.ReactNode }) {
   return (
     <div
@@ -80,8 +173,15 @@ function Section({ title, children }: { title: string; children: React.ReactNode
   )
 }
 
-export function SiteSettingsClient({ initial }: { initial: SiteSettingsData }) {
+export function SiteSettingsClient({
+  initial,
+  initialPresets,
+}: {
+  initial: SiteSettingsData
+  initialPresets: GalleryPresetsData
+}) {
   const [data, setData] = useState<SiteSettingsData>(initial)
+  const [presets, setPresets] = useState<GalleryPresetsData>(initialPresets)
   const [saving, setSaving] = useState(false)
   const [saved, setSaved] = useState(false)
   const [error, setError] = useState('')
@@ -91,16 +191,28 @@ export function SiteSettingsClient({ initial }: { initial: SiteSettingsData }) {
     setData((d) => ({ ...d, [key]: value }))
   }
 
+  const setPreset = <K extends keyof GalleryPresetsData>(key: K, value: GalleryPresetsData[K]) => {
+    setSaved(false)
+    setPresets((p) => ({ ...p, [key]: value }))
+  }
+
   const save = async () => {
     setSaving(true)
     setError('')
     try {
-      const res = await fetch('/api/site-settings/save', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(data),
-      })
-      if (res.ok) {
+      const [siteRes, presetsRes] = await Promise.all([
+        fetch('/api/site-settings/save', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(data),
+        }),
+        fetch('/api/gallery-presets/save', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(presets),
+        }),
+      ])
+      if (siteRes.ok && presetsRes.ok) {
         setSaved(true)
       } else {
         setError('Failed to save. Please try again.')
@@ -226,6 +338,45 @@ export function SiteSettingsClient({ initial }: { initial: SiteSettingsData }) {
             value={data.pinterestUrl}
             onChange={(v) => set('pinterestUrl', v)}
             placeholder="https://pinterest.com/..."
+          />
+        </Section>
+
+        <Section title="Gallery Presets">
+          <p style={{ margin: '0 0 1rem', color: '#9B9A9A', fontSize: '0.82rem', lineHeight: 1.5 }}>
+            Defaults applied automatically whenever you create a new gallery, so you don&apos;t have to reconfigure the same
+            options every time. You can still override any of these per-gallery.
+          </p>
+          <SelectField
+            label="Default Category"
+            description="Pre-selected category in the New Collection modal. Choose &quot;No default&quot; to always pick manually."
+            value={presets.defaultCategory}
+            onChange={(v) => setPreset('defaultCategory', v)}
+            options={CATEGORY_OPTIONS}
+          />
+          <SelectField
+            label="Default Status"
+            description="Status applied to a gallery when it is first created."
+            value={presets.defaultStatus}
+            onChange={(v) => setPreset('defaultStatus', v)}
+            options={STATUS_OPTIONS}
+          />
+          <CheckboxField
+            label="Default to Taped Photo Style"
+            description="New galleries start with the editorial taped-photo look already turned on."
+            checked={presets.defaultTapedStyle}
+            onChange={(v) => setPreset('defaultTapedStyle', v)}
+          />
+          <CheckboxField
+            label="Default to Show on Homepage"
+            description="New galleries start featured on the homepage."
+            checked={presets.defaultFeatured}
+            onChange={(v) => setPreset('defaultFeatured', v)}
+          />
+          <CheckboxField
+            label="Default to Allow Photo Downloads"
+            description="New galleries start with client photo downloads turned on."
+            checked={presets.defaultAllowDownload}
+            onChange={(v) => setPreset('defaultAllowDownload', v)}
           />
         </Section>
 

--- a/app/site-settings/page.tsx
+++ b/app/site-settings/page.tsx
@@ -16,6 +16,7 @@ export default async function SiteSettingsPage() {
   if (user.role !== 'admin') redirect('/studio')
 
   const siteConfig = await payload.findGlobal({ slug: 'site-config' })
+  const galleryPresets = await payload.findGlobal({ slug: 'gallery-presets' })
 
   return (
     <SiteSettingsClient
@@ -28,6 +29,13 @@ export default async function SiteSettingsPage() {
         facebookUrl: siteConfig.facebookUrl ?? '',
         tiktokUrl: siteConfig.tiktokUrl ?? '',
         pinterestUrl: siteConfig.pinterestUrl ?? '',
+      }}
+      initialPresets={{
+        defaultCategory: galleryPresets.defaultCategory ?? '',
+        defaultStatus: galleryPresets.defaultStatus ?? 'draft',
+        defaultTapedStyle: galleryPresets.defaultTapedStyle ?? false,
+        defaultFeatured: galleryPresets.defaultFeatured ?? false,
+        defaultAllowDownload: galleryPresets.defaultAllowDownload ?? false,
       }}
     />
   )

--- a/collections/Galleries.ts
+++ b/collections/Galleries.ts
@@ -30,6 +30,27 @@ const autoSlugFromTitle: CollectionBeforeValidateHook = ({ data = {} }) => {
   return data
 }
 
+// Apply Gallery Presets (TYN-323) on creation only - fills in status,
+// tapedStyle, featured, and allowDownload when the create request does not
+// already specify them, so the "New Collection" modals don't have to be
+// rebuilt with pickers for every preset-able field. Never overrides a value
+// the client actually sent. Best-effort: falls through to the field's own
+// defaultValue if the presets global cannot be read.
+const applyGalleryPresets: CollectionBeforeValidateHook = async ({ data = {}, operation, req }) => {
+  if (operation !== 'create') return data
+  try {
+    const presets = await req.payload.findGlobal({ slug: 'gallery-presets' })
+    if (data.category === undefined && presets.defaultCategory) data.category = presets.defaultCategory
+    if (data.status === undefined && presets.defaultStatus) data.status = presets.defaultStatus
+    if (data.tapedStyle === undefined) data.tapedStyle = presets.defaultTapedStyle ?? false
+    if (data.featured === undefined) data.featured = presets.defaultFeatured ?? false
+    if (data.allowDownload === undefined) data.allowDownload = presets.defaultAllowDownload ?? false
+  } catch (err) {
+    console.warn('[galleries] failed to apply gallery presets on create (non-fatal):', err)
+  }
+  return data
+}
+
 // Bust the ISR cache for the affected gallery page (and the portfolio index)
 // on every save so the Live Preview pane reflects changes immediately instead
 // of waiting up to the 120s revalidate window (TYN-200). No-op outside a Next
@@ -52,7 +73,7 @@ export const Galleries: CollectionConfig = {
   },
   hooks: {
     beforeChange: [hashGalleryPassword],
-    beforeValidate: [autoSlugFromTitle],
+    beforeValidate: [applyGalleryPresets, autoSlugFromTitle],
     afterChange: [revalidateGallery],
   },
   admin: {
@@ -184,10 +205,15 @@ export const Galleries: CollectionConfig = {
       ],
     },
     {
+      // No defaultValue here - Payload resolves field-level defaults before
+      // beforeValidate hooks run, which would pre-empt applyGalleryPresets's
+      // "not provided by the client" check on create. Gallery Presets (TYN-323)
+      // is the single source of truth for what a new gallery starts as; the
+      // Postgres column's own DEFAULT 'published' is the final fallback if the
+      // presets hook itself fails.
       name: 'status',
       type: 'select',
       label: 'Status',
-      defaultValue: 'published',
       admin: {
         position: 'sidebar',
         description: 'Draft galleries are hidden from your public portfolio.',
@@ -198,20 +224,20 @@ export const Galleries: CollectionConfig = {
       ],
     },
     {
+      // No defaultValue - see the note on `status` above.
       name: 'tapedStyle',
       type: 'checkbox',
       label: 'Taped Photo Style',
-      defaultValue: false,
       admin: {
         description:
           'Display this gallery with the editorial taped-photo look (each photo on a cream mat with tape corners and a slight tilt). Leave off for a clean grid.',
       },
     },
     {
+      // No defaultValue - see the note on `status` above.
       name: 'featured',
       type: 'checkbox',
       label: 'Show on Homepage',
-      defaultValue: false,
       admin: {
         description: 'Turn on to feature this gallery on your homepage.',
       },
@@ -245,10 +271,10 @@ export const Galleries: CollectionConfig = {
       },
     },
     {
+      // No defaultValue - see the note on `status` above.
       name: 'allowDownload',
       type: 'checkbox',
       label: 'Allow Photo Downloads',
-      defaultValue: false,
       admin: { hidden: true },
     },
   ],

--- a/globals/GalleryPresets.ts
+++ b/globals/GalleryPresets.ts
@@ -1,0 +1,73 @@
+import type { GlobalConfig } from 'payload'
+import { isAdmin } from '@/app/lib/access'
+
+export const GalleryPresets: GlobalConfig = {
+  slug: 'gallery-presets',
+  label: 'Gallery Presets',
+  access: {
+    read: isAdmin,
+    update: isAdmin,
+  },
+  admin: {
+    group: 'My Portfolio',
+    description:
+      'Default values applied automatically whenever a new gallery is created, so you do not have to reconfigure the same options every time. Edited from Settings.',
+  },
+  fields: [
+    {
+      name: 'defaultCategory',
+      type: 'select',
+      label: 'Default Category',
+      admin: {
+        description: 'Pre-selected category when creating a new gallery. Leave unset to always require a manual choice.',
+      },
+      options: [
+        { label: 'Weddings', value: 'weddings' },
+        { label: 'Portraits', value: 'portraits' },
+        { label: 'Families', value: 'families' },
+        { label: 'Couples', value: 'couples' },
+        { label: 'Brands', value: 'brands' },
+      ],
+    },
+    {
+      name: 'defaultStatus',
+      type: 'select',
+      label: 'Default Status',
+      defaultValue: 'draft',
+      admin: {
+        description: 'Status applied to a gallery when it is first created.',
+      },
+      options: [
+        { label: 'Published', value: 'published' },
+        { label: 'Draft', value: 'draft' },
+      ],
+    },
+    {
+      name: 'defaultTapedStyle',
+      type: 'checkbox',
+      label: 'Default to Taped Photo Style',
+      defaultValue: false,
+      admin: {
+        description: 'New galleries start with the editorial taped-photo look already turned on.',
+      },
+    },
+    {
+      name: 'defaultFeatured',
+      type: 'checkbox',
+      label: 'Default to Show on Homepage',
+      defaultValue: false,
+      admin: {
+        description: 'New galleries start featured on the homepage.',
+      },
+    },
+    {
+      name: 'defaultAllowDownload',
+      type: 'checkbox',
+      label: 'Default to Allow Photo Downloads',
+      defaultValue: false,
+      admin: {
+        description: 'New galleries start with client photo downloads turned on.',
+      },
+    },
+  ],
+}

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -73,6 +73,11 @@ const nextConfig = {
         destination: '/site-settings',
         permanent: false,
       },
+      {
+        source: '/admin/globals/gallery-presets',
+        destination: '/site-settings',
+        permanent: false,
+      },
     ]
   },
   async headers() {

--- a/payload-types.ts
+++ b/payload-types.ts
@@ -106,6 +106,7 @@ export interface Config {
     'site-design': SiteDesign;
     'booking-settings': BookingSetting;
     availability: Availability;
+    'gallery-presets': GalleryPreset;
   };
   globalsSelect: {
     'hero-slides': HeroSlidesSelect<false> | HeroSlidesSelect<true>;
@@ -114,6 +115,7 @@ export interface Config {
     'site-design': SiteDesignSelect<false> | SiteDesignSelect<true>;
     'booking-settings': BookingSettingsSelect<false> | BookingSettingsSelect<true>;
     availability: AvailabilitySelect<false> | AvailabilitySelect<true>;
+    'gallery-presets': GalleryPresetsSelect<false> | GalleryPresetsSelect<true>;
   };
   locale: null;
   widgets: {
@@ -1114,6 +1116,37 @@ export interface Availability {
   createdAt?: string | null;
 }
 /**
+ * Default values applied automatically whenever a new gallery is created, so you do not have to reconfigure the same options every time. Edited from Settings.
+ *
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "gallery-presets".
+ */
+export interface GalleryPreset {
+  id: number;
+  /**
+   * Pre-selected category when creating a new gallery. Leave unset to always require a manual choice.
+   */
+  defaultCategory?: ('weddings' | 'portraits' | 'families' | 'couples' | 'brands') | null;
+  /**
+   * Status applied to a gallery when it is first created.
+   */
+  defaultStatus?: ('published' | 'draft') | null;
+  /**
+   * New galleries start with the editorial taped-photo look already turned on.
+   */
+  defaultTapedStyle?: boolean | null;
+  /**
+   * New galleries start featured on the homepage.
+   */
+  defaultFeatured?: boolean | null;
+  /**
+   * New galleries start with client photo downloads turned on.
+   */
+  defaultAllowDownload?: boolean | null;
+  updatedAt?: string | null;
+  createdAt?: string | null;
+}
+/**
  * This interface was referenced by `Config`'s JSON-Schema
  * via the `definition` "hero-slides_select".
  */
@@ -1199,6 +1232,20 @@ export interface SiteDesignSelect<T extends boolean = true> {
 export interface BookingSettingsSelect<T extends boolean = true> {
   minLeadTimeHours?: T;
   maxBookingMonths?: T;
+  updatedAt?: T;
+  createdAt?: T;
+  globalType?: T;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "gallery-presets_select".
+ */
+export interface GalleryPresetsSelect<T extends boolean = true> {
+  defaultCategory?: T;
+  defaultStatus?: T;
+  defaultTapedStyle?: T;
+  defaultFeatured?: T;
+  defaultAllowDownload?: T;
   updatedAt?: T;
   createdAt?: T;
   globalType?: T;

--- a/payload.config.ts
+++ b/payload.config.ts
@@ -19,6 +19,7 @@ import { SiteConfig } from './globals/SiteConfig'
 import { SiteDesign } from './globals/SiteDesign'
 import { BookingSettings } from './globals/BookingSettings'
 import { Availability } from './globals/Availability'
+import { GalleryPresets } from './globals/GalleryPresets'
 import { Pages } from './collections/Pages'
 import { Projects } from './collections/Projects'
 
@@ -118,7 +119,7 @@ export default buildConfig({
   },
   sharp,
   collections: [Users, Photos, Galleries, Testimonials, Services, Posts, Pages, Projects],
-  globals: [HeroSlides, AboutPage, SiteConfig, SiteDesign, BookingSettings, Availability],
+  globals: [HeroSlides, AboutPage, SiteConfig, SiteDesign, BookingSettings, Availability, GalleryPresets],
   editor: lexicalEditor(),
   secret: process.env.PAYLOAD_SECRET || '',
   typescript: {

--- a/scripts/migrate-db.mjs
+++ b/scripts/migrate-db.mjs
@@ -634,6 +634,29 @@ async function run() {
     `)
 
     console.log('✓ site_design watermark columns ready')
+
+    // ------------------------------------------------------------------
+    // Migration 20260717_300000: gallery_presets global table (TYN-323)
+    // Defaults applied automatically when a new gallery is created (see the
+    // applyGalleryPresets hook in collections/Galleries.ts), edited from the
+    // Settings > Gallery Presets section. default_status defaults to 'draft'
+    // to match the create-modal behavior that existed before this feature.
+    // ------------------------------------------------------------------
+
+    await client.query(`
+      CREATE TABLE IF NOT EXISTS "gallery_presets" (
+        "id"                     serial  PRIMARY KEY NOT NULL,
+        "default_category"       varchar,
+        "default_status"         varchar DEFAULT 'draft',
+        "default_taped_style"    boolean DEFAULT false,
+        "default_featured"       boolean DEFAULT false,
+        "default_allow_download" boolean DEFAULT false,
+        "updated_at"             timestamp(3) with time zone DEFAULT now() NOT NULL,
+        "created_at"             timestamp(3) with time zone DEFAULT now() NOT NULL
+      )
+    `)
+
+    console.log('✓ gallery_presets table ready')
   } finally {
     client.release()
     await pool.end()


### PR DESCRIPTION
## Summary
- Adds a "Gallery Presets" section to Settings (`/site-settings`): default category, default status, default taped-photo style, default show-on-homepage, and default allow-downloads
- Applied automatically on gallery creation via a new `applyGalleryPresets` beforeValidate hook on the Galleries collection (create only) - fills in fields the client didn't explicitly provide, never overrides explicit values
- Both live "New Collection" entry points (Portfolio builder tab, individual gallery editor sidebar) now pre-select the default category and no longer hardcode `status: 'draft'`, so the actual preset takes effect
- Removed the affected fields' Payload-level `defaultValue`s, since Payload resolves those before `beforeValidate` hooks run - this was silently pre-empting the hook's "did the client provide this" check (caught during verification, not by design)
- New `gallery-presets` DB migration (table only, already run against production)

## Scope decision
Per discussion: built the full field set (category, status, taped style, featured, allow-downloads) rather than a narrower subset.

## Out of scope, flagged separately
Discovered during verification: both live "New Collection" modals currently 400 in production because `Galleries.coverPhoto` is required but neither modal collects a cover photo. Pre-existing bug, unrelated to this change - spawned as its own task.

## Test plan
- [x] Typecheck + production build pass
- [x] Verified end-to-end locally against a production build and the shared production database:
  - Settings page saves/reloads presets correctly
  - New gallery correctly inherits all 5 presets when not explicitly overridden
  - An explicit override (simulating `duplicateGallery`) still wins over the preset
  - Category pre-selects correctly in both "New Collection" modals
- [x] Cleaned up all test galleries and reset presets to neutral defaults afterward - confirmed only the 2 pre-existing production galleries remain