### PR TITLE
feat(builder): add TikTok Feed block (TYN-339)

### DIFF
--- a/app/builder/puck.config.tsx
+++ b/app/builder/puck.config.tsx
@@ -369,7 +369,7 @@ export const config: Config = {
   categories: {
     layout: { title: 'Layout', components: ['SectionHeading', 'Spacer', 'Shape', 'Line', 'SocialLinks'] },
     content: { title: 'Content', components: ['RichText', 'TypewriterHeading', 'SplitImageText', 'Services', 'Testimonials', 'Accordion', 'ContactFormBlock', 'CTA'] },
-    media: { title: 'Media', components: ['Hero', 'PhotoGallery', 'PhotoCarousel', 'ImageGrid', 'FullWidthImage', 'Video', 'Map', 'InstagramFeed'] },
+    media: { title: 'Media', components: ['Hero', 'PhotoGallery', 'PhotoCarousel', 'ImageGrid', 'FullWidthImage', 'Video', 'Map', 'InstagramFeed', 'TikTokFeed'] },
   },
 
   components: {
@@ -1467,6 +1467,64 @@ export const config: Config = {
             ) : (
               <div style={{ position: 'absolute', inset: 0, display: 'flex', alignItems: 'center', justifyContent: 'center', background: C.accent, color: C.detail, textAlign: 'center', padding: '1rem' }}>
                 Add a SnapWidget embed URL to show the feed.
+              </div>
+            )}
+          </div>
+        </Section>
+      ),
+    },
+
+    // ------------------------------------------------------------ TikTokFeed
+    // Same third-party-widget decision as InstagramFeed (TYN-335) - a
+    // developer-app + token setup is a maintenance burden neither ticket's
+    // scope wanted. Unlike SnapWidget for Instagram, there isn't one single
+    // dominant iframe-native TikTok widget provider to standardize on with
+    // full confidence, so this field is intentionally generic ("widget embed
+    // URL") rather than named to one brand. Defaulted the CSP frame-src entry
+    // to Elfsight (apps.elfsight.com), a widely-used social-feed widget
+    // platform that supports TikTok - flagged as a best-effort default that
+    // may need swapping for whichever specific provider Tynnell ends up
+    // using, the same way the Video/Map/Instagram blocks' CSP entries are
+    // each tied to one concrete origin.
+    TikTokFeed: {
+      label: 'TikTok Feed',
+      fields: {
+        heading: { type: 'text', label: 'Heading (optional)' },
+        embedUrl: { type: 'text', label: 'Widget embed URL (iframe URL from a TikTok feed widget provider, e.g. Elfsight)' },
+        height: {
+          type: 'select',
+          label: 'Height',
+          options: [
+            { label: 'Tall', value: '600px' },
+            { label: 'Medium', value: '450px' },
+            { label: 'Short', value: '300px' },
+          ],
+        },
+        ...styleFields,
+        ...responsiveFields,
+      },
+      defaultProps: {
+        heading: '',
+        embedUrl: '',
+        height: '450px',
+        ...styleDefaults,
+        ...responsiveDefaults,
+      },
+      render: ({ heading, embedUrl, height, background, backgroundImage, backgroundFade, spacing, hideOnMobile, hideOnDesktop }: any) => (
+        <Section background={background} backgroundImage={backgroundImage} backgroundFade={backgroundFade} spacing={spacing} className={visClass(hideOnMobile, hideOnDesktop)}>
+          {heading && <h2 style={{ ...headingStyle(), textAlign: 'center', marginBottom: '1.5rem' }}>{heading}</h2>}
+          <div style={{ position: 'relative', width: '100%', height }}>
+            {embedUrl ? (
+              <iframe
+                src={embedUrl}
+                style={{ position: 'absolute', inset: 0, width: '100%', height: '100%', border: 0 }}
+                loading="lazy"
+                scrolling="no"
+                title={heading || 'TikTok Feed'}
+              />
+            ) : (
+              <div style={{ position: 'absolute', inset: 0, display: 'flex', alignItems: 'center', justifyContent: 'center', background: C.accent, color: C.detail, textAlign: 'center', padding: '1rem' }}>
+                Add a widget embed URL to show the feed.
               </div>
             )}
           </div>

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -26,11 +26,14 @@ const csp = [
   `connect-src 'self' https://va.vercel-scripts.com https://c5edbede1b4e1c8723a363615b47bb4c.r2.cloudflarestorage.com`,
   // YouTube/Vimeo embeds for the builder Video block (TYN-330), Google Maps
   // for the builder Map block (TYN-333, plain output=embed iframe, no API
-  // key needed), and SnapWidget for the builder Instagram Feed block
-  // (TYN-335, third-party embed widget - avoids Instagram's own API/token
-  // maintenance) - each origin must be allow-listed here or the browser
-  // silently blocks the embed.
-  `frame-src 'self' https://www.youtube.com https://player.vimeo.com https://www.google.com https://snapwidget.com`,
+  // key needed), SnapWidget for the builder Instagram Feed block (TYN-335),
+  // and Elfsight for the builder TikTok Feed block (TYN-339) - all three
+  // "Feed" blocks are third-party embed widgets, avoiding each platform's
+  // own API/token maintenance. Each origin must be allow-listed here or the
+  // browser silently blocks the embed. The Elfsight entry is a best-effort
+  // default (see TikTokFeed's comment in puck.config.tsx) - swap it for
+  // whichever provider Tynnell actually uses if it's not Elfsight.
+  `frame-src 'self' https://www.youtube.com https://player.vimeo.com https://www.google.com https://snapwidget.com https://apps.elfsight.com`,
   `frame-ancestors 'self'`,
   `object-src 'none'`,
   `base-uri 'self'`,


### PR DESCRIPTION
## Summary
- Adds a TikTok Feed block to the Puck builder (Media category): heading, widget embed URL, height, plus the shared style/spacing/responsive controls - matches the InstagramFeed block's shape exactly for consistency.
- Same third-party-widget decision as TYN-335 (avoids TikTok's own Display API and its developer-app/token-refresh maintenance burden).
- **Important caveat, different from TYN-335's SnapWidget pick**: there isn't one dominant iframe-native TikTok widget provider I have high confidence in the way SnapWidget is for Instagram - most social-feed widget platforms (Elfsight, Tagembed, EmbedSocial, etc.) default to a script+div embed rather than a plain iframe. Because of that, the field is intentionally generic ("Widget embed URL") rather than named to one brand, and the CSP `frame-src` entry defaults to Elfsight (`apps.elfsight.com`) as a best-effort choice - **this may need to change** once Tynnell picks an actual provider and we confirm its real iframe-embed domain.

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] Production build succeeds
- [x] Confirmed "TikTok Feed" appears in the Media category in the real builder editor
- [x] Injected a `TikTokFeed` block into a throwaway test page via the Payload REST API; confirmed on the rendered public page: heading renders, iframe `src`/`title` match the configured values, no CSP violations in the console
- [x] Confirmed the empty-state message renders when no embed URL is set
- [ ] Manual pass required: pick an actual TikTok feed widget provider, generate a real embed, and confirm both that the iframe renders (not just that the CSP allows it) and that its domain matches `apps.elfsight.com` - if it doesn't, `next.config.mjs`'s `frame-src` needs updating to the real provider's origin

Closes out the TYN-327 epic (Puck builder feature parity with Pixieset's editor) in full.