### PR TITLE
feat(admin): add gallery email-sharing, expiration, and CMS email templates (TYN-324)

### DIFF
--- a/app/(site)/portfolio/[slug]/GalleryExpiredNotice.tsx
+++ b/app/(site)/portfolio/[slug]/GalleryExpiredNotice.tsx
@@ -1,0 +1,76 @@
+import Link from 'next/link'
+
+export function GalleryExpiredNotice() {
+  return (
+    <main style={{
+      minHeight: '100vh',
+      display: 'flex',
+      flexDirection: 'column',
+      alignItems: 'center',
+      justifyContent: 'center',
+      background: 'var(--color-bg, #0C0C0C)',
+      padding: '2rem',
+    }}>
+      <div style={{ textAlign: 'center', maxWidth: 420, width: '100%' }}>
+        <div style={{
+          fontSize: '2rem',
+          marginBottom: '1.5rem',
+          opacity: 0.35,
+          color: 'var(--color-detail, #9B9A9A)',
+        }} aria-hidden="true">&#8987;</div>
+
+        <h1 style={{
+          fontFamily: 'var(--font-display, Tangerine, serif)',
+          fontSize: 'clamp(2.5rem, 6vw, 3.5rem)',
+          fontWeight: 400,
+          color: 'var(--color-heading, #D6D1CE)',
+          margin: '0 0 0.5rem',
+          letterSpacing: '0.02em',
+          lineHeight: 1.2,
+        }}>
+          Gallery Expired
+        </h1>
+
+        <p style={{
+          fontFamily: 'var(--font-heading, Archivo, sans-serif)',
+          fontSize: '0.88rem',
+          color: 'var(--color-detail, #9B9A9A)',
+          margin: '0 0 2rem',
+          lineHeight: 1.6,
+        }}>
+          This gallery is no longer available. Reach out if you&apos;d like access extended.
+        </p>
+
+        <Link href="/contact" style={{
+          display: 'inline-block',
+          background: 'var(--color-btn-bg, #9B9A9A)',
+          color: '#0C0C0C',
+          borderRadius: 6,
+          padding: '0.75rem 2rem',
+          fontFamily: 'var(--font-heading, Archivo, sans-serif)',
+          fontSize: '0.8rem',
+          fontWeight: 700,
+          letterSpacing: '0.08em',
+          textTransform: 'uppercase',
+          textDecoration: 'none',
+        }}>
+          Get in Touch
+        </Link>
+
+        <div>
+          <Link href="/portfolio" style={{
+            display: 'inline-block',
+            marginTop: '1.75rem',
+            fontFamily: 'var(--font-heading, Archivo, sans-serif)',
+            fontSize: '0.75rem',
+            color: 'var(--color-detail, #9B9A9A)',
+            textDecoration: 'none',
+            letterSpacing: '0.05em',
+          }}>
+            &#8592; Back to Portfolio
+          </Link>
+        </div>
+      </div>
+    </main>
+  )
+}

--- a/app/(site)/portfolio/[slug]/page.tsx
+++ b/app/(site)/portfolio/[slug]/page.tsx
@@ -10,6 +10,8 @@ import type { Photo } from '@/payload-types'
 import JsonLd from '@/app/components/JsonLd/JsonLd'
 import { GalleryViewer, type LightboxPhoto } from './GalleryViewer'
 import { GalleryPasswordGate } from './GalleryPasswordGate'
+import { GalleryExpiredNotice } from './GalleryExpiredNotice'
+import { isGalleryExpired } from '@/app/lib/galleryExpiry'
 import { DownloadAllButtonLoader as DownloadAllButton } from './DownloadButtonLoader'
 import styles from './page.module.css'
 
@@ -49,7 +51,14 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const gallery = docs[0]
   if (!gallery) return { title: 'Gallery' }
 
-  // Don't reveal the gallery name or cover image in metadata before auth
+  // Don't reveal the gallery name or cover image in metadata before auth,
+  // or for an expired gallery whose content is no longer accessible. Expiry
+  // is checked first, matching the same precedence used in the page body
+  // below - an expired gallery is "Gallery Expired" regardless of whether
+  // it also happens to be password protected.
+  if (isGalleryExpired(gallery.expiresAt)) {
+    return { title: 'Gallery Expired', robots: { index: false } }
+  }
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   if ((gallery as any).isPasswordProtected) {
     return { title: 'Private Gallery', robots: { index: false } }
@@ -90,6 +99,13 @@ export default async function GalleryPage({ params, searchParams }: Props) {
   const gallery = docs[0]
 
   if (!gallery || gallery.status === 'draft') notFound()
+
+  // Expiry gate: independent of password protection - a plain shared
+  // gallery can expire too, and there's no point making an already-expired
+  // client enter a password only to hit a dead end.
+  if (isGalleryExpired(gallery.expiresAt)) {
+    return <GalleryExpiredNotice />
+  }
 
   // Password gate: check cookie if gallery is protected
   if (gallery.isPasswordProtected && gallery.password) {

--- a/app/api/cron/gallery-expiry-notify/route.ts
+++ b/app/api/cron/gallery-expiry-notify/route.ts
@@ -1,0 +1,104 @@
+import { NextResponse } from 'next/server'
+import { Resend } from 'resend'
+import { getPayload } from 'payload'
+import config from '@payload-config'
+import { EMAIL_FROM } from '@/app/lib/constants'
+import { templatedCtaEmailHtml } from '@/app/lib/emails'
+import { interpolateHtml, interpolateText } from '@/app/lib/templateInterpolation'
+import { daysUntilExpiry } from '@/app/lib/galleryExpiry'
+
+export const dynamic = 'force-dynamic'
+
+const resend = new Resend(process.env.RESEND_API_KEY)
+const SITE_URL = 'https://tynnellhollinsphotography.com'
+
+export async function GET(request: Request) {
+  const cronSecret = process.env.CRON_SECRET
+  if (!cronSecret) {
+    console.error('[cron/gallery-expiry-notify] CRON_SECRET is not set; refusing request')
+    return NextResponse.json({ error: 'Server misconfiguration' }, { status: 500 })
+  }
+
+  const authHeader = request.headers.get('authorization')
+  if (authHeader !== `Bearer ${cronSecret}`) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  try {
+    const payload = await getPayload({ config })
+    const templates = await payload.findGlobal({ slug: 'email-templates' })
+    const reminderDaysBefore = templates.reminderDaysBefore ?? 3
+
+    const { docs: galleries } = await payload.find({
+      collection: 'galleries',
+      where: {
+        and: [
+          { expiresAt: { exists: true } },
+          { clientEmail: { exists: true } },
+          { expiryReminderSent: { not_equals: true } },
+          { status: { not_equals: 'draft' } },
+        ],
+      },
+      depth: 0,
+      limit: 500,
+    })
+
+    let sent = 0
+
+    for (const gallery of galleries) {
+      if (!gallery.expiresAt || !gallery.clientEmail) continue
+
+      const remaining = daysUntilExpiry(gallery.expiresAt)
+      if (remaining === null || remaining < 0 || remaining > reminderDaysBefore) continue
+
+      const expiresAtStr = new Date(gallery.expiresAt).toLocaleDateString('en-US', {
+        month: 'long',
+        day: 'numeric',
+        year: 'numeric',
+        timeZone: 'UTC',
+      })
+
+      const vars: Record<string, string> = {
+        clientName: gallery.clientName || 'there',
+        galleryTitle: gallery.title,
+        expiresAt: expiresAtStr,
+      }
+
+      const subject = interpolateText(templates.reminderSubject ?? '', vars)
+      const headingHtml = interpolateHtml(templates.reminderHeading ?? '', vars)
+      const bodyHtml = interpolateHtml(templates.reminderBody ?? '', vars)
+
+      const html = templatedCtaEmailHtml({
+        eyebrowText: 'Expiring soon',
+        headingHtml,
+        bodyHtml,
+        ctaHref: `${SITE_URL}/portfolio/${gallery.slug}`,
+        ctaLabel: templates.reminderButtonLabel || 'View Your Gallery',
+      })
+
+      const result = await resend.emails.send({
+        from: EMAIL_FROM,
+        to: gallery.clientEmail,
+        subject,
+        html,
+      })
+
+      if (result.error) {
+        console.error(`[cron/gallery-expiry-notify] email send failed for gallery ${gallery.id}:`, JSON.stringify(result.error))
+        continue
+      }
+
+      await payload.update({
+        collection: 'galleries',
+        id: gallery.id,
+        data: { expiryReminderSent: true },
+      })
+      sent++
+    }
+
+    return NextResponse.json({ sent })
+  } catch (err) {
+    console.error('[cron/gallery-expiry-notify] unhandled error:', err)
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
+  }
+}

--- a/app/api/email-templates/save/route.ts
+++ b/app/api/email-templates/save/route.ts
@@ -1,0 +1,48 @@
+import { NextResponse } from 'next/server'
+import { requireAdminUser } from '@/app/lib/builderAuth'
+
+// Persist Email Templates (TYN-324). Admin-only. No public page reads this,
+// so no revalidation is needed - it only affects emails sent going forward.
+export const dynamic = 'force-dynamic'
+
+const FIELDS = [
+  'shareSubject',
+  'shareHeading',
+  'shareBody',
+  'shareButtonLabel',
+  'reminderSubject',
+  'reminderHeading',
+  'reminderBody',
+  'reminderButtonLabel',
+  'reminderDaysBefore',
+] as const
+
+export async function POST(request: Request) {
+  const auth = await requireAdminUser()
+  if (auth instanceof NextResponse) return auth
+  const { payload } = auth
+
+  let body: Record<string, unknown>
+  try {
+    body = await request.json()
+  } catch {
+    return NextResponse.json({ error: 'Invalid request body' }, { status: 400 })
+  }
+
+  const data: Record<string, unknown> = {}
+  for (const key of FIELDS) {
+    if (key in body) data[key] = body[key]
+  }
+  if (Object.keys(data).length === 0) {
+    return NextResponse.json({ error: 'No valid fields provided' }, { status: 400 })
+  }
+
+  try {
+    await payload.updateGlobal({ slug: 'email-templates', data })
+  } catch (err) {
+    console.error('[email-templates/save] failed to save templates:', err)
+    return NextResponse.json({ error: 'Failed to save settings' }, { status: 500 })
+  }
+
+  return NextResponse.json({ ok: true })
+}

--- a/app/api/galleries/[id]/share/route.ts
+++ b/app/api/galleries/[id]/share/route.ts
@@ -1,0 +1,129 @@
+import { NextResponse } from 'next/server'
+import { Resend } from 'resend'
+import { requireBuilderUser } from '@/app/lib/builderAuth'
+import { isValidEmail, anyFieldTooLong, SHARE_MAX_LENGTHS } from '@/app/lib/validation'
+import { interpolateHtml, interpolateText } from '@/app/lib/templateInterpolation'
+import { templatedCtaEmailHtml } from '@/app/lib/emails'
+import { EMAIL_FROM } from '@/app/lib/constants'
+
+export const dynamic = 'force-dynamic'
+
+const resend = new Resend(process.env.RESEND_API_KEY)
+const SITE_URL = 'https://tynnellhollinsphotography.com'
+
+type Props = { params: Promise<{ id: string }> }
+
+export async function POST(request: Request, { params }: Props) {
+  const auth = await requireBuilderUser()
+  if (auth instanceof NextResponse) return auth
+  const { payload } = auth
+
+  const { id } = await params
+  const galleryId = Number(id)
+  if (!galleryId || isNaN(galleryId)) {
+    return NextResponse.json({ error: 'Invalid gallery id' }, { status: 400 })
+  }
+
+  let body: { clientName?: string; clientEmail?: string; expiresAt?: string | null }
+  try {
+    body = await request.json()
+  } catch {
+    return NextResponse.json({ error: 'Invalid request body' }, { status: 400 })
+  }
+
+  const clientName = (body.clientName ?? '').trim()
+  const clientEmail = (body.clientEmail ?? '').trim()
+  const expiresAt = body.expiresAt || null
+
+  if (!isValidEmail(clientEmail)) {
+    return NextResponse.json({ error: 'A valid client email is required' }, { status: 400 })
+  }
+  if (anyFieldTooLong({ clientName }, SHARE_MAX_LENGTHS)) {
+    return NextResponse.json({ error: 'Client name is too long' }, { status: 400 })
+  }
+  if (expiresAt) {
+    const parsed = new Date(expiresAt)
+    if (isNaN(parsed.getTime())) {
+      return NextResponse.json({ error: 'Invalid expiration date' }, { status: 400 })
+    }
+    const endOfExpiryDay = new Date(parsed)
+    endOfExpiryDay.setUTCHours(23, 59, 59, 999)
+    if (endOfExpiryDay.getTime() < Date.now()) {
+      return NextResponse.json({ error: 'Expiration date must be in the future' }, { status: 400 })
+    }
+  }
+
+  let gallery
+  try {
+    gallery = await payload.findByID({ collection: 'galleries', id: galleryId, depth: 0 })
+  } catch {
+    return NextResponse.json({ error: 'Gallery not found' }, { status: 404 })
+  }
+  if (!gallery) {
+    return NextResponse.json({ error: 'Gallery not found' }, { status: 404 })
+  }
+
+  let templates
+  try {
+    templates = await payload.findGlobal({ slug: 'email-templates' })
+  } catch (err) {
+    console.error('[galleries/share] failed to load email templates:', err)
+    return NextResponse.json({ error: 'Failed to load email template' }, { status: 500 })
+  }
+
+  const galleryLink = `${SITE_URL}/portfolio/${gallery.slug}`
+  const passwordNote = gallery.isPasswordProtected
+    ? "This gallery is password protected - I'll share the password with you separately."
+    : ''
+
+  const vars: Record<string, string> = {
+    clientName: clientName || 'there',
+    galleryTitle: gallery.title,
+    passwordNote,
+  }
+
+  const subject = interpolateText(templates.shareSubject ?? '', vars)
+  const headingHtml = interpolateHtml(templates.shareHeading ?? '', vars)
+  const bodyHtml = interpolateHtml(templates.shareBody ?? '', vars)
+
+  const html = templatedCtaEmailHtml({
+    eyebrowText: 'Your gallery is ready',
+    headingHtml,
+    bodyHtml,
+    ctaHref: galleryLink,
+    ctaLabel: templates.shareButtonLabel || 'View Your Gallery',
+  })
+
+  // Send first, persist second - the gallery should never claim "shared with
+  // X" in the database if no email actually went out.
+  const result = await resend.emails.send({
+    from: EMAIL_FROM,
+    to: clientEmail,
+    subject,
+    html,
+  })
+
+  if (result.error) {
+    console.error('[galleries/share] email send failed:', JSON.stringify(result.error))
+    return NextResponse.json({ error: 'Failed to send email' }, { status: 502 })
+  }
+
+  try {
+    await payload.update({
+      collection: 'galleries',
+      id: galleryId,
+      data: {
+        clientName: clientName || null,
+        clientEmail,
+        expiresAt,
+        expiryReminderSent: false,
+      },
+    })
+  } catch (err) {
+    // The email genuinely sent - log the persistence failure but don't
+    // report an error to the caller.
+    console.error('[galleries/share] email sent but failed to persist sharing fields:', err)
+  }
+
+  return NextResponse.json({ ok: true })
+}

--- a/app/api/photos/[id]/download/route.ts
+++ b/app/api/photos/[id]/download/route.ts
@@ -4,6 +4,7 @@ import config from '@payload-config'
 import type { Photo } from '@/payload-types'
 import { cookies } from 'next/headers'
 import { createHmac, timingSafeEqual } from 'crypto'
+import { isGalleryExpired } from '@/app/lib/galleryExpiry'
 
 // Verify the gallery auth cookie for password-protected galleries.
 function verifyToken(slug: string, passwordHash: string, token: string): boolean {
@@ -50,6 +51,7 @@ export async function GET(req: NextRequest, { params }: Props) {
   if (!gallery) return new NextResponse('Not found', { status: 404 })
   if (!gallery.allowDownload) return new NextResponse('Downloads not enabled', { status: 403 })
   if (gallery.status === 'draft') return new NextResponse('Not found', { status: 404 })
+  if (isGalleryExpired(gallery.expiresAt)) return new NextResponse('Gallery has expired', { status: 403 })
 
   // Password-protected gallery: check cookie.
   if (gallery.isPasswordProtected && gallery.password) {

--- a/app/gallery-editor/[id]/GalleryEditorClient.tsx
+++ b/app/gallery-editor/[id]/GalleryEditorClient.tsx
@@ -2,6 +2,7 @@
 import { useEffect, useRef, useState, useCallback } from 'react'
 import Link from 'next/link'
 import { isUnsupportedImage, uploadPhotoToLibrary } from '@/app/lib/uploadPhoto'
+import { isValidEmail } from '@/app/lib/validation'
 import type { PhotoItem, GalleryListItem } from './page'
 
 const CATEGORIES = ['weddings', 'portraits', 'families', 'couples', 'brands'] as const
@@ -17,6 +18,9 @@ type Props = {
   initialIsPasswordProtected: boolean
   initialPasswordSet: boolean
   initialAllowDownload: boolean
+  initialClientName: string
+  initialClientEmail: string
+  initialExpiresAt: string
   initialCoverId: number | null
   initialCoverThumb: string | null
   initialHeroUrl: string | null
@@ -35,6 +39,9 @@ export function GalleryEditorClient({
   initialIsPasswordProtected,
   initialPasswordSet,
   initialAllowDownload,
+  initialClientName,
+  initialClientEmail,
+  initialExpiresAt,
   initialCoverId,
   initialCoverThumb,
   initialHeroUrl,
@@ -50,6 +57,13 @@ export function GalleryEditorClient({
   const [featured, setFeatured] = useState(initialFeatured)
   const [isPasswordProtected, setIsPasswordProtected] = useState(initialIsPasswordProtected)
   const [allowDownload, setAllowDownload] = useState(initialAllowDownload)
+  const [clientName, setClientName] = useState(initialClientName)
+  const [clientEmail, setClientEmail] = useState(initialClientEmail)
+  const [expiresAt, setExpiresAt] = useState(initialExpiresAt)
+  const [showShareModal, setShowShareModal] = useState(false)
+  const [sharing, setSharing] = useState(false)
+  const [shareError, setShareError] = useState('')
+  const [shareSuccess, setShareSuccess] = useState(false)
   // Empty string = no new password typed yet. When initialPasswordSet is true we show
   // a placeholder so the hash is never sent to the client.
   const [galleryPassword, setGalleryPassword] = useState('')
@@ -141,6 +155,37 @@ export function GalleryEditorClient({
     } finally {
       setDuplicating(false)
     }
+  }
+
+  const sendShareEmail = async () => {
+    if (!isValidEmail(clientEmail.trim())) {
+      setShareError('Enter a valid client email address.')
+      return
+    }
+    setSharing(true)
+    setShareError('')
+    try {
+      const res = await fetch(`/api/galleries/${galleryId}/share`, {
+        method: 'POST',
+        credentials: 'include',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          clientName: clientName.trim(),
+          clientEmail: clientEmail.trim(),
+          expiresAt: expiresAt || null,
+        }),
+      })
+      if (res.ok) {
+        setShareSuccess(true)
+        setHasChanges(false)
+      } else {
+        const data = await res.json().catch(() => ({}))
+        setShareError(data.error || 'Could not send email. Please try again.')
+      }
+    } catch {
+      setShareError('Could not send email. Check your connection.')
+    }
+    setSharing(false)
   }
 
   // Pre-select the Gallery Presets default category (TYN-323), if one is set.
@@ -341,6 +386,9 @@ export function GalleryEditorClient({
               : {}),
           coverPhoto: coverId,
           photos: photos.map(p => ({ photo: p.id })),
+          clientName: clientName.trim() || null,
+          clientEmail: clientEmail.trim() || null,
+          expiresAt: expiresAt || null,
         }),
       })
       if (res.ok) {
@@ -379,7 +427,7 @@ export function GalleryEditorClient({
     autoSaveTimer.current = setTimeout(() => { void save() }, 2500)
     return () => { if (autoSaveTimer.current) clearTimeout(autoSaveTimer.current) }
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [hasChanges, title, slug, category, status, featured, tapedStyle, isPasswordProtected, allowDownload, galleryPassword, coverId, photos])
+  }, [hasChanges, title, slug, category, status, featured, tapedStyle, isPasswordProtected, allowDownload, galleryPassword, coverId, photos, clientName, clientEmail, expiresAt])
 
   // Warn before closing/navigating away with unsaved changes
   useEffect(() => {
@@ -481,6 +529,84 @@ export function GalleryEditorClient({
                 {deleting ? 'Deleting...' : 'Delete gallery'}
               </button>
             </div>
+          </div>
+        </div>
+      )}
+
+      {/* Send Gallery Email modal */}
+      {showShareModal && (
+        <div
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="share-gallery-title"
+          style={{ position: 'fixed', inset: 0, background: 'rgba(0,0,0,0.75)', zIndex: 100, display: 'flex', alignItems: 'center', justifyContent: 'center' }}
+          onClick={e => { if (e.target === e.currentTarget) setShowShareModal(false) }}
+          onKeyDown={e => { if (e.key === 'Escape') setShowShareModal(false) }}
+        >
+          <div style={{ background: '#1a1a1a', border: '1px solid rgba(255,255,255,0.1)', borderRadius: 10, padding: '2rem', width: 380, display: 'flex', flexDirection: 'column', gap: '1.1rem', boxShadow: '0 24px 64px rgba(0,0,0,0.6)' }}>
+            <h2 id="share-gallery-title" style={{ margin: 0, fontFamily: ui, fontSize: '1.05rem', fontWeight: 600, color: '#e6e1de', letterSpacing: '-0.01em' }}>Send gallery email</h2>
+
+            {shareSuccess ? (
+              <>
+                <p style={{ margin: 0, fontSize: '0.85rem', color: '#6b6a6a', fontFamily: ui, lineHeight: 1.5 }}>
+                  Email sent to {clientEmail}.
+                </p>
+                <div style={{ display: 'flex', justifyContent: 'flex-end' }}>
+                  <button type="button" onClick={() => setShowShareModal(false)} style={{ background: '#1db954', border: 'none', color: '#fff', borderRadius: 6, padding: '0.5rem 1.1rem', fontSize: '0.85rem', fontWeight: 600, cursor: 'pointer', fontFamily: ui }}>Done</button>
+                </div>
+              </>
+            ) : (
+              <>
+                <label style={{ display: 'flex', flexDirection: 'column', gap: '0.4rem' }}>
+                  <span style={{ fontSize: '0.72rem', fontWeight: 500, color: '#9b9a9a', fontFamily: ui }}>Client name</span>
+                  <input
+                    type="text"
+                    value={clientName}
+                    onChange={e => setField(setClientName)(e.target.value)}
+                    placeholder="Jane Doe"
+                    style={{ background: '#0c0c0c', border: '1px solid rgba(255,255,255,0.12)', borderRadius: 6, padding: '0.6rem 0.75rem', color: '#e6e1de', fontSize: '0.9rem', outline: 'none', fontFamily: ui }}
+                  />
+                </label>
+                <label style={{ display: 'flex', flexDirection: 'column', gap: '0.4rem' }}>
+                  <span style={{ fontSize: '0.72rem', fontWeight: 500, color: '#9b9a9a', fontFamily: ui }}>Client email</span>
+                  <input
+                    type="email"
+                    value={clientEmail}
+                    onChange={e => setField(setClientEmail)(e.target.value)}
+                    placeholder="jane@example.com"
+                    autoFocus
+                    style={{ background: '#0c0c0c', border: '1px solid rgba(255,255,255,0.12)', borderRadius: 6, padding: '0.6rem 0.75rem', color: '#e6e1de', fontSize: '0.9rem', outline: 'none', fontFamily: ui }}
+                  />
+                </label>
+                <label style={{ display: 'flex', flexDirection: 'column', gap: '0.4rem' }}>
+                  <span style={{ fontSize: '0.72rem', fontWeight: 500, color: '#9b9a9a', fontFamily: ui }}>Expires on (optional)</span>
+                  <input
+                    type="date"
+                    value={expiresAt}
+                    onChange={e => setField(setExpiresAt)(e.target.value)}
+                    style={{ background: '#0c0c0c', border: '1px solid rgba(255,255,255,0.12)', borderRadius: 6, padding: '0.6rem 0.75rem', color: '#e6e1de', fontSize: '0.9rem', outline: 'none', fontFamily: ui, colorScheme: 'dark' }}
+                  />
+                </label>
+                {isPasswordProtected && (
+                  <p style={{ margin: 0, fontSize: '0.72rem', color: '#3a3a3a', fontFamily: ui, lineHeight: 1.5 }}>
+                    This gallery is password protected. The email will let the client know a password is required - be sure to share it with them separately.
+                  </p>
+                )}
+                {shareError && <p role="alert" style={{ margin: 0, fontSize: '0.78rem', color: '#f0a3a3', fontFamily: ui }}>{shareError}</p>}
+                <div style={{ display: 'flex', gap: '0.6rem', justifyContent: 'flex-end', paddingTop: '0.25rem' }}>
+                  <button type="button" onClick={() => setShowShareModal(false)} style={{ background: 'none', border: '1px solid rgba(255,255,255,0.15)', color: '#9b9a9a', borderRadius: 6, padding: '0.5rem 1.1rem', fontSize: '0.85rem', cursor: 'pointer', fontFamily: ui, fontWeight: 500 }}>Cancel</button>
+                  <button
+                    type="button"
+                    onClick={() => void sendShareEmail()}
+                    disabled={sharing || !clientEmail.trim()}
+                    aria-busy={sharing}
+                    style={{ background: '#1db954', border: 'none', color: '#fff', borderRadius: 6, padding: '0.5rem 1.3rem', fontSize: '0.85rem', fontWeight: 600, cursor: (sharing || !clientEmail.trim()) ? 'not-allowed' : 'pointer', fontFamily: ui, opacity: (sharing || !clientEmail.trim()) ? 0.5 : 1 }}
+                  >
+                    {sharing ? 'Sending...' : 'Send email'}
+                  </button>
+                </div>
+              </>
+            )}
           </div>
         </div>
       )}
@@ -847,6 +973,52 @@ export function GalleryEditorClient({
                       <span style={{ fontSize: '0.67rem', color: '#3a3a3a', fontFamily: ui }}>Share this with your clients</span>
                     </label>
                   )}
+                </div>
+
+                <div style={{ height: 1, background: 'rgba(255,255,255,0.06)', margin: '0.1rem 0' }} />
+
+                <div style={{ display: 'flex', flexDirection: 'column', gap: '0.65rem' }}>
+                  <span style={{ fontSize: '0.72rem', fontWeight: 500, color: '#6b6a6a', fontFamily: ui }}>Client sharing</span>
+                  <label style={{ display: 'flex', flexDirection: 'column', gap: '0.4rem' }}>
+                    <span style={{ fontSize: '0.72rem', fontWeight: 500, color: '#6b6a6a', fontFamily: ui }}>Client name</span>
+                    <input
+                      type="text"
+                      value={clientName}
+                      onChange={e => setField(setClientName)(e.target.value)}
+                      placeholder="Jane Doe"
+                      style={{ background: '#181818', border: '1px solid rgba(255,255,255,0.1)', borderRadius: 6, padding: '0.5rem 0.65rem', color: '#e6e1de', fontSize: '0.875rem', outline: 'none', fontFamily: ui }}
+                      aria-label="Client name"
+                    />
+                  </label>
+                  <label style={{ display: 'flex', flexDirection: 'column', gap: '0.4rem' }}>
+                    <span style={{ fontSize: '0.72rem', fontWeight: 500, color: '#6b6a6a', fontFamily: ui }}>Client email</span>
+                    <input
+                      type="email"
+                      value={clientEmail}
+                      onChange={e => setField(setClientEmail)(e.target.value)}
+                      placeholder="jane@example.com"
+                      style={{ background: '#181818', border: '1px solid rgba(255,255,255,0.1)', borderRadius: 6, padding: '0.5rem 0.65rem', color: '#e6e1de', fontSize: '0.875rem', outline: 'none', fontFamily: ui }}
+                      aria-label="Client email"
+                    />
+                  </label>
+                  <label style={{ display: 'flex', flexDirection: 'column', gap: '0.4rem' }}>
+                    <span style={{ fontSize: '0.72rem', fontWeight: 500, color: '#6b6a6a', fontFamily: ui }}>Expires on</span>
+                    <input
+                      type="date"
+                      value={expiresAt}
+                      onChange={e => setField(setExpiresAt)(e.target.value)}
+                      style={{ background: '#181818', border: '1px solid rgba(255,255,255,0.1)', borderRadius: 6, padding: '0.5rem 0.65rem', color: '#e6e1de', fontSize: '0.875rem', outline: 'none', fontFamily: ui, colorScheme: 'dark' }}
+                      aria-label="Gallery expiration date"
+                    />
+                    <span style={{ fontSize: '0.67rem', color: '#3a3a3a', fontFamily: ui }}>Leave blank for a gallery that never expires</span>
+                  </label>
+                  <button
+                    type="button"
+                    onClick={() => { setShareError(''); setShareSuccess(false); setShowShareModal(true) }}
+                    style={{ background: 'none', border: '1px solid rgba(255,255,255,0.15)', color: '#9b9a9a', borderRadius: 6, padding: '0.5rem 0.75rem', fontSize: '0.8rem', fontWeight: 500, cursor: 'pointer', fontFamily: ui, textAlign: 'center' }}
+                  >
+                    Send Gallery Email
+                  </button>
                 </div>
 
                 <div style={{ height: 1, background: 'rgba(255,255,255,0.06)', margin: '0.1rem 0' }} />

--- a/app/gallery-editor/[id]/page.tsx
+++ b/app/gallery-editor/[id]/page.tsx
@@ -99,6 +99,9 @@ export default async function GalleryEditorPage({ params }: Props) {
       initialIsPasswordProtected={gallery.isPasswordProtected ?? false}
       initialPasswordSet={typeof gallery.password === 'string' && gallery.password.length > 0}
       initialAllowDownload={gallery.allowDownload ?? false}
+      initialClientName={gallery.clientName ?? ''}
+      initialClientEmail={gallery.clientEmail ?? ''}
+      initialExpiresAt={typeof gallery.expiresAt === 'string' ? gallery.expiresAt.slice(0, 10) : ''}
       initialCoverId={coverPhoto?.id ?? null}
       initialCoverThumb={coverPhoto?.sizes?.card?.url ?? coverPhoto?.url ?? null}
       initialHeroUrl={heroPhoto?.sizes?.hero?.url ?? heroPhoto?.url ?? null}

--- a/app/lib/emails.ts
+++ b/app/lib/emails.ts
@@ -105,6 +105,17 @@ function divider(): string {
   return `<hr style="border:none;border-top:1px solid ${BORDER};margin:28px 0;" />`
 }
 
+function ctaButton(href: string, label: string): string {
+  return `
+    <table cellpadding="0" cellspacing="0" style="margin:8px 0 24px;">
+      <tr>
+        <td style="border-radius:4px;background:${BRAND_DARK};">
+          <a href="${href}" style="display:inline-block;padding:14px 32px;font-family:'Courier New',monospace;font-size:12px;letter-spacing:1px;text-transform:uppercase;color:#ffffff;text-decoration:none;">${label}</a>
+        </td>
+      </tr>
+    </table>`
+}
+
 function signature(): string {
   return `
     <p style="margin:28px 0 0;font-family:Georgia,serif;font-size:15px;line-height:1.8;color:#444;">
@@ -310,6 +321,35 @@ export function clientReceiptEmailHtml(f: ClientReceiptEmailFields): string {
     ${body(`Hi ${f.clientName}, your <strong>${f.amountPaid}</strong> deposit for a <strong>${f.packageName}</strong> session has been received. I&rsquo;m so excited to work with you.`)}
     ${dateNote}
     ${followUpNote}
+    ${divider()}
+    ${signature()}
+  `)
+}
+
+// ---------------------------------------------------------------------------
+// Gallery sharing + expiry reminder (sent to a client, TYN-324)
+//
+// Both emails are CMS-editable (Settings > Email Templates) - the heading
+// and body text below have already been interpolated (variables substituted
+// and HTML-escaped) by app/lib/templateInterpolation.ts before reaching this
+// function. This one function renders both, since they share an identical
+// visual shape (branded wrapper + heading + body + CTA button + signature).
+// ---------------------------------------------------------------------------
+
+export interface TemplatedCtaEmailFields {
+  eyebrowText: string
+  headingHtml: string
+  bodyHtml: string
+  ctaHref: string
+  ctaLabel: string
+}
+
+export function templatedCtaEmailHtml(f: TemplatedCtaEmailFields): string {
+  return emailWrapper(`
+    ${eyebrow(f.eyebrowText)}
+    ${heading(f.headingHtml)}
+    ${body(f.bodyHtml)}
+    ${ctaButton(f.ctaHref, f.ctaLabel)}
     ${divider()}
     ${signature()}
   `)

--- a/app/lib/galleryExpiry.test.ts
+++ b/app/lib/galleryExpiry.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { isGalleryExpired, daysUntilExpiry } from './galleryExpiry'
+
+afterEach(() => {
+  vi.useRealTimers()
+})
+
+describe('isGalleryExpired', () => {
+  it('returns false when expiresAt is unset', () => {
+    expect(isGalleryExpired(null)).toBe(false)
+    expect(isGalleryExpired(undefined)).toBe(false)
+    expect(isGalleryExpired('')).toBe(false)
+  })
+
+  it('returns false when expiresAt is invalid', () => {
+    expect(isGalleryExpired('not-a-date')).toBe(false)
+  })
+
+  it('returns false for a future date', () => {
+    expect(isGalleryExpired('2099-01-01')).toBe(false)
+  })
+
+  it('returns true for a clearly past date', () => {
+    expect(isGalleryExpired('2020-01-01')).toBe(true)
+  })
+
+  it('is NOT expired at any point during the expiry date itself (end-of-day boundary)', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-07-20T08:00:00Z'))
+    expect(isGalleryExpired('2026-07-20')).toBe(false)
+  })
+
+  it('IS expired the day after the expiry date', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-07-21T00:00:01Z'))
+    expect(isGalleryExpired('2026-07-20')).toBe(true)
+  })
+})
+
+describe('daysUntilExpiry', () => {
+  it('returns null when expiresAt is unset or invalid', () => {
+    expect(daysUntilExpiry(null)).toBeNull()
+    expect(daysUntilExpiry(undefined)).toBeNull()
+    expect(daysUntilExpiry('garbage')).toBeNull()
+  })
+
+  it('returns 0 on the expiry day itself', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-07-20T12:00:00Z'))
+    expect(daysUntilExpiry('2026-07-20')).toBe(0)
+  })
+
+  it('returns a positive count for a future date', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-07-20T00:00:00Z'))
+    expect(daysUntilExpiry('2026-07-23')).toBe(3)
+  })
+
+  it('returns a negative count for an already-past date', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-07-25T00:00:00Z'))
+    expect(daysUntilExpiry('2026-07-20')).toBeLessThan(0)
+  })
+})

--- a/app/lib/galleryExpiry.ts
+++ b/app/lib/galleryExpiry.ts
@@ -1,0 +1,45 @@
+/**
+ * A gallery's expiresAt is a date-only value (midnight of the chosen day).
+ * Treated as "end of that day" everywhere it's checked, so a gallery set to
+ * expire on a given date stays available through the entirety of that date
+ * rather than dying at 12:00am - "available through July 20" not "until
+ * July 19 at midnight".
+ */
+
+// A date-only string ("2026-07-20") parses as UTC midnight per the ISO 8601
+// spec, so end-of-day must be computed in UTC too - using local setHours()
+// here would make expiry depend on the server/test machine's timezone.
+function endOfDay(dateStr: string): Date {
+  const d = new Date(dateStr)
+  d.setUTCHours(23, 59, 59, 999)
+  return d
+}
+
+export function isGalleryExpired(expiresAt: string | null | undefined): boolean {
+  if (!expiresAt) return false
+  const expiry = endOfDay(expiresAt)
+  if (isNaN(expiry.getTime())) return false
+  return Date.now() > expiry.getTime()
+}
+
+const MS_PER_DAY = 1000 * 60 * 60 * 24
+
+/**
+ * Whole calendar days between today and expiresAt (0 on the expiry date
+ * itself, regardless of time of day; negative once expiresAt has passed).
+ * Distinct from isGalleryExpired's precise end-of-day boundary check - this
+ * is a day-granularity count for the "remind N days before" cron window.
+ * Returns null if expiresAt is unset or invalid.
+ */
+export function daysUntilExpiry(expiresAt: string | null | undefined): number | null {
+  if (!expiresAt) return null
+  const expiry = new Date(expiresAt)
+  if (isNaN(expiry.getTime())) return null
+
+  const todayMidnight = new Date()
+  todayMidnight.setUTCHours(0, 0, 0, 0)
+  const expiryMidnight = new Date(expiry)
+  expiryMidnight.setUTCHours(0, 0, 0, 0)
+
+  return Math.round((expiryMidnight.getTime() - todayMidnight.getTime()) / MS_PER_DAY)
+}

--- a/app/lib/templateInterpolation.test.ts
+++ b/app/lib/templateInterpolation.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'vitest'
+import { interpolateHtml, interpolateText } from './templateInterpolation'
+
+describe('interpolateHtml', () => {
+  it('substitutes known tokens', () => {
+    expect(interpolateHtml('Hi {{clientName}}!', { clientName: 'Jane' })).toBe('Hi Jane!')
+  })
+
+  it('substitutes multiple occurrences of the same token', () => {
+    expect(interpolateHtml('{{name}} and {{name}}', { name: 'A' })).toBe('A and A')
+  })
+
+  it('leaves unknown tokens untouched', () => {
+    expect(interpolateHtml('Hi {{clientName}}, {{unknownToken}}', { clientName: 'Jane' }))
+      .toBe('Hi Jane, {{unknownToken}}')
+  })
+
+  it('escapes HTML in a substituted value', () => {
+    const result = interpolateHtml('Hi {{clientName}}', { clientName: '<script>alert(1)</script>' })
+    expect(result).not.toContain('<script>')
+    expect(result).toContain('&lt;script&gt;')
+  })
+
+  it('converts newlines in the result to <br />', () => {
+    expect(interpolateHtml('Line one\nLine two', {})).toBe('Line one<br />Line two')
+  })
+
+  it('handles CRLF newlines', () => {
+    expect(interpolateHtml('Line one\r\nLine two', {})).toBe('Line one<br />Line two')
+  })
+})
+
+describe('interpolateText', () => {
+  it('substitutes known tokens without HTML-escaping', () => {
+    expect(interpolateText('Hi {{clientName}}', { clientName: "O'Brien" })).toBe("Hi O'Brien")
+  })
+
+  it('strips line breaks from substituted values to prevent header injection', () => {
+    const result = interpolateText('Subject: {{clientName}}', { clientName: 'Jane\r\nBcc: evil@example.com' })
+    expect(result).not.toContain('\r')
+    expect(result).not.toContain('\n')
+  })
+
+  it('leaves unknown tokens untouched', () => {
+    expect(interpolateText('{{missing}}', {})).toBe('{{missing}}')
+  })
+})

--- a/app/lib/templateInterpolation.ts
+++ b/app/lib/templateInterpolation.ts
@@ -1,0 +1,45 @@
+/**
+ * Interpolates {{token}} placeholders in CMS-authored email template text
+ * (Settings > Email Templates) with dynamic values at send time.
+ *
+ * The template text itself is trusted (only an admin can edit it via
+ * /site-settings). Only the substituted variable *values* (client name,
+ * gallery title, etc.) are untrusted and must be escaped.
+ */
+
+import { escapeHtml } from './validation'
+
+const TOKEN_PATTERN = /\{\{(\w+)\}\}/g
+
+function substitute(template: string, vars: Record<string, string>, escape: (v: string) => string): string {
+  return template.replace(TOKEN_PATTERN, (match, key: string) => {
+    if (!(key in vars)) return match
+    return escape(vars[key])
+  })
+}
+
+// Strips CR/LF from a substituted value so it can't inject extra header
+// lines into a Resend subject (or any other single-line context).
+function stripLineBreaks(value: string): string {
+  return value.replace(/[\r\n]+/g, ' ')
+}
+
+/**
+ * For multi-line template bodies rendered as HTML. Escapes each variable's
+ * value, substitutes it into the (trusted) template text, then converts any
+ * remaining newlines in the result to <br /> so line breaks Tynnell typed
+ * into a textarea actually show up in the rendered email.
+ */
+export function interpolateHtml(template: string, vars: Record<string, string>): string {
+  const substituted = substitute(template, vars, escapeHtml)
+  return substituted.replace(/\r\n|\r|\n/g, '<br />')
+}
+
+/**
+ * For single-line contexts (the Resend subject line). Does not HTML-escape
+ * (a subject line isn't HTML), but strips line breaks from substituted
+ * values to prevent header injection.
+ */
+export function interpolateText(template: string, vars: Record<string, string>): string {
+  return substitute(template, vars, stripLineBreaks)
+}

--- a/app/lib/validation.ts
+++ b/app/lib/validation.ts
@@ -18,6 +18,10 @@ export const CHECKOUT_MAX_LENGTHS = {
   clientName:  100,
 } as const
 
+export const SHARE_MAX_LENGTHS = {
+  clientName: 100,
+} as const
+
 /**
  * Returns true if any field in `values` exceeds its limit in `limits`.
  * Only checks string values - non-strings are skipped.

--- a/app/site-settings/SiteSettingsClient.tsx
+++ b/app/site-settings/SiteSettingsClient.tsx
@@ -21,6 +21,18 @@ type GalleryPresetsData = {
   defaultAllowDownload: boolean
 }
 
+type EmailTemplatesData = {
+  shareSubject: string
+  shareHeading: string
+  shareBody: string
+  shareButtonLabel: string
+  reminderSubject: string
+  reminderHeading: string
+  reminderBody: string
+  reminderButtonLabel: string
+  reminderDaysBefore: string
+}
+
 const CATEGORY_OPTIONS = [
   { value: '', label: 'No default (always choose manually)' },
   { value: 'weddings', label: 'Weddings' },
@@ -130,6 +142,48 @@ function SelectField({
   )
 }
 
+function TextAreaField({
+  label,
+  description,
+  value,
+  onChange,
+}: {
+  label: string
+  description: string
+  value: string
+  onChange: (v: string) => void
+}) {
+  return (
+    <div style={{ marginBottom: '1.5rem' }}>
+      <label style={{ display: 'block', color: '#D6D1CE', fontSize: '0.85rem', fontWeight: 600, fontFamily: ui, marginBottom: '0.5rem' }}>
+        {label}
+      </label>
+      <textarea
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        rows={4}
+        style={{
+          width: '100%',
+          maxWidth: 480,
+          padding: '0.65rem 0.85rem',
+          background: '#1a1a1a',
+          border: '1px solid rgba(155,154,154,0.25)',
+          borderRadius: 6,
+          color: '#E6E1DE',
+          fontSize: '0.9rem',
+          fontFamily: ui,
+          outline: 'none',
+          boxSizing: 'border-box',
+          resize: 'vertical',
+        }}
+      />
+      <p style={{ margin: '0.5rem 0 0', color: '#6b6a6a', fontSize: '0.78rem', lineHeight: 1.5, maxWidth: 480 }}>
+        {description}
+      </p>
+    </div>
+  )
+}
+
 function CheckboxField({
   label,
   description,
@@ -176,12 +230,15 @@ function Section({ title, children }: { title: string; children: React.ReactNode
 export function SiteSettingsClient({
   initial,
   initialPresets,
+  initialEmailTemplates,
 }: {
   initial: SiteSettingsData
   initialPresets: GalleryPresetsData
+  initialEmailTemplates: EmailTemplatesData
 }) {
   const [data, setData] = useState<SiteSettingsData>(initial)
   const [presets, setPresets] = useState<GalleryPresetsData>(initialPresets)
+  const [templates, setTemplates] = useState<EmailTemplatesData>(initialEmailTemplates)
   const [saving, setSaving] = useState(false)
   const [saved, setSaved] = useState(false)
   const [error, setError] = useState('')
@@ -196,11 +253,16 @@ export function SiteSettingsClient({
     setPresets((p) => ({ ...p, [key]: value }))
   }
 
+  const setTemplate = <K extends keyof EmailTemplatesData>(key: K, value: EmailTemplatesData[K]) => {
+    setSaved(false)
+    setTemplates((t) => ({ ...t, [key]: value }))
+  }
+
   const save = async () => {
     setSaving(true)
     setError('')
     try {
-      const [siteRes, presetsRes] = await Promise.all([
+      const [siteRes, presetsRes, templatesRes] = await Promise.all([
         fetch('/api/site-settings/save', {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
@@ -211,8 +273,16 @@ export function SiteSettingsClient({
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify(presets),
         }),
+        fetch('/api/email-templates/save', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            ...templates,
+            reminderDaysBefore: Number(templates.reminderDaysBefore) || 0,
+          }),
+        }),
       ])
-      if (siteRes.ok && presetsRes.ok) {
+      if (siteRes.ok && presetsRes.ok && templatesRes.ok) {
         setSaved(true)
       } else {
         setError('Failed to save. Please try again.')
@@ -377,6 +447,76 @@ export function SiteSettingsClient({
             description="New galleries start with client photo downloads turned on."
             checked={presets.defaultAllowDownload}
             onChange={(v) => setPreset('defaultAllowDownload', v)}
+          />
+        </Section>
+
+        <Section title="Email Templates">
+          <p style={{ margin: '0 0 1rem', color: '#9B9A9A', fontSize: '0.82rem', lineHeight: 1.5 }}>
+            Copy for the emails sent when you share a gallery with a client, and the automatic reminder sent before it
+            expires.
+          </p>
+
+          <h3 style={{ margin: '0 0 0.75rem', color: '#D6D1CE', fontSize: '0.85rem', fontWeight: 600, fontFamily: ui }}>
+            Collection Sharing Email
+          </h3>
+          <Field
+            label="Subject"
+            description="Available variables: {{clientName}}, {{galleryTitle}}"
+            value={templates.shareSubject}
+            onChange={(v) => setTemplate('shareSubject', v)}
+          />
+          <Field
+            label="Heading"
+            description="Available variables: {{clientName}}, {{galleryTitle}}"
+            value={templates.shareHeading}
+            onChange={(v) => setTemplate('shareHeading', v)}
+          />
+          <TextAreaField
+            label="Body"
+            description="Available variables: {{clientName}}, {{galleryTitle}}, {{passwordNote}} (only appears if the gallery is password protected)"
+            value={templates.shareBody}
+            onChange={(v) => setTemplate('shareBody', v)}
+          />
+          <Field
+            label="Button Label"
+            description="Text shown on the call-to-action button linking to the gallery."
+            value={templates.shareButtonLabel}
+            onChange={(v) => setTemplate('shareButtonLabel', v)}
+          />
+
+          <h3 style={{ margin: '2rem 0 0.75rem', color: '#D6D1CE', fontSize: '0.85rem', fontWeight: 600, fontFamily: ui }}>
+            Expiry Reminder Email
+          </h3>
+          <Field
+            label="Subject"
+            description="Available variables: {{clientName}}, {{galleryTitle}}, {{expiresAt}}"
+            value={templates.reminderSubject}
+            onChange={(v) => setTemplate('reminderSubject', v)}
+          />
+          <Field
+            label="Heading"
+            description="Available variables: {{clientName}}, {{galleryTitle}}, {{expiresAt}}"
+            value={templates.reminderHeading}
+            onChange={(v) => setTemplate('reminderHeading', v)}
+          />
+          <TextAreaField
+            label="Body"
+            description="Available variables: {{clientName}}, {{galleryTitle}}, {{expiresAt}}"
+            value={templates.reminderBody}
+            onChange={(v) => setTemplate('reminderBody', v)}
+          />
+          <Field
+            label="Button Label"
+            description="Text shown on the call-to-action button linking to the gallery."
+            value={templates.reminderButtonLabel}
+            onChange={(v) => setTemplate('reminderButtonLabel', v)}
+          />
+          <Field
+            label="Send Reminder (Days Before Expiry)"
+            description="How many days before a gallery expires to send the reminder email."
+            type="number"
+            value={templates.reminderDaysBefore}
+            onChange={(v) => setTemplate('reminderDaysBefore', v)}
           />
         </Section>
 

--- a/app/site-settings/page.tsx
+++ b/app/site-settings/page.tsx
@@ -17,6 +17,7 @@ export default async function SiteSettingsPage() {
 
   const siteConfig = await payload.findGlobal({ slug: 'site-config' })
   const galleryPresets = await payload.findGlobal({ slug: 'gallery-presets' })
+  const emailTemplates = await payload.findGlobal({ slug: 'email-templates' })
 
   return (
     <SiteSettingsClient
@@ -36,6 +37,17 @@ export default async function SiteSettingsPage() {
         defaultTapedStyle: galleryPresets.defaultTapedStyle ?? false,
         defaultFeatured: galleryPresets.defaultFeatured ?? false,
         defaultAllowDownload: galleryPresets.defaultAllowDownload ?? false,
+      }}
+      initialEmailTemplates={{
+        shareSubject: emailTemplates.shareSubject ?? '',
+        shareHeading: emailTemplates.shareHeading ?? '',
+        shareBody: emailTemplates.shareBody ?? '',
+        shareButtonLabel: emailTemplates.shareButtonLabel ?? '',
+        reminderSubject: emailTemplates.reminderSubject ?? '',
+        reminderHeading: emailTemplates.reminderHeading ?? '',
+        reminderBody: emailTemplates.reminderBody ?? '',
+        reminderButtonLabel: emailTemplates.reminderButtonLabel ?? '',
+        reminderDaysBefore: String(emailTemplates.reminderDaysBefore ?? 3),
       }}
     />
   )

--- a/collections/Galleries.ts
+++ b/collections/Galleries.ts
@@ -51,6 +51,20 @@ const applyGalleryPresets: CollectionBeforeValidateHook = async ({ data = {}, op
   return data
 }
 
+// Reset the expiry-reminder idempotency flag whenever expiresAt or
+// clientEmail changes, regardless of which code path made the edit (the
+// /share route, a plain Settings-tab PATCH, or a raw Payload edit) - this is
+// a collection-level invariant, not something each caller should have to
+// remember to do itself.
+const resetExpiryReminderOnChange: CollectionBeforeChangeHook = ({ data, originalDoc }) => {
+  const expiresAtChanged = 'expiresAt' in data && data.expiresAt !== originalDoc?.expiresAt
+  const clientEmailChanged = 'clientEmail' in data && data.clientEmail !== originalDoc?.clientEmail
+  if (expiresAtChanged || clientEmailChanged) {
+    data.expiryReminderSent = false
+  }
+  return data
+}
+
 // Bust the ISR cache for the affected gallery page (and the portfolio index)
 // on every save so the Live Preview pane reflects changes immediately instead
 // of waiting up to the 120s revalidate window (TYN-200). No-op outside a Next
@@ -72,7 +86,7 @@ export const Galleries: CollectionConfig = {
     plural: 'Collections',
   },
   hooks: {
-    beforeChange: [hashGalleryPassword],
+    beforeChange: [hashGalleryPassword, resetExpiryReminderOnChange],
     beforeValidate: [applyGalleryPresets, autoSlugFromTitle],
     afterChange: [revalidateGallery],
   },
@@ -275,6 +289,36 @@ export const Galleries: CollectionConfig = {
       name: 'allowDownload',
       type: 'checkbox',
       label: 'Allow Photo Downloads',
+      admin: { hidden: true },
+    },
+    {
+      // Managed via the gallery editor's Settings tab / "Send Gallery Email"
+      // modal (TYN-324), not the raw Payload form.
+      name: 'clientName',
+      type: 'text',
+      label: 'Client Name',
+      admin: { hidden: true },
+    },
+    {
+      name: 'clientEmail',
+      type: 'email',
+      label: 'Client Email',
+      admin: { hidden: true },
+    },
+    {
+      name: 'expiresAt',
+      type: 'date',
+      label: 'Expires On',
+      admin: {
+        hidden: true,
+        date: { pickerAppearance: 'dayOnly' },
+      },
+    },
+    {
+      name: 'expiryReminderSent',
+      type: 'checkbox',
+      label: 'Expiry Reminder Sent',
+      defaultValue: false,
       admin: { hidden: true },
     },
   ],

--- a/globals/EmailTemplates.ts
+++ b/globals/EmailTemplates.ts
@@ -1,0 +1,96 @@
+import type { GlobalConfig } from 'payload'
+import { isAdmin } from '@/app/lib/access'
+
+export const EmailTemplates: GlobalConfig = {
+  slug: 'email-templates',
+  label: 'Email Templates',
+  access: {
+    read: isAdmin,
+    update: isAdmin,
+  },
+  admin: {
+    group: 'My Portfolio',
+    description:
+      'Copy for the emails sent when you share a gallery with a client, and the automatic reminder sent before it expires. Edited from Settings.',
+  },
+  fields: [
+    {
+      name: 'shareSubject',
+      type: 'text',
+      label: 'Collection Sharing: Subject',
+      defaultValue: 'Your {{galleryTitle}} Gallery Is Ready!',
+      admin: {
+        description: 'Available variables: {{clientName}}, {{galleryTitle}}',
+      },
+    },
+    {
+      name: 'shareHeading',
+      type: 'text',
+      label: 'Collection Sharing: Heading',
+      defaultValue: 'Your photos are ready.',
+      admin: {
+        description: 'Available variables: {{clientName}}, {{galleryTitle}}',
+      },
+    },
+    {
+      name: 'shareBody',
+      type: 'textarea',
+      label: 'Collection Sharing: Body',
+      defaultValue:
+        "Hi {{clientName}},\n\nI'm so excited to share your {{galleryTitle}} gallery with you! Click below to view and enjoy your photos.\n\n{{passwordNote}}",
+      admin: {
+        description: 'Available variables: {{clientName}}, {{galleryTitle}}, {{passwordNote}} (only appears if the gallery is password protected)',
+      },
+    },
+    {
+      name: 'shareButtonLabel',
+      type: 'text',
+      label: 'Collection Sharing: Button Label',
+      defaultValue: 'View Your Gallery',
+    },
+    {
+      name: 'reminderSubject',
+      type: 'text',
+      label: 'Expiry Reminder: Subject',
+      defaultValue: 'Reminder: Your {{galleryTitle}} Gallery Expires Soon',
+      admin: {
+        description: 'Available variables: {{clientName}}, {{galleryTitle}}, {{expiresAt}}',
+      },
+    },
+    {
+      name: 'reminderHeading',
+      type: 'text',
+      label: 'Expiry Reminder: Heading',
+      defaultValue: "Don't forget your photos.",
+      admin: {
+        description: 'Available variables: {{clientName}}, {{galleryTitle}}, {{expiresAt}}',
+      },
+    },
+    {
+      name: 'reminderBody',
+      type: 'textarea',
+      label: 'Expiry Reminder: Body',
+      defaultValue:
+        'Hi {{clientName}},\n\nJust a friendly reminder that your {{galleryTitle}} gallery will expire on {{expiresAt}}. Be sure to view and download your favorites before then!',
+      admin: {
+        description: 'Available variables: {{clientName}}, {{galleryTitle}}, {{expiresAt}}',
+      },
+    },
+    {
+      name: 'reminderButtonLabel',
+      type: 'text',
+      label: 'Expiry Reminder: Button Label',
+      defaultValue: 'View Your Gallery',
+    },
+    {
+      name: 'reminderDaysBefore',
+      type: 'number',
+      label: 'Send Reminder (Days Before Expiry)',
+      defaultValue: 3,
+      min: 0,
+      admin: {
+        description: 'How many days before a gallery expires to send the reminder email.',
+      },
+    },
+  ],
+}

--- a/payload-types.ts
+++ b/payload-types.ts
@@ -107,6 +107,7 @@ export interface Config {
     'booking-settings': BookingSetting;
     availability: Availability;
     'gallery-presets': GalleryPreset;
+    'email-templates': EmailTemplate;
   };
   globalsSelect: {
     'hero-slides': HeroSlidesSelect<false> | HeroSlidesSelect<true>;
@@ -116,6 +117,7 @@ export interface Config {
     'booking-settings': BookingSettingsSelect<false> | BookingSettingsSelect<true>;
     availability: AvailabilitySelect<false> | AvailabilitySelect<true>;
     'gallery-presets': GalleryPresetsSelect<false> | GalleryPresetsSelect<true>;
+    'email-templates': EmailTemplatesSelect<false> | EmailTemplatesSelect<true>;
   };
   locale: null;
   widgets: {
@@ -307,6 +309,10 @@ export interface Gallery {
    * Optional full-width hero photo shown at the top of the gallery page.
    */
   heroPhoto?: number | Photo | null;
+  clientName?: string | null;
+  clientEmail?: string | null;
+  expiresAt?: string | null;
+  expiryReminderSent?: boolean | null;
   updatedAt: string;
   createdAt: string;
 }
@@ -738,6 +744,10 @@ export interface GalleriesSelect<T extends boolean = true> {
   displayOrder?: T;
   isPasswordProtected?: T;
   password?: T;
+  clientName?: T;
+  clientEmail?: T;
+  expiresAt?: T;
+  expiryReminderSent?: T;
   updatedAt?: T;
   createdAt?: T;
 }
@@ -1147,6 +1157,26 @@ export interface GalleryPreset {
   createdAt?: string | null;
 }
 /**
+ * Copy for the emails sent when you share a gallery with a client, and the automatic reminder sent before it expires. Edited from Settings.
+ *
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "email-templates".
+ */
+export interface EmailTemplate {
+  id: number;
+  shareSubject?: string | null;
+  shareHeading?: string | null;
+  shareBody?: string | null;
+  shareButtonLabel?: string | null;
+  reminderSubject?: string | null;
+  reminderHeading?: string | null;
+  reminderBody?: string | null;
+  reminderButtonLabel?: string | null;
+  reminderDaysBefore?: number | null;
+  updatedAt?: string | null;
+  createdAt?: string | null;
+}
+/**
  * This interface was referenced by `Config`'s JSON-Schema
  * via the `definition` "hero-slides_select".
  */
@@ -1246,6 +1276,24 @@ export interface GalleryPresetsSelect<T extends boolean = true> {
   defaultTapedStyle?: T;
   defaultFeatured?: T;
   defaultAllowDownload?: T;
+  updatedAt?: T;
+  createdAt?: T;
+  globalType?: T;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "email-templates_select".
+ */
+export interface EmailTemplatesSelect<T extends boolean = true> {
+  shareSubject?: T;
+  shareHeading?: T;
+  shareBody?: T;
+  shareButtonLabel?: T;
+  reminderSubject?: T;
+  reminderHeading?: T;
+  reminderBody?: T;
+  reminderButtonLabel?: T;
+  reminderDaysBefore?: T;
   updatedAt?: T;
   createdAt?: T;
   globalType?: T;

--- a/payload.config.ts
+++ b/payload.config.ts
@@ -20,6 +20,7 @@ import { SiteDesign } from './globals/SiteDesign'
 import { BookingSettings } from './globals/BookingSettings'
 import { Availability } from './globals/Availability'
 import { GalleryPresets } from './globals/GalleryPresets'
+import { EmailTemplates } from './globals/EmailTemplates'
 import { Pages } from './collections/Pages'
 import { Projects } from './collections/Projects'
 
@@ -119,7 +120,7 @@ export default buildConfig({
   },
   sharp,
   collections: [Users, Photos, Galleries, Testimonials, Services, Posts, Pages, Projects],
-  globals: [HeroSlides, AboutPage, SiteConfig, SiteDesign, BookingSettings, Availability, GalleryPresets],
+  globals: [HeroSlides, AboutPage, SiteConfig, SiteDesign, BookingSettings, Availability, GalleryPresets, EmailTemplates],
   editor: lexicalEditor(),
   secret: process.env.PAYLOAD_SECRET || '',
   typescript: {

--- a/scripts/migrate-db.mjs
+++ b/scripts/migrate-db.mjs
@@ -657,6 +657,59 @@ async function run() {
     `)
 
     console.log('✓ gallery_presets table ready')
+
+    // ------------------------------------------------------------------
+    // Migration 20260717_400000: galleries client-sharing/expiry columns
+    // (TYN-324). client_name/client_email/expires_at are set via the new
+    // "Send Gallery Email" flow (app/api/galleries/[id]/share); expiry_
+    // reminder_sent is an idempotency flag reset to false whenever
+    // client_email or expires_at changes (see the resetExpiryReminderOnChange
+    // beforeChange hook in collections/Galleries.ts), and flipped to true by
+    // the gallery-expiry-notify cron once a reminder has gone out.
+    // ------------------------------------------------------------------
+
+    await client.query(`
+      ALTER TABLE "galleries" ADD COLUMN IF NOT EXISTS "client_name" varchar
+    `)
+    await client.query(`
+      ALTER TABLE "galleries" ADD COLUMN IF NOT EXISTS "client_email" varchar
+    `)
+    await client.query(`
+      ALTER TABLE "galleries" ADD COLUMN IF NOT EXISTS "expires_at" timestamp(3) with time zone
+    `)
+    await client.query(`
+      ALTER TABLE "galleries" ADD COLUMN IF NOT EXISTS "expiry_reminder_sent" boolean DEFAULT false
+    `)
+
+    console.log('✓ galleries client-sharing/expiry columns ready')
+
+    // ------------------------------------------------------------------
+    // Migration 20260717_500000: email_templates global table (TYN-324)
+    // Editable copy for the Collection Sharing and Expiry Reminder client
+    // emails, edited from Settings > Email Templates. {{token}} placeholders
+    // in *_heading/*_body are interpolated at send time
+    // (app/lib/templateInterpolation.ts) - see app/api/galleries/[id]/share
+    // and app/api/cron/gallery-expiry-notify.
+    // ------------------------------------------------------------------
+
+    await client.query(`
+      CREATE TABLE IF NOT EXISTS "email_templates" (
+        "id"                     serial  PRIMARY KEY NOT NULL,
+        "share_subject"          varchar,
+        "share_heading"          varchar,
+        "share_body"             varchar,
+        "share_button_label"     varchar,
+        "reminder_subject"       varchar,
+        "reminder_heading"       varchar,
+        "reminder_body"          varchar,
+        "reminder_button_label"  varchar,
+        "reminder_days_before"   numeric DEFAULT 3,
+        "updated_at"             timestamp(3) with time zone DEFAULT now() NOT NULL,
+        "created_at"             timestamp(3) with time zone DEFAULT now() NOT NULL
+      )
+    `)
+
+    console.log('✓ email_templates table ready')
   } finally {
     client.release()
     await pool.end()

--- a/vercel.json
+++ b/vercel.json
@@ -10,6 +10,10 @@
     {
       "path": "/api/cron/ooo-return-notify",
       "schedule": "0 9 * * *"
+    },
+    {
+      "path": "/api/cron/gallery-expiry-notify",
+      "schedule": "0 10 * * *"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Gallery editor: set a client name/email and an optional expiration date, then send a branded "your gallery is ready" email with one click ("Send Gallery Email")
- New daily cron sends an automatic reminder before a gallery expires (configurable days-before, default 3)
- Both emails' copy is editable from Settings > Email Templates (subject/heading/body/button label, with `{{clientName}}`/`{{galleryTitle}}`/`{{galleryLink}}`/`{{expiresAt}}`/`{{passwordNote}}` variables) rather than hardcoded
- Expired galleries show a new branded "Gallery Expired" notice on the public page and 403 on the photo download route, instead of a bare 404 or silently still working

## Key design decisions
- Never emails the plaintext gallery password - the share email just notes one is required and that it'll be shared separately (matches existing manual practice, avoids emailing secrets)
- New `clientName`/`clientEmail`/`expiresAt`/`expiryReminderSent` fields on Galleries are hidden from the raw Payload form, managed entirely through the gallery editor's Settings tab + Share modal (shared state, not a parallel form)
- `expiryReminderSent` resets via a `beforeChange` hook whenever `expiresAt`/`clientEmail` changes, regardless of which code path made the edit
- The `/share` route sends the email first, persists second - a gallery never claims "shared with X" if the send actually failed
- Expiry is checked before the password gate (independent of password protection) on both the public page and the download route
- The cron uses a days-remaining range check rather than an exact-date match, since the idempotency flag already covers exact-once delivery - a range survives a missed cron run where an exact match wouldn't

## Test plan
- [x] Typecheck + full `app/lib` test suite pass (117 tests, including 19 new ones for the interpolation/escaping and expiry day-math helpers)
- [x] Production build passes
- [x] Verified end-to-end locally against a production build and the shared production database:
  - Settings > Email Templates renders defaults, saves, persists on reload
  - Gallery editor Settings tab fields autosave; Share modal correctly reads/writes the same state
  - `expiryReminderSent` reset confirmed via both the `/share` route and a raw PATCH (proves the collection hook, not just the route, owns the invariant)
  - Expired-gallery notice renders on the public page and download route 403s, with and without password protection on the same gallery (expiry wins in both) - caught and fixed a real bug here: `generateMetadata` originally checked password-protection before expiry, inconsistent with the page body's order
  - Cron's WHERE-clause query confirmed to match the intended galleries (expiresAt + clientEmail set, reminder not yet sent, not draft)
  - Missing-`CRON_SECRET` 500 guard confirmed still works
- [x] Resend's actual send couldn't be exercised locally (no valid API key in this dev environment) - confirmed correct failure handling instead (502, no premature persist to the gallery record)
- [x] All test data cleaned up on the two real production galleries used for verification

## Follow-ups spawned (not fixed here, out of scope)
- Pre-existing bug found during TYN-323: New Collection creation 400s on missing `coverPhoto`
- vitest picking up stray test files from a gitignored `.claude/worktrees/` directory