### PR TITLE
feat(builder): implement real click-to-add for blocks (TYN-340)

### DIFF
--- a/app/builder/DrawerItemClickToAdd.tsx
+++ b/app/builder/DrawerItemClickToAdd.tsx
@@ -1,0 +1,41 @@
+'use client'
+
+import { usePuck } from '@measured/puck'
+
+// TYN-340: the builder's own Help panel claims a block can be added by
+// clicking it, not just dragging - but Puck's Drawer.Item has no click
+// handler at all (confirmed by reading the compiled source: the sidebar
+// item's only listener is onMouseDown preventDefault, purely to suppress
+// native drag/text-select chrome). This override adds a real click-to-add
+// path via Puck's `drawerItem` override (the current key - `componentItem`
+// is deprecated), which hands us the clicked block's `name` directly.
+//
+// Appends a fresh instance of that component (with its own defaultProps) to
+// the end of the page via a plain `setData` dispatch - the same public,
+// documented usePuck() approach already used for TYN-328's Move Up/Down,
+// deliberately avoiding Puck's private/unexported root-zone-id string.
+// Coexists cleanly with drag: dnd-kit's drag activation requires pointer
+// movement past a threshold, so a plain click (no movement) never competes
+// with an actual drag gesture.
+export function DrawerItemClickToAdd({ children, name }: { children: React.ReactNode; name: string }) {
+  const { dispatch, config } = usePuck()
+
+  const handleClick = () => {
+    const componentConfig = (config.components as Record<string, { defaultProps?: Record<string, unknown> }>)[name]
+    if (!componentConfig) return
+    const id = `${name}-${crypto.randomUUID()}`
+    dispatch({
+      type: 'setData',
+      data: (prev) => ({
+        ...prev,
+        content: [...prev.content, { type: name, props: { ...componentConfig.defaultProps, id } }],
+      }),
+    })
+  }
+
+  return (
+    <div onClick={handleClick} title={`Add ${name}`} style={{ cursor: 'pointer' }}>
+      {children}
+    </div>
+  )
+}

--- a/app/builder/[slug]/EditorClient.tsx
+++ b/app/builder/[slug]/EditorClient.tsx
@@ -7,6 +7,7 @@ import { useCallback, useEffect, useRef, useState } from 'react'
 import Link from 'next/link'
 import { config } from '../puck.config'
 import { SectionMoveOverlay } from '../SectionMoveOverlay'
+import { DrawerItemClickToAdd } from '../DrawerItemClickToAdd'
 
 // Per-page Puck editor (TYN-216). Saves the document for `slug` via the save
 // API; Publish marks the page published so it renders at /{slug}. Puck's
@@ -129,6 +130,7 @@ export function EditorClient({
         headerPath={`/${slug}`}
         overrides={{
           componentOverlay: SectionMoveOverlay,
+          drawerItem: DrawerItemClickToAdd,
           headerActions: ({ children }) => (
             <>
               <span


### PR DESCRIPTION
## Summary
- The builder's own Help panel (Tip #1) has always said "Drag a block from the left panel onto the page, or click it." The "or click it" half was never true - confirmed by reading Puck's compiled source: `Drawer.Item`'s only event handler is `onMouseDown preventDefault` (suppresses native drag chrome), no `onClick` anywhere in the library, and this codebase's own `puck.config.tsx`/`EditorClient.tsx` never added one either.
- Adds real click-to-add via Puck's `drawerItem` override (current key, not the deprecated `componentItem` alias), which hands us the clicked block's `name` directly. Clicking a block appends a fresh instance (with its own `defaultProps`) to the end of the page via a `setData` dispatch - the same public `usePuck()` pattern already used for TYN-328's Move Up/Down.
- New file `app/builder/DrawerItemClickToAdd.tsx`, wired into `EditorClient.tsx`'s `overrides.drawerItem` alongside the existing `componentOverlay`.

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] Production build succeeds
- [x] In the real builder editor (not API injection): clicked "TikTok Feed" in the sidebar, confirmed it appeared in the Outline and canvas with its correct default content (empty-state text)
- [x] Clicked "Section Heading" next, confirmed it stacked below the first block (top to bottom), matching the Help panel's own description
- [x] Clicked the newly-added Section Heading block on the canvas, confirmed normal block selection still works - the full Fields panel opened (Eyebrow, Heading, Subtext, Alignment, Background, etc.) and the Move Up/Down arrows from TYN-328 still appear - no interference between click-to-add and existing selection/editing
- [x] No console errors
- [x] Test page deleted afterward

Closes TYN-340. This also means the Help panel's existing "or click it" text is now accurate rather than needing a correction.