### PR TITLE
feat(builder): add Typewriter Text block (TYN-337)

### DIFF
--- a/app/builder/TypewriterText.tsx
+++ b/app/builder/TypewriterText.tsx
@@ -1,0 +1,82 @@
+'use client'
+import { useEffect, useState } from 'react'
+
+export interface TypewriterTextProps {
+  phrases: string[]
+  speed?: number
+  pause?: number
+}
+
+const visuallyHidden: React.CSSProperties = {
+  position: 'absolute',
+  width: 1,
+  height: 1,
+  padding: 0,
+  margin: -1,
+  overflow: 'hidden',
+  clip: 'rect(0,0,0,0)',
+  whiteSpace: 'nowrap',
+  border: 0,
+}
+
+// Character-by-character typing effect (TYN-337), cycling through multiple
+// phrases. Respects both the sitewide "Enable animations" Design toggle
+// (app/(site)/layout.tsx sets data-animations="off" on <html>) and the
+// browser's prefers-reduced-motion - renders the first phrase statically
+// immediately in either case, rather than forcing the effect.
+export function TypewriterText({ phrases, speed = 60, pause = 1800 }: TypewriterTextProps) {
+  const validPhrases = phrases.filter(Boolean)
+  const [display, setDisplay] = useState('')
+  const [disabled, setDisabled] = useState(true)
+
+  useEffect(() => {
+    const reduceMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches
+    const animationsOff = document.documentElement.dataset.animations === 'off'
+    setDisabled(reduceMotion || animationsOff)
+  }, [])
+
+  useEffect(() => {
+    if (disabled || validPhrases.length === 0) return
+    let phraseIndex = 0
+    let charIndex = 0
+    let deleting = false
+    let timer: ReturnType<typeof setTimeout>
+
+    function tick() {
+      const current = validPhrases[phraseIndex]
+      if (!deleting) {
+        charIndex++
+        setDisplay(current.slice(0, charIndex))
+        if (charIndex === current.length) {
+          deleting = true
+          timer = setTimeout(tick, pause)
+          return
+        }
+      } else {
+        charIndex--
+        setDisplay(current.slice(0, charIndex))
+        if (charIndex === 0) {
+          deleting = false
+          phraseIndex = (phraseIndex + 1) % validPhrases.length
+        }
+      }
+      timer = setTimeout(tick, deleting ? speed / 2 : speed)
+    }
+    timer = setTimeout(tick, speed)
+    return () => clearTimeout(timer)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [disabled, speed, pause])
+
+  if (validPhrases.length === 0) return null
+
+  if (disabled) {
+    return <>{validPhrases[0]}</>
+  }
+
+  return (
+    <>
+      <span aria-hidden="true">{display}</span>
+      <span style={visuallyHidden}>{validPhrases.join(' ')}</span>
+    </>
+  )
+}

--- a/app/builder/puck.config.tsx
+++ b/app/builder/puck.config.tsx
@@ -15,6 +15,7 @@ import type { ReactNode } from 'react'
 import type { Config } from '@measured/puck'
 import { ImagePickerField } from './ImagePickerField'
 import { PhotoCarouselBlock } from './PhotoCarouselBlock'
+import { TypewriterText } from './TypewriterText'
 
 // CSS-var-backed (TYN-314) so page-builder content follows the site-wide
 // Design editor theme, not a fixed palette - fallbacks match tokens.css's
@@ -210,7 +211,7 @@ export const config: Config = {
 
   categories: {
     layout: { title: 'Layout', components: ['SectionHeading', 'Spacer'] },
-    content: { title: 'Content', components: ['RichText', 'SplitImageText', 'Services', 'Testimonials', 'CTA'] },
+    content: { title: 'Content', components: ['RichText', 'TypewriterHeading', 'SplitImageText', 'Services', 'Testimonials', 'CTA'] },
     media: { title: 'Media', components: ['Hero', 'PhotoGallery', 'PhotoCarousel', 'FullWidthImage'] },
   },
 
@@ -318,6 +319,53 @@ export const config: Config = {
           <div style={{ maxWidth: '70ch', margin: align === 'center' ? '0 auto' : undefined, textAlign: align }}>
             <p style={{ color: C.body, fontSize: '1.05rem', lineHeight: 1.8, whiteSpace: 'pre-wrap', margin: 0 }}>{text}</p>
           </div>
+        </Section>
+      ),
+    },
+
+    // ------------------------------------------------------ TypewriterHeading
+    TypewriterHeading: {
+      label: 'Typewriter Text',
+      fields: {
+        prefix: { type: 'text', label: 'Prefix (optional, stays static)' },
+        phrases: {
+          type: 'array',
+          label: 'Phrases (typed one at a time, in a loop)',
+          arrayFields: { text: { type: 'text', label: 'Phrase' } },
+          defaultItemProps: { text: 'A new phrase' },
+          getItemSummary: (item: any) => item?.text || 'Phrase',
+        },
+        size: {
+          type: 'select',
+          label: 'Size',
+          options: [
+            { label: 'Small', value: 'clamp(1.1rem, 2.5vw, 1.5rem)' },
+            { label: 'Medium', value: 'clamp(1.6rem, 3.5vw, 2.75rem)' },
+            { label: 'Large', value: 'clamp(2rem, 5vw, 3.75rem)' },
+          ],
+        },
+        align: alignField,
+        ...styleFields,
+        ...responsiveFields,
+      },
+      defaultProps: {
+        prefix: 'I photograph ',
+        phrases: [
+          { text: 'weddings.' },
+          { text: 'portraits.' },
+          { text: 'families.' },
+        ],
+        size: 'clamp(1.6rem, 3.5vw, 2.75rem)',
+        align: 'center',
+        ...styleDefaults,
+        ...responsiveDefaults,
+      },
+      render: ({ prefix, phrases, size, align, background, backgroundImage, backgroundFade, spacing, hideOnMobile, hideOnDesktop }: any) => (
+        <Section background={background} backgroundImage={backgroundImage} backgroundFade={backgroundFade} spacing={spacing} className={visClass(hideOnMobile, hideOnDesktop)}>
+          <p style={{ ...headingStyle(size), textAlign: align, maxWidth: align === 'center' ? '70ch' : undefined, margin: align === 'center' ? '0 auto' : 0 }}>
+            {prefix}
+            <TypewriterText phrases={(phrases ?? []).map((p: any) => p.text).filter(Boolean)} />
+          </p>
         </Section>
       ),
     },


### PR DESCRIPTION
## Summary
- New **Typewriter Text** block: character-by-character typing effect cycling through multiple phrases, with an optional static prefix.
- Respects the sitewide "Enable animations" Design toggle and `prefers-reduced-motion` - both render the first phrase statically and immediately rather than forcing the effect.
- A visually-hidden span carries the full phrase list for screen readers, since the animated span is `aria-hidden`.

Part of the [TYN-327](https://linear.app/tynnell-hollins-photography/issue/TYN-327/puck-builder-editor-feature-parity-with-pixieset) builder feature-parity epic.

## Test plan
- [x] Typecheck + production build pass
- [x] Confirmed the block appears in the Content category
- [x] Verified the actual typing/deleting cycle via direct Puck-content injection + polling rendered text over time (full phrase -> pause -> character-by-character delete)
- [x] Verified the animations-disabled path by temporarily setting `SiteDesign.animationsEnabled` to `false`, reloading, and confirming static/immediate rendering - then restored the setting
- [x] Test page deleted afterward