### PR TITLE
feat(design): make photo-frame tape/mat colors adjustable (TYN-338)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -196,6 +196,12 @@ node node_modules/tsx/dist/cli.mjs node_modules/payload/bin.js generate:types
 --padding-x: max(1.25rem, 2.5vw)
 ```
 
+### Style-exposure convention (TYN-338)
+
+Any new visual/style option added to a block or sitewide treatment must be exposed as an adjustable control (the `/design` Design editor for sitewide treatments, or a per-block field in `app/builder/puck.config.tsx` for builder-only options) rather than hardcoded. Tynnell needs to be able to change it herself without filing a dev ticket.
+
+TYN-338 is the reference example: the taped/polaroid photo-frame mat and tape-strip colors were a hardcoded sitewide constant (`--tape-mat`, `--tape-color` in `tokens.css`) used by the gallery album, portfolio teaser, about headshot, blog cards, and the builder's PhotoGallery block. They were promoted to `SiteDesign.tapeMatColor`/`tapeColor` fields, added to the `/design` editor's "Photo Frame" accordion (`app/builder/DesignPanelShared.tsx`), and plumbed through `themeToCssVarMap` (`app/lib/siteTheme.ts`) the same way the existing color palette already was (TYN-314). `tokens.css`'s hardcoded values remain only as the CSS-var fallback for when `SiteDesign` hasn't been read yet (e.g. isolated tooling).
+
 ---
 
 ## Pages (public site)

--- a/app/api/design/save/route.ts
+++ b/app/api/design/save/route.ts
@@ -21,6 +21,8 @@ const FIELDS = [
   'colorBody',
   'colorDetail',
   'colorBtnBg',
+  'tapeMatColor',
+  'tapeColor',
   'spacingScale',
   'buttonStyle',
   'animationsEnabled',

--- a/app/builder/DesignPanelShared.tsx
+++ b/app/builder/DesignPanelShared.tsx
@@ -32,6 +32,16 @@ export const COLOR_FIELDS: { key: keyof Pick<SiteTheme, 'colorBg' | 'colorBgAcce
   { key: 'colorBtnBg', label: 'Button color' },
 ]
 
+// TYN-338: the taped/polaroid photo-frame treatment (gallery album, portfolio
+// teaser, about headshot, blog cards, builder PhotoGallery block) used to be a
+// hardcoded sitewide constant. tapeColor is usually an rgba() value, not a
+// hex, so its swatch preview in ColorInput won't parse - the text field still
+// accepts and applies any valid CSS color.
+export const TAPE_FIELDS: { key: keyof Pick<SiteTheme, 'tapeMatColor' | 'tapeColor'>; label: string }[] = [
+  { key: 'tapeMatColor', label: 'Photo mat color' },
+  { key: 'tapeColor', label: 'Tape strip color' },
+]
+
 export function AccordionRow({ label, isOpen, onToggle, children }: { label: string; isOpen: boolean; onToggle: () => void; children: React.ReactNode }) {
   return (
     <div style={{ borderBottom: '1px solid #1a1a1a' }}>
@@ -136,6 +146,16 @@ export function DesignSections({
             <ColorInput value={theme[f.key]} onChange={(v) => set(f.key, v)} />
           </div>
         ))}
+      </AccordionRow>
+
+      <AccordionRow label="Photo Frame" isOpen={open === 'photoFrame'} onToggle={() => setOpen(open === 'photoFrame' ? null : 'photoFrame')}>
+        {TAPE_FIELDS.map((f, i) => (
+          <div key={f.key} style={{ marginTop: i === 0 ? 0 : 12 }}>
+            <FieldLabel>{f.label}</FieldLabel>
+            <ColorInput value={theme[f.key]} onChange={(v) => set(f.key, v)} />
+          </div>
+        ))}
+        <p style={{ color: '#6b6a6a', fontSize: 11, marginTop: 8 }}>Used by the Taped and Polaroid photo styles across the portfolio, galleries, and builder.</p>
       </AccordionRow>
 
       <AccordionRow label="Animations" isOpen={open === 'animations'} onToggle={() => setOpen(open === 'animations' ? null : 'animations')}>

--- a/app/lib/siteDesign.ts
+++ b/app/lib/siteDesign.ts
@@ -35,6 +35,8 @@ export const getSiteDesign = cache(async (): Promise<SiteTheme> => {
       colorBody: doc.colorBody || DEFAULT_THEME.colorBody,
       colorDetail: doc.colorDetail || DEFAULT_THEME.colorDetail,
       colorBtnBg: doc.colorBtnBg || DEFAULT_THEME.colorBtnBg,
+      tapeMatColor: doc.tapeMatColor || DEFAULT_THEME.tapeMatColor,
+      tapeColor: doc.tapeColor || DEFAULT_THEME.tapeColor,
       spacingScale: doc.spacingScale || DEFAULT_THEME.spacingScale,
       buttonStyle: doc.buttonStyle || DEFAULT_THEME.buttonStyle,
       animationsEnabled: doc.animationsEnabled ?? true,

--- a/app/lib/siteTheme.ts
+++ b/app/lib/siteTheme.ts
@@ -18,6 +18,8 @@ export interface SiteTheme {
   colorBody: string
   colorDetail: string
   colorBtnBg: string
+  tapeMatColor: string
+  tapeColor: string
   spacingScale: 'compact' | 'normal' | 'spacious'
   buttonStyle: 'sharp' | 'rounded' | 'pill'
   animationsEnabled: boolean
@@ -36,6 +38,8 @@ export const DEFAULT_THEME: SiteTheme = {
   colorBody: '#E6E1DE',
   colorDetail: '#9B9A9A',
   colorBtnBg: '#9B9A9A',
+  tapeMatColor: '#f4efe8',
+  tapeColor: 'rgba(214, 209, 206, 0.42)',
   spacingScale: 'normal',
   buttonStyle: 'sharp',
   animationsEnabled: true,
@@ -69,6 +73,8 @@ export function themeToCssVarMap(theme: SiteTheme): Record<string, string> {
     '--color-body': theme.colorBody,
     '--color-detail': theme.colorDetail,
     '--color-btn-bg': theme.colorBtnBg,
+    '--tape-mat': theme.tapeMatColor,
+    '--tape-color': theme.tapeColor,
     '--space-scale': String(SPACE_SCALE[theme.spacingScale]),
     '--btn-radius': BTN_RADIUS[theme.buttonStyle],
   }

--- a/globals/SiteDesign.ts
+++ b/globals/SiteDesign.ts
@@ -97,6 +97,18 @@ export const SiteDesign: GlobalConfig = {
       defaultValue: '#9B9A9A',
     },
     {
+      name: 'tapeMatColor',
+      type: 'text',
+      label: 'Photo mat color (tape/polaroid frames)',
+      defaultValue: '#f4efe8',
+    },
+    {
+      name: 'tapeColor',
+      type: 'text',
+      label: 'Tape strip color',
+      defaultValue: 'rgba(214, 209, 206, 0.42)',
+    },
+    {
       name: 'spacingScale',
       type: 'select',
       label: 'Overall spacing',

--- a/payload-types.ts
+++ b/payload-types.ts
@@ -1046,6 +1046,8 @@ export interface SiteDesign {
   colorBody?: string | null;
   colorDetail?: string | null;
   colorBtnBg?: string | null;
+  tapeMatColor?: string | null;
+  tapeColor?: string | null;
   spacingScale?: ('compact' | 'normal' | 'spacious') | null;
   buttonStyle?: ('sharp' | 'rounded' | 'pill') | null;
   animationsEnabled?: boolean | null;
@@ -1218,6 +1220,8 @@ export interface SiteDesignSelect<T extends boolean = true> {
   colorBody?: T;
   colorDetail?: T;
   colorBtnBg?: T;
+  tapeMatColor?: T;
+  tapeColor?: T;
   spacingScale?: T;
   buttonStyle?: T;
   animationsEnabled?: T;

--- a/scripts/migrate-db.mjs
+++ b/scripts/migrate-db.mjs
@@ -636,6 +636,22 @@ async function run() {
     console.log('✓ site_design watermark columns ready')
 
     // ------------------------------------------------------------------
+    // Migration 20260719_100000: site_design tape/polaroid frame colors
+    // (TYN-338). Previously a hardcoded sitewide CSS constant
+    // (--tape-mat/--tape-color in tokens.css) - defaults here match those
+    // same values so publishing for the first time is a no-op visually.
+    // ------------------------------------------------------------------
+
+    await client.query(`
+      ALTER TABLE "site_design" ADD COLUMN IF NOT EXISTS "tape_mat_color" varchar DEFAULT '#f4efe8'
+    `)
+    await client.query(`
+      ALTER TABLE "site_design" ADD COLUMN IF NOT EXISTS "tape_color" varchar DEFAULT 'rgba(214, 209, 206, 0.42)'
+    `)
+
+    console.log('✓ site_design tape/polaroid frame color columns ready')
+
+    // ------------------------------------------------------------------
     // Migration 20260717_300000: gallery_presets global table (TYN-323)
     // Defaults applied automatically when a new gallery is created (see the
     // applyGalleryPresets hook in collections/Galleries.ts), edited from the


### PR DESCRIPTION
## Summary
- Promotes the hardcoded `--tape-mat`/`--tape-color` sitewide CSS constants (used by the gallery album, portfolio teaser, about headshot, blog cards, and the builder's PhotoGallery block) to `SiteDesign.tapeMatColor`/`tapeColor` fields.
- New "Photo Frame" accordion in the `/design` editor (`app/builder/DesignPanelShared.tsx`), following the exact same pattern the existing color palette uses (TYN-314): `themeToCssVarMap` plumbing, live preview sync, publish flow.
- DB migration adds `tape_mat_color`/`tape_color` columns to `site_design`, defaulted to the prior hardcoded values so publishing for the first time is a visual no-op.
- Documents the underlying convention in CLAUDE.md's "Design tokens" section: any new visual/style option on a block or sitewide treatment must be exposed as an adjustable control (Design editor or per-block builder field), not hardcoded. This ticket is the first concrete example of applying that standard retroactively.

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] Production build succeeds
- [x] Migration run against the shared database, confirmed new columns exist
- [x] `/design` editor: "Photo Frame" accordion renders both color fields with correct defaults, edited the mat color, published, confirmed the change (`getComputedStyle(document.documentElement).getPropertyValue('--tape-mat')`) on the live `/portfolio` page
- [x] Reset both fields back to their original defaults and confirmed via `GET /api/globals/site-design`

Part of the TYN-327 epic (Puck builder feature parity with Pixieset's editor).