### PR TITLE
feat(builder): add Accordion block (TYN-336)

### DIFF
--- a/app/builder/AccordionBlock.tsx
+++ b/app/builder/AccordionBlock.tsx
@@ -1,0 +1,75 @@
+'use client'
+import { useState } from 'react'
+
+export interface AccordionItem {
+  title: string
+  body: string
+}
+
+const HEADING_FONT = "var(--font-heading, Archivo, sans-serif)"
+const BODY_FONT = "var(--font-body, 'Roboto Mono', monospace)"
+
+// Collapsible title/body rows (TYN-336) - only one section open at a time,
+// matching the common FAQ-accordion convention.
+export function AccordionBlock({ items }: { items: AccordionItem[] }) {
+  const [openIndex, setOpenIndex] = useState<number | null>(0)
+
+  return (
+    <div style={{ maxWidth: '760px', margin: '0 auto' }}>
+      {items.map((item, i) => {
+        const isOpen = openIndex === i
+        return (
+          <div key={i} style={{ borderBottom: '1px solid rgba(155,154,154,0.18)' }}>
+            <button
+              type="button"
+              onClick={() => setOpenIndex(isOpen ? null : i)}
+              aria-expanded={isOpen}
+              style={{
+                width: '100%',
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'space-between',
+                gap: '1rem',
+                padding: '1.1rem 0',
+                background: 'none',
+                border: 'none',
+                cursor: 'pointer',
+                textAlign: 'left',
+                fontFamily: HEADING_FONT,
+                fontSize: '1rem',
+                color: 'var(--color-heading, #D6D1CE)',
+              }}
+            >
+              <span>{item.title}</span>
+              <span
+                aria-hidden="true"
+                style={{
+                  flexShrink: 0,
+                  color: 'var(--color-detail, #9B9A9A)',
+                  transform: isOpen ? 'rotate(180deg)' : 'none',
+                  transition: 'transform 0.2s',
+                }}
+              >
+                &#9660;
+              </span>
+            </button>
+            {isOpen && (
+              <p
+                style={{
+                  margin: '0 0 1.25rem',
+                  color: 'var(--color-body, #E6E1DE)',
+                  fontFamily: BODY_FONT,
+                  lineHeight: 1.7,
+                  fontSize: '0.92rem',
+                  whiteSpace: 'pre-wrap',
+                }}
+              >
+                {item.body}
+              </p>
+            )}
+          </div>
+        )
+      })}
+    </div>
+  )
+}

--- a/app/builder/puck.config.tsx
+++ b/app/builder/puck.config.tsx
@@ -15,6 +15,7 @@ import type { ReactNode } from 'react'
 import type { Config } from '@measured/puck'
 import { ImagePickerField } from './ImagePickerField'
 import { PhotoCarouselBlock } from './PhotoCarouselBlock'
+import { AccordionBlock } from './AccordionBlock'
 
 // CSS-var-backed (TYN-314) so page-builder content follows the site-wide
 // Design editor theme, not a fixed palette - fallbacks match tokens.css's
@@ -210,7 +211,7 @@ export const config: Config = {
 
   categories: {
     layout: { title: 'Layout', components: ['SectionHeading', 'Spacer'] },
-    content: { title: 'Content', components: ['RichText', 'SplitImageText', 'Services', 'Testimonials', 'CTA'] },
+    content: { title: 'Content', components: ['RichText', 'SplitImageText', 'Services', 'Testimonials', 'Accordion', 'CTA'] },
     media: { title: 'Media', components: ['Hero', 'PhotoGallery', 'PhotoCarousel', 'FullWidthImage'] },
   },
 
@@ -462,6 +463,40 @@ export const config: Config = {
               </figure>
             ))}
           </div>
+        </Section>
+      ),
+    },
+
+    // ----------------------------------------------------------- Accordion
+    Accordion: {
+      label: 'Accordion',
+      fields: {
+        heading: { type: 'text', label: 'Heading (optional)' },
+        items: {
+          type: 'array',
+          label: 'Sections',
+          arrayFields: {
+            title: { type: 'text', label: 'Title' },
+            body: { type: 'textarea', label: 'Body' },
+          },
+          defaultItemProps: { title: 'A common question', body: 'The answer, in a sentence or two.' },
+          getItemSummary: (item: any) => item?.title || 'Section',
+        },
+        ...styleFields,
+        ...responsiveFields,
+      },
+      defaultProps: {
+        heading: 'Frequently Asked Questions',
+        items: [
+          { title: 'How far in advance should I book?', body: 'Most sessions book 4-8 weeks out - weddings often further ahead.' },
+        ],
+        ...styleDefaults,
+        ...responsiveDefaults,
+      },
+      render: ({ heading, items, background, backgroundImage, backgroundFade, spacing, hideOnMobile, hideOnDesktop }: any) => (
+        <Section background={background} backgroundImage={backgroundImage} backgroundFade={backgroundFade} spacing={spacing} className={visClass(hideOnMobile, hideOnDesktop)}>
+          {heading && <h2 style={{ ...headingStyle(), textAlign: 'center', marginBottom: '2rem' }}>{heading}</h2>}
+          <AccordionBlock items={items ?? []} />
         </Section>
       ),
     },


### PR DESCRIPTION
## Summary
- New **Accordion** block: collapsible title/body sections (FAQ-style), only one section open at a time. New `AccordionBlock.tsx` client component owns the expand/collapse state.

Part of the [TYN-327](https://linear.app/tynnell-hollins-photography/issue/TYN-327/puck-builder-editor-feature-parity-with-pixieset) builder feature-parity epic.

## Test plan
- [x] Typecheck + production build pass
- [x] Confirmed the block appears in the Content category
- [x] Verified rendering + interactivity via direct Puck-content injection: first item open by default, clicking a second item's toggle both expands it and collapses the first
- [x] Test page deleted afterward