### PR TITLE
feat(builder): add Move Up/Down to the per-block hover overlay (TYN-328)

### DIFF
--- a/app/builder/SectionMoveOverlay.tsx
+++ b/app/builder/SectionMoveOverlay.tsx
@@ -1,0 +1,114 @@
+'use client'
+
+import { usePuck } from '@measured/puck'
+
+// TYN-328: Puck's built-in per-block hover overlay already provides Duplicate,
+// Delete, and drag-to-reorder (its default ActionBar), and clicking any block
+// already selects it and opens its settings in the right-hand Fields panel -
+// so those parts of the ticket need no code here. The one gap Puck doesn't
+// cover is a non-drag way to reorder: this override adds Move Up / Move Down
+// buttons to the same hover overlay.
+//
+// Puck's `actionBar` override does not receive the component's id, only
+// `label`/`children`/`parentAction` - there is no supported way to know which
+// block a custom action bar button belongs to from there. `componentOverlay`
+// does receive `componentId`, so the buttons are added there instead,
+// positioned over the top-left corner of the block to sit clear of the
+// default action bar's icons (top-right).
+//
+// Scoped to top-level content only (this codebase has no nested slot/dropzone
+// fields today, so every real block lives in the root content array).
+export function SectionMoveOverlay({
+  children,
+  componentId,
+  hover,
+  isSelected,
+}: {
+  children: React.ReactNode
+  componentId: string
+  componentType: string
+  hover: boolean
+  isSelected: boolean
+}) {
+  const { appState, dispatch } = usePuck()
+  const content = appState.data.content
+  const index = content.findIndex((item) => item.props.id === componentId)
+  const visible = (hover || isSelected) && index !== -1
+
+  const move = (direction: -1 | 1) => {
+    const target = index + direction
+    if (index === -1 || target < 0 || target >= content.length) return
+    dispatch({
+      type: 'setData',
+      data: (prev) => {
+        const next = [...prev.content]
+        ;[next[index], next[target]] = [next[target], next[index]]
+        return { ...prev, content: next }
+      },
+    })
+  }
+
+  return (
+    <>
+      {children}
+      {visible && (
+        <div
+          style={{
+            position: 'absolute',
+            top: 6,
+            left: 6,
+            zIndex: 2,
+            display: 'flex',
+            gap: 4,
+            pointerEvents: 'auto',
+          }}
+        >
+          <button
+            type="button"
+            title="Move up"
+            aria-label="Move section up"
+            disabled={index <= 0}
+            onClick={(e) => {
+              e.stopPropagation()
+              move(-1)
+            }}
+            style={moveBtnStyle(index <= 0)}
+          >
+            &#8593;
+          </button>
+          <button
+            type="button"
+            title="Move down"
+            aria-label="Move section down"
+            disabled={index === -1 || index >= content.length - 1}
+            onClick={(e) => {
+              e.stopPropagation()
+              move(1)
+            }}
+            style={moveBtnStyle(index === -1 || index >= content.length - 1)}
+          >
+            &#8595;
+          </button>
+        </div>
+      )}
+    </>
+  )
+}
+
+function moveBtnStyle(disabled: boolean): React.CSSProperties {
+  return {
+    width: 24,
+    height: 24,
+    display: 'inline-flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    background: '#1a1a1a',
+    color: disabled ? '#5a5a5a' : '#e6e1de',
+    border: '1px solid rgba(255,255,255,0.15)',
+    borderRadius: 4,
+    fontSize: 13,
+    lineHeight: 1,
+    cursor: disabled ? 'default' : 'pointer',
+    padding: 0,
+  }
+}

--- a/app/builder/[slug]/EditorClient.tsx
+++ b/app/builder/[slug]/EditorClient.tsx
@@ -6,6 +6,7 @@ import '../puck-theme.css'
 import { useCallback, useEffect, useRef, useState } from 'react'
 import Link from 'next/link'
 import { config } from '../puck.config'
+import { SectionMoveOverlay } from '../SectionMoveOverlay'
 
 // Per-page Puck editor (TYN-216). Saves the document for `slug` via the save
 // API; Publish marks the page published so it renders at /{slug}. Puck's
@@ -127,6 +128,7 @@ export function EditorClient({
         headerTitle={title}
         headerPath={`/${slug}`}
         overrides={{
+          componentOverlay: SectionMoveOverlay,
           headerActions: ({ children }) => (
             <>
               <span


### PR DESCRIPTION
## Summary
- The ticket asked for a Pixieset-style hover toolbar (duplicate/delete/reorder/open-editor) over each canvas block. Investigating Puck 0.20.2's actual behavior first: it already ships a per-block hover overlay with Duplicate and Delete, drag-to-reorder is already native canvas behavior, and clicking any block already selects it and opens its settings in the right-hand Fields panel. None of that needed new code.
- The one real gap: no non-drag way to reorder. This adds **Move Up / Move Down** buttons to the same hover overlay.
- Implementation note: Puck's `actionBar` override (where Duplicate/Delete render) does not receive the block's id - only `label`/`children`/`parentAction` - so there's no supported way to know which block a custom action bar button belongs to from there (verified by reading Puck's compiled source, not just its types). `componentOverlay` does receive `componentId`, so the new buttons are added there instead via a new `SectionMoveOverlay` component, wired into `EditorClient.tsx`'s `overrides.componentOverlay`. It reads/writes Puck's own app state (`usePuck()` + a `setData` dispatch), scoped to the top-level content array - this codebase has no nested slot/dropzone fields today, so that covers every real block.
- `app/builder/SiteEditorClient.tsx` (referenced in the ticket) doesn't render its own `<Puck>` instance - `EditorClient.tsx` is the only place `<Puck>` is actually used, so it's the only file that needed wiring.

## Test plan
- [x] `npx tsc --noEmit` clean (confirms `SectionMoveOverlay`'s props structurally match Puck's `componentOverlay` override signature)
- [x] Production build succeeds
- [x] Created a 3-block test page, hovered the first block in the real builder editor (via the browser automation's `hover` action - no drag needed) and confirmed the overlay shows all 4 actions together: Duplicate, Delete, Move section up (correctly disabled on the first block), Move section down (enabled)
- [x] Clicked Move section down and confirmed the block moved in both the canvas and the Outline panel
- [x] Saved and confirmed the new order persisted on the live public page

Part of the TYN-327 epic (Puck builder feature parity with Pixieset's editor) - the last sub-ticket in this batch.