### PR TITLE
feat(builder): add Map block (TYN-333)

### DIFF
--- a/app/builder/puck.config.tsx
+++ b/app/builder/puck.config.tsx
@@ -211,7 +211,7 @@ export const config: Config = {
   categories: {
     layout: { title: 'Layout', components: ['SectionHeading', 'Spacer'] },
     content: { title: 'Content', components: ['RichText', 'SplitImageText', 'Services', 'Testimonials', 'CTA'] },
-    media: { title: 'Media', components: ['Hero', 'PhotoGallery', 'PhotoCarousel', 'FullWidthImage'] },
+    media: { title: 'Media', components: ['Hero', 'PhotoGallery', 'PhotoCarousel', 'FullWidthImage', 'Map'] },
   },
 
   components: {
@@ -626,6 +626,57 @@ export const config: Config = {
           </div>
           {caption && <p style={{ textAlign: 'center', color: C.detail, fontSize: '0.78rem', padding: '0.75rem 1rem 0', margin: 0 }}>{caption}</p>}
         </section>
+      ),
+    },
+
+    // -------------------------------------------------------------------- Map
+    // Plain Google Maps "output=embed" iframe (TYN-333) - no API key, no JS
+    // map library, so this costs nothing and can't fail on a missing/rotated
+    // key. Zoom/style customization isn't available on this embed form, which
+    // is the deliberate tradeoff for zero setup and zero recurring cost.
+    Map: {
+      label: 'Map',
+      fields: {
+        heading: { type: 'text', label: 'Heading (optional)' },
+        address: { type: 'text', label: 'Address or location' },
+        height: {
+          type: 'select',
+          label: 'Height',
+          options: [
+            { label: 'Tall', value: '480px' },
+            { label: 'Medium', value: '380px' },
+            { label: 'Short', value: '280px' },
+          ],
+        },
+        ...styleFields,
+        ...responsiveFields,
+      },
+      defaultProps: {
+        heading: '',
+        address: 'Los Angeles, CA',
+        height: '380px',
+        ...styleDefaults,
+        ...responsiveDefaults,
+      },
+      render: ({ heading, address, height, background, backgroundImage, backgroundFade, spacing, hideOnMobile, hideOnDesktop }: any) => (
+        <Section background={background} backgroundImage={backgroundImage} backgroundFade={backgroundFade} spacing={spacing} className={visClass(hideOnMobile, hideOnDesktop)}>
+          {heading && <h2 style={{ ...headingStyle(), textAlign: 'center', marginBottom: '1.5rem' }}>{heading}</h2>}
+          <div style={{ position: 'relative', width: '100%', height }}>
+            {address ? (
+              <iframe
+                src={`https://www.google.com/maps?q=${encodeURIComponent(address)}&output=embed`}
+                style={{ position: 'absolute', inset: 0, width: '100%', height: '100%', border: 0 }}
+                loading="lazy"
+                referrerPolicy="no-referrer-when-downgrade"
+                title={heading || 'Map'}
+              />
+            ) : (
+              <div style={{ position: 'absolute', inset: 0, display: 'flex', alignItems: 'center', justifyContent: 'center', background: C.accent, color: C.detail }}>
+                Add an address to show the map.
+              </div>
+            )}
+          </div>
+        </Section>
       ),
     },
 

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -21,7 +21,10 @@ const csp = [
   // upload sitewide (Photo Library, galleries, blog covers, builder/Design
   // image pickers) is silently blocked by the browser as a CSP violation.
   `connect-src 'self' https://va.vercel-scripts.com https://c5edbede1b4e1c8723a363615b47bb4c.r2.cloudflarestorage.com`,
-  `frame-src 'self'`,
+  // Puck builder Map block (TYN-333) embeds a plain Google Maps iframe
+  // (maps?...&output=embed) - no API key needed, but the iframe's own origin
+  // must be allow-listed here or the browser silently blocks the embed.
+  `frame-src 'self' https://www.google.com`,
   `frame-ancestors 'self'`,
   `object-src 'none'`,
   `base-uri 'self'`,


### PR DESCRIPTION
## Summary
- Adds a Map block to the Puck builder (Media category): heading, address/location text field, height select, plus the shared style/spacing/responsive controls.
- Uses a plain Google Maps `output=embed` iframe keyed off the address - no API key, no JS map library, no per-load cost, matching the scoping default already written into the TYN-333 ticket. Tradeoff: no zoom/style customization on this embed form.
- Adds `https://www.google.com` to the CSP `frame-src` directive so the embed isn't silently blocked by the browser (same class of gotcha as TYN-330's Video block CSP update).

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] Production build succeeds
- [x] Injected a `Map` block into a throwaway test page via the Payload REST API; confirmed on the rendered public page: heading renders, iframe `src` correctly URL-encodes the address into the `output=embed` URL, `title` matches heading, no CSP violations in the console
- [ ] Manual pass recommended: dragging the block onto the canvas through the actual builder UI (this session's browser automation can click-test the component list but not drag-and-drop-to-canvas)

Part of the TYN-327 epic (Puck builder feature parity with Pixieset's editor).