### PR TITLE
feat(builder): add Instagram Feed block (TYN-335)

### DIFF
--- a/app/builder/puck.config.tsx
+++ b/app/builder/puck.config.tsx
@@ -369,7 +369,7 @@ export const config: Config = {
   categories: {
     layout: { title: 'Layout', components: ['SectionHeading', 'Spacer', 'Shape', 'Line', 'SocialLinks'] },
     content: { title: 'Content', components: ['RichText', 'TypewriterHeading', 'SplitImageText', 'Services', 'Testimonials', 'Accordion', 'ContactFormBlock', 'CTA'] },
-    media: { title: 'Media', components: ['Hero', 'PhotoGallery', 'PhotoCarousel', 'ImageGrid', 'FullWidthImage', 'Video', 'Map'] },
+    media: { title: 'Media', components: ['Hero', 'PhotoGallery', 'PhotoCarousel', 'ImageGrid', 'FullWidthImage', 'Video', 'Map', 'InstagramFeed'] },
   },
 
   components: {
@@ -1420,6 +1420,60 @@ export const config: Config = {
         </Section>
       ),
     },
+    // --------------------------------------------------------- InstagramFeed
+    // Third-party embed (TYN-335), not Instagram's own Graph API - avoids
+    // registering a developer app and refreshing an access token forever.
+    // Standardized on SnapWidget specifically because its default embed is a
+    // plain iframe (no injected <script>, so no CSP script-src loosening
+    // needed) with a free tier. Switching providers later means updating
+    // both this block's help text and the snapwidget.com CSP frame-src entry
+    // in next.config.mjs.
+    InstagramFeed: {
+      label: 'Instagram Feed',
+      fields: {
+        heading: { type: 'text', label: 'Heading (optional)' },
+        embedUrl: { type: 'text', label: 'SnapWidget embed URL (from snapwidget.com, looks like https://snapwidget.com/embed/123456)' },
+        height: {
+          type: 'select',
+          label: 'Height',
+          options: [
+            { label: 'Tall', value: '600px' },
+            { label: 'Medium', value: '450px' },
+            { label: 'Short', value: '300px' },
+          ],
+        },
+        ...styleFields,
+        ...responsiveFields,
+      },
+      defaultProps: {
+        heading: '',
+        embedUrl: '',
+        height: '450px',
+        ...styleDefaults,
+        ...responsiveDefaults,
+      },
+      render: ({ heading, embedUrl, height, background, backgroundImage, backgroundFade, spacing, hideOnMobile, hideOnDesktop }: any) => (
+        <Section background={background} backgroundImage={backgroundImage} backgroundFade={backgroundFade} spacing={spacing} className={visClass(hideOnMobile, hideOnDesktop)}>
+          {heading && <h2 style={{ ...headingStyle(), textAlign: 'center', marginBottom: '1.5rem' }}>{heading}</h2>}
+          <div style={{ position: 'relative', width: '100%', height }}>
+            {embedUrl ? (
+              <iframe
+                src={embedUrl}
+                style={{ position: 'absolute', inset: 0, width: '100%', height: '100%', border: 0 }}
+                loading="lazy"
+                scrolling="no"
+                title={heading || 'Instagram Feed'}
+              />
+            ) : (
+              <div style={{ position: 'absolute', inset: 0, display: 'flex', alignItems: 'center', justifyContent: 'center', background: C.accent, color: C.detail, textAlign: 'center', padding: '1rem' }}>
+                Add a SnapWidget embed URL to show the feed.
+              </div>
+            )}
+          </div>
+        </Section>
+      ),
+    },
+
     // ---------------------------------------------------------------- Spacer
     Spacer: {
       label: 'Spacer',

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -24,11 +24,13 @@ const csp = [
   // upload sitewide (Photo Library, galleries, blog covers, builder/Design
   // image pickers) is silently blocked by the browser as a CSP violation.
   `connect-src 'self' https://va.vercel-scripts.com https://c5edbede1b4e1c8723a363615b47bb4c.r2.cloudflarestorage.com`,
-  // YouTube/Vimeo embeds for the builder Video block (TYN-330), plus Google
-  // Maps for the builder Map block (TYN-333, plain output=embed iframe, no
-  // API key needed) - each origin must be allow-listed here or the browser
+  // YouTube/Vimeo embeds for the builder Video block (TYN-330), Google Maps
+  // for the builder Map block (TYN-333, plain output=embed iframe, no API
+  // key needed), and SnapWidget for the builder Instagram Feed block
+  // (TYN-335, third-party embed widget - avoids Instagram's own API/token
+  // maintenance) - each origin must be allow-listed here or the browser
   // silently blocks the embed.
-  `frame-src 'self' https://www.youtube.com https://player.vimeo.com https://www.google.com`,
+  `frame-src 'self' https://www.youtube.com https://player.vimeo.com https://www.google.com https://snapwidget.com`,
   `frame-ancestors 'self'`,
   `object-src 'none'`,
   `base-uri 'self'`,


### PR DESCRIPTION
## Summary
- Adds an Instagram Feed block to the Puck builder (Media category): heading, SnapWidget embed URL, height, plus the shared style/spacing/responsive controls.
- Resolves the decision the ticket flagged (official Instagram Graph API w/ token maintenance vs. third-party embed widget) - user explicitly chose the third-party widget approach.
- Standardized on **SnapWidget** specifically: its default embed is a plain iframe, so this needs only a `frame-src` CSP addition, not a `script-src` loosening (which a script-tag-based widget like Elfsight or Behold.so would require). Free tier available, no Instagram developer app or access-token refresh to maintain.
- Also filed [TYN-339](https://linear.app/tynnell-hollins-photography/issue/TYN-339/builder-add-tiktok-feed-block) (TikTok Feed, same pattern) since Tynnell is active on TikTok too - not built yet, left for a future ticket.

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] Production build succeeds
- [x] Confirmed "Instagram Feed" appears in the Media category in the real builder editor
- [x] Injected an `InstagramFeed` block into a throwaway test page via the Payload REST API; confirmed on the rendered public page: heading renders, iframe `src`/`title` match the configured values, no CSP violations in the console
- [x] Confirmed the empty-state message renders when no embed URL is set
- [ ] Manual pass recommended: a real SnapWidget account + embed URL to confirm the actual Instagram grid renders (this session used a placeholder URL, not a live SnapWidget widget)

Closes the TYN-327 epic's block-parity work except TYN-339 (TikTok, filed but not started).