### PR TITLE
feat(builder): add Contact Form block (TYN-332)

### DIFF
--- a/app/(site)/contact/ContactForm.tsx
+++ b/app/(site)/contact/ContactForm.tsx
@@ -61,7 +61,12 @@ const EMPTY_FORM: FormFields = {
   howHeard: '',
 }
 
-export default function ContactForm({ minDate, maxDate }: { minDate: string; maxDate: string }) {
+// minDate/maxDate are optional (TYN-332) so this component can be embedded
+// via the builder's Contact Form block without a server-side BookingSettings
+// fetch - the date input simply won't proactively restrict the calendar
+// widget in that case, but /api/contact still enforces the real lead-time/
+// booking-window rules server-side on submit regardless.
+export default function ContactForm({ minDate, maxDate }: { minDate?: string; maxDate?: string }) {
   const [fields, setFields] = useState<FormFields>(EMPTY_FORM)
   const [status, setStatus] = useState<FormStatus>('idle')
   const [errorMessage, setErrorMessage] = useState<ReactNode>('')

--- a/app/builder/puck.config.tsx
+++ b/app/builder/puck.config.tsx
@@ -15,6 +15,7 @@ import type { ReactNode } from 'react'
 import type { Config } from '@measured/puck'
 import { ImagePickerField } from './ImagePickerField'
 import { PhotoCarouselBlock } from './PhotoCarouselBlock'
+import ContactForm from '@/app/(site)/contact/ContactForm'
 
 // CSS-var-backed (TYN-314) so page-builder content follows the site-wide
 // Design editor theme, not a fixed palette - fallbacks match tokens.css's
@@ -210,7 +211,7 @@ export const config: Config = {
 
   categories: {
     layout: { title: 'Layout', components: ['SectionHeading', 'Spacer'] },
-    content: { title: 'Content', components: ['RichText', 'SplitImageText', 'Services', 'Testimonials', 'CTA'] },
+    content: { title: 'Content', components: ['RichText', 'SplitImageText', 'Services', 'Testimonials', 'ContactFormBlock', 'CTA'] },
     media: { title: 'Media', components: ['Hero', 'PhotoGallery', 'PhotoCarousel', 'FullWidthImage'] },
   },
 
@@ -461,6 +462,35 @@ export const config: Config = {
                 {it.name && <figcaption style={{ marginTop: '1rem', color: C.detail, fontSize: '0.8rem', letterSpacing: '0.06em' }}><span aria-hidden="true">- </span>{it.name}</figcaption>}
               </figure>
             ))}
+          </div>
+        </Section>
+      ),
+    },
+
+    // ------------------------------------------------------- ContactFormBlock
+    ContactFormBlock: {
+      label: 'Contact Form',
+      fields: {
+        eyebrow: { type: 'text', label: 'Eyebrow (optional)' },
+        heading: { type: 'text', label: 'Heading (optional)' },
+        subtext: { type: 'textarea', label: 'Subtext (optional)' },
+        ...styleFields,
+        ...responsiveFields,
+      },
+      defaultProps: {
+        eyebrow: '',
+        heading: "Let's Connect",
+        subtext: "Fill out the form and I'll be in touch within 48 hours.",
+        ...styleDefaults,
+        ...responsiveDefaults,
+      },
+      render: ({ eyebrow, heading, subtext, background, backgroundImage, backgroundFade, spacing, hideOnMobile, hideOnDesktop }: any) => (
+        <Section background={background} backgroundImage={backgroundImage} backgroundFade={backgroundFade} spacing={spacing} className={visClass(hideOnMobile, hideOnDesktop)}>
+          <div style={{ maxWidth: '640px', margin: '0 auto' }}>
+            {eyebrow && <p style={{ ...eyebrowStyle, textAlign: 'center' }}>{eyebrow}</p>}
+            {heading && <h2 style={{ ...headingStyle('clamp(1.5rem,3vw,2.4rem)'), textAlign: 'center' }}>{heading}</h2>}
+            {subtext && <p style={{ marginTop: '0.85rem', marginBottom: '2rem', color: C.detail, textAlign: 'center' }}>{subtext}</p>}
+            <ContactForm />
           </div>
         </Section>
       ),


### PR DESCRIPTION
## Summary
- Adds a Contact Form block to the Puck builder (Content category), embedding the real `ContactForm` component so any page can carry a working inquiry form.
- Full field set (name/email/phone/contactPreference/sessionType/date/location/message/howHeard) posting to the existing `/api/contact` route - not a configurable subset, since the route's server-side validation requires 7 of the 9 fields and any subset would be non-functional.
- `ContactForm`'s `minDate`/`maxDate` props are now optional so it can render inside the builder without a server-side `BookingSettings` fetch. The real `/contact` page is unaffected - verified its date input still receives correct `min`/`max` constraints after this change.
- Cosmetic fields only: eyebrow, heading, subtext text, plus the shared style/spacing/responsive controls every other block gets.

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] Production build succeeds
- [x] Regression: `/contact` page's date input still has correct `min`/`max` attributes after the prop-type relaxation
- [x] Injected a `ContactFormBlock` into a throwaway test page via the Payload REST API and confirmed on the rendered public page: eyebrow/heading/subtext render correctly, and the full 9-field form renders with no date restriction (as expected with no `minDate`/`maxDate` passed)
- [ ] Manual pass recommended: actually submitting the embedded form in a real browser to confirm `/api/contact` accepts it end-to-end (drag-and-drop-to-canvas and live form submission couldn't be exercised through this session's browser automation)

Part of the TYN-327 epic (Puck builder feature parity with Pixieset's editor).