### PR TITLE
feat(settings): add Search Engine Visibility and Photo Sharpening (TYN-325)

### DIFF
--- a/app/(site)/portfolio/[slug]/page.tsx
+++ b/app/(site)/portfolio/[slug]/page.tsx
@@ -80,6 +80,11 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
         images: [ogImageUrl],
       },
     }),
+    // Search Engine Visibility (TYN-325): unlike the password/expired cases
+    // above, this is a plain indexing preference, not a security gate - the
+    // real title/description/OG image are still returned so shared links
+    // preview correctly, only `robots.index` is suppressed.
+    ...(gallery.seoIndexable === false && { robots: { index: false } }),
   }
 }
 

--- a/app/api/design/save/route.ts
+++ b/app/api/design/save/route.ts
@@ -26,6 +26,7 @@ const FIELDS = [
   'spacingScale',
   'buttonStyle',
   'animationsEnabled',
+  'sharpeningLevel',
 ] as const
 
 export async function POST(request: Request) {

--- a/app/api/photos/ingest/route.ts
+++ b/app/api/photos/ingest/route.ts
@@ -4,6 +4,7 @@ import { headers } from 'next/headers'
 import config from '@payload-config'
 import { S3Client, GetObjectCommand, DeleteObjectCommand } from '@aws-sdk/client-s3'
 import { applyWatermarkIfEnabled } from '@/app/lib/watermark'
+import { applySharpeningIfEnabled } from '@/app/lib/sharpening'
 import type { Photo } from '@/payload-types'
 
 export const dynamic = 'force-dynamic'
@@ -143,6 +144,17 @@ export async function POST(request: Request) {
       })
 
       console.log(`[photos/ingest] payload.create done for ${filename} in ${Date.now() - createStart}ms (total: ${Date.now() - requestStart}ms)`)
+
+      // Sharpen the preview sizes if enabled (TYN-325), before watermarking so
+      // the watermark itself is never re-sharpened. Both are best-effort and
+      // never fail the upload. The full original stays untouched.
+      try {
+        const sharpenStart = Date.now()
+        await applySharpeningIfEnabled({ s3, bucket, sizes: (doc as Photo).sizes })
+        console.log(`[photos/ingest] sharpening step for ${filename} took ${Date.now() - sharpenStart}ms`)
+      } catch (err) {
+        console.warn(`[photos/ingest] sharpening step failed for ${filename} (non-fatal):`, err)
+      }
 
       // Watermark the preview sizes if enabled (TYN-322) - best-effort,
       // never fails the upload. The full original stays untouched.

--- a/app/builder/DesignPanelShared.tsx
+++ b/app/builder/DesignPanelShared.tsx
@@ -22,6 +22,12 @@ export const BUTTON_OPTIONS: { label: string; value: SiteTheme['buttonStyle'] }[
   { label: 'Rounded', value: 'rounded' },
   { label: 'Pill', value: 'pill' },
 ]
+export const SHARPENING_OPTIONS: { label: string; value: SiteTheme['sharpeningLevel'] }[] = [
+  { label: 'None', value: 'none' },
+  { label: 'Subtle', value: 'subtle' },
+  { label: 'Moderate', value: 'moderate' },
+  { label: 'Strong', value: 'strong' },
+]
 
 export const COLOR_FIELDS: { key: keyof Pick<SiteTheme, 'colorBg' | 'colorBgAccent' | 'colorHeading' | 'colorBody' | 'colorDetail' | 'colorBtnBg'>; label: string }[] = [
   { key: 'colorBg', label: 'Background color' },
@@ -174,6 +180,15 @@ export function DesignSections({
       <AccordionRow label="Buttons" isOpen={open === 'buttons'} onToggle={() => setOpen(open === 'buttons' ? null : 'buttons')}>
         <FieldLabel>Button shape</FieldLabel>
         <Select value={theme.buttonStyle} onChange={(v) => set('buttonStyle', v as SiteTheme['buttonStyle'])} options={BUTTON_OPTIONS} />
+      </AccordionRow>
+
+      <AccordionRow label="Photo Sharpening" isOpen={open === 'sharpening'} onToggle={() => setOpen(open === 'sharpening' ? null : 'sharpening')}>
+        <FieldLabel>Sharpening level</FieldLabel>
+        <Select value={theme.sharpeningLevel} onChange={(v) => set('sharpeningLevel', v as SiteTheme['sharpeningLevel'])} options={SHARPENING_OPTIONS} />
+        <p style={{ color: '#6b6a6a', fontSize: 11, marginTop: 8 }}>
+          Applies to new uploads only, on the web-display copies shown in your galleries and portfolio. The full-resolution
+          original a client downloads is never altered.
+        </p>
       </AccordionRow>
     </>
   )

--- a/app/gallery-editor/[id]/GalleryEditorClient.tsx
+++ b/app/gallery-editor/[id]/GalleryEditorClient.tsx
@@ -18,6 +18,7 @@ type Props = {
   initialIsPasswordProtected: boolean
   initialPasswordSet: boolean
   initialAllowDownload: boolean
+  initialSeoIndexable: boolean
   initialClientName: string
   initialClientEmail: string
   initialExpiresAt: string
@@ -39,6 +40,7 @@ export function GalleryEditorClient({
   initialIsPasswordProtected,
   initialPasswordSet,
   initialAllowDownload,
+  initialSeoIndexable,
   initialClientName,
   initialClientEmail,
   initialExpiresAt,
@@ -57,6 +59,7 @@ export function GalleryEditorClient({
   const [featured, setFeatured] = useState(initialFeatured)
   const [isPasswordProtected, setIsPasswordProtected] = useState(initialIsPasswordProtected)
   const [allowDownload, setAllowDownload] = useState(initialAllowDownload)
+  const [seoIndexable, setSeoIndexable] = useState(initialSeoIndexable)
   const [clientName, setClientName] = useState(initialClientName)
   const [clientEmail, setClientEmail] = useState(initialClientEmail)
   const [expiresAt, setExpiresAt] = useState(initialExpiresAt)
@@ -376,6 +379,7 @@ export function GalleryEditorClient({
           tapedStyle,
           isPasswordProtected,
           allowDownload,
+          seoIndexable,
           // Only send a password value when the admin typed a new one.
           // When isPasswordProtected is true and the field is blank, we omit `password`
           // entirely so the server keeps the existing bcrypt hash unchanged.
@@ -427,7 +431,7 @@ export function GalleryEditorClient({
     autoSaveTimer.current = setTimeout(() => { void save() }, 2500)
     return () => { if (autoSaveTimer.current) clearTimeout(autoSaveTimer.current) }
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [hasChanges, title, slug, category, status, featured, tapedStyle, isPasswordProtected, allowDownload, galleryPassword, coverId, photos, clientName, clientEmail, expiresAt])
+  }, [hasChanges, title, slug, category, status, featured, tapedStyle, isPasswordProtected, allowDownload, seoIndexable, galleryPassword, coverId, photos, clientName, clientEmail, expiresAt])
 
   // Warn before closing/navigating away with unsaved changes
   useEffect(() => {
@@ -458,7 +462,7 @@ export function GalleryEditorClient({
     window.addEventListener('keydown', handler)
     return () => window.removeEventListener('keydown', handler)
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [saving, selectMode, title, slug, category, status, featured, tapedStyle, isPasswordProtected, allowDownload, galleryPassword, coverId, photos])
+  }, [saving, selectMode, title, slug, category, status, featured, tapedStyle, isPasswordProtected, allowDownload, seoIndexable, galleryPassword, coverId, photos])
 
   return (
     <div style={{ display: 'flex', flexDirection: 'column', height: '100vh', background: '#141414', overflow: 'hidden' }}>
@@ -1035,6 +1039,20 @@ export function GalleryEditorClient({
                     <div>
                       <div style={{ fontSize: '0.82rem', fontWeight: 500, color: '#d6d1ce', fontFamily: ui }}>Allow downloads</div>
                       <div style={{ fontSize: '0.7rem', color: '#4b4b4b', fontFamily: ui, marginTop: '0.1rem' }}>Clients can download photos</div>
+                    </div>
+                  </label>
+
+                  <label style={{ display: 'flex', alignItems: 'center', gap: '0.6rem', cursor: 'pointer' }}>
+                    <input
+                      type="checkbox"
+                      checked={seoIndexable}
+                      onChange={e => setField(setSeoIndexable)(e.target.checked)}
+                      style={{ width: 15, height: 15, accentColor: '#1db954', cursor: 'pointer', flexShrink: 0, marginTop: '0.15rem' }}
+                      aria-label="Search engine visible"
+                    />
+                    <div>
+                      <div style={{ fontSize: '0.82rem', fontWeight: 500, color: '#d6d1ce', fontFamily: ui }}>Search engine visible</div>
+                      <div style={{ fontSize: '0.7rem', color: '#4b4b4b', fontFamily: ui, marginTop: '0.1rem' }}>Uncheck to hide this gallery from Google search results (still viewable via direct link)</div>
                     </div>
                   </label>
                 </div>

--- a/app/gallery-editor/[id]/page.tsx
+++ b/app/gallery-editor/[id]/page.tsx
@@ -99,6 +99,7 @@ export default async function GalleryEditorPage({ params }: Props) {
       initialIsPasswordProtected={gallery.isPasswordProtected ?? false}
       initialPasswordSet={typeof gallery.password === 'string' && gallery.password.length > 0}
       initialAllowDownload={gallery.allowDownload ?? false}
+      initialSeoIndexable={gallery.seoIndexable ?? true}
       initialClientName={gallery.clientName ?? ''}
       initialClientEmail={gallery.clientEmail ?? ''}
       initialExpiresAt={typeof gallery.expiresAt === 'string' ? gallery.expiresAt.slice(0, 10) : ''}

--- a/app/lib/r2Stream.ts
+++ b/app/lib/r2Stream.ts
@@ -1,0 +1,10 @@
+// Shared by the ingest-time image post-processing steps (watermark.ts,
+// sharpening.ts) that download an already-uploaded R2 object, transform it
+// with sharp, and re-upload it in place.
+export async function streamToBuffer(stream: AsyncIterable<Uint8Array>): Promise<Buffer> {
+  const chunks: Buffer[] = []
+  for await (const chunk of stream) {
+    chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk))
+  }
+  return Buffer.concat(chunks)
+}

--- a/app/lib/sharpening.ts
+++ b/app/lib/sharpening.ts
@@ -1,0 +1,84 @@
+import sharp from 'sharp'
+import { S3Client, GetObjectCommand, PutObjectCommand } from '@aws-sdk/client-s3'
+import { getSiteDesign } from './siteDesign'
+import { streamToBuffer } from './r2Stream'
+
+// Sharpening Level (TYN-325): sharpens a newly-uploaded photo's
+// thumbnail/card/hero preview sizes - the ones actually rendered on public
+// gallery/portfolio pages - overwriting them in place at the same R2 key.
+// The full original (served by app/api/photos/[id]/download/route.ts for
+// client downloads) is never touched, matching the watermark step's scope
+// (app/lib/watermark.ts). New uploads only - existing photos are unaffected.
+//
+// This is a sitewide default rather than per-gallery: a Photo's preview sizes
+// are generated once at ingest and shared across every gallery that later
+// references it (Gallery.photos is a many-to-many join, not an ownership
+// relationship), so there is no single "collection" to scope sharpening to at
+// upload time.
+//
+// Called as a best-effort post-process step after payload.create(), before
+// the watermark step (so the watermark itself is never re-sharpened) in
+// app/api/photos/ingest/route.ts. Any failure here is logged and swallowed:
+// the Photo record already exists and should not be rolled back just because
+// this step had a problem.
+
+type SizeSlot = { filename?: string | null; mimeType?: string | null } | null | undefined
+
+const SHARPEN_SIGMA: Record<'subtle' | 'moderate' | 'strong', number> = {
+  subtle: 0.5,
+  moderate: 1,
+  strong: 1.8,
+}
+
+async function sharpenOneSize(params: {
+  s3: S3Client
+  bucket: string
+  sigma: number
+  slot: SizeSlot
+}): Promise<void> {
+  const { s3, bucket, sigma, slot } = params
+  const key = slot?.filename
+  if (!key) return
+
+  const { Body } = await s3.send(new GetObjectCommand({ Bucket: bucket, Key: key }))
+  if (!Body) return
+  const original = await streamToBuffer(Body as AsyncIterable<Uint8Array>)
+
+  const sharpened = await sharp(original).sharpen({ sigma }).toBuffer()
+
+  await s3.send(
+    new PutObjectCommand({
+      Bucket: bucket,
+      Key: key,
+      Body: sharpened,
+      ContentType: slot?.mimeType ?? 'image/jpeg',
+    })
+  )
+}
+
+export async function applySharpeningIfEnabled(params: {
+  s3: S3Client
+  bucket: string
+  sizes: { thumbnail?: SizeSlot; card?: SizeSlot; hero?: SizeSlot } | null | undefined
+}): Promise<void> {
+  const { s3, bucket, sizes } = params
+  if (!sizes) return
+
+  const theme = await getSiteDesign()
+  if (theme.sharpeningLevel === 'none') return
+  const sigma = SHARPEN_SIGMA[theme.sharpeningLevel]
+
+  const slots: [string, SizeSlot][] = [
+    ['thumbnail', sizes.thumbnail],
+    ['card', sizes.card],
+    ['hero', sizes.hero],
+  ]
+
+  for (const [name, slot] of slots) {
+    try {
+      await sharpenOneSize({ s3, bucket, sigma, slot })
+    } catch (err) {
+      console.warn(`[sharpening] failed to sharpen "${name}" size:`, err)
+    }
+  }
+}

--- a/app/lib/siteDesign.ts
+++ b/app/lib/siteDesign.ts
@@ -40,6 +40,7 @@ export const getSiteDesign = cache(async (): Promise<SiteTheme> => {
       spacingScale: doc.spacingScale || DEFAULT_THEME.spacingScale,
       buttonStyle: doc.buttonStyle || DEFAULT_THEME.buttonStyle,
       animationsEnabled: doc.animationsEnabled ?? true,
+      sharpeningLevel: doc.sharpeningLevel || DEFAULT_THEME.sharpeningLevel,
     }
   } catch {
     return DEFAULT_THEME

--- a/app/lib/siteTheme.ts
+++ b/app/lib/siteTheme.ts
@@ -23,6 +23,7 @@ export interface SiteTheme {
   spacingScale: 'compact' | 'normal' | 'spacious'
   buttonStyle: 'sharp' | 'rounded' | 'pill'
   animationsEnabled: boolean
+  sharpeningLevel: 'none' | 'subtle' | 'moderate' | 'strong'
 }
 
 export const DEFAULT_THEME: SiteTheme = {
@@ -43,6 +44,7 @@ export const DEFAULT_THEME: SiteTheme = {
   spacingScale: 'normal',
   buttonStyle: 'sharp',
   animationsEnabled: true,
+  sharpeningLevel: 'none',
 }
 
 const FONT_ROLE_VAR: Record<'tangerine' | 'abril', string> = {

--- a/app/lib/watermark.ts
+++ b/app/lib/watermark.ts
@@ -1,6 +1,7 @@
 import sharp from 'sharp'
 import { S3Client, GetObjectCommand, PutObjectCommand } from '@aws-sdk/client-s3'
 import { getSiteDesign } from './siteDesign'
+import { streamToBuffer } from './r2Stream'
 
 // Watermarking (TYN-322): composites the site's configured watermark image
 // onto a newly-uploaded photo's thumbnail/card/hero preview sizes - the ones
@@ -15,14 +16,6 @@ import { getSiteDesign } from './siteDesign'
 // because the watermark step had a problem.
 
 type SizeSlot = { filename?: string | null; mimeType?: string | null } | null | undefined
-
-async function streamToBuffer(stream: AsyncIterable<Uint8Array>): Promise<Buffer> {
-  const chunks: Buffer[] = []
-  for await (const chunk of stream) {
-    chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk))
-  }
-  return Buffer.concat(chunks)
-}
 
 async function watermarkOneSize(params: {
   s3: S3Client

--- a/collections/Galleries.ts
+++ b/collections/Galleries.ts
@@ -292,6 +292,16 @@ export const Galleries: CollectionConfig = {
       admin: { hidden: true },
     },
     {
+      // Search engine visibility (TYN-325) - independent of `status`. A
+      // published gallery can still be excluded from search-engine indexing;
+      // it stays reachable via direct link, it just won't appear in results.
+      name: 'seoIndexable',
+      type: 'checkbox',
+      label: 'Search Engine Visible',
+      defaultValue: true,
+      admin: { hidden: true },
+    },
+    {
       // Managed via the gallery editor's Settings tab / "Send Gallery Email"
       // modal (TYN-324), not the raw Payload form.
       name: 'clientName',

--- a/globals/SiteDesign.ts
+++ b/globals/SiteDesign.ts
@@ -136,5 +136,19 @@ export const SiteDesign: GlobalConfig = {
       label: 'Enable animations',
       defaultValue: true,
     },
+    {
+      // TYN-325: applied to new uploads' web display sizes only, never the
+      // full original (see app/lib/sharpening.ts).
+      name: 'sharpeningLevel',
+      type: 'select',
+      label: 'Photo sharpening',
+      defaultValue: 'none',
+      options: [
+        { label: 'None', value: 'none' },
+        { label: 'Subtle', value: 'subtle' },
+        { label: 'Moderate', value: 'moderate' },
+        { label: 'Strong', value: 'strong' },
+      ],
+    },
   ],
 }

--- a/payload-types.ts
+++ b/payload-types.ts
@@ -301,6 +301,7 @@ export interface Gallery {
   isPasswordProtected?: boolean | null;
   password?: string | null;
   allowDownload?: boolean | null;
+  seoIndexable?: boolean | null;
   /**
    * Draft galleries are hidden from your public portfolio.
    */
@@ -744,6 +745,8 @@ export interface GalleriesSelect<T extends boolean = true> {
   displayOrder?: T;
   isPasswordProtected?: T;
   password?: T;
+  allowDownload?: T;
+  seoIndexable?: T;
   clientName?: T;
   clientEmail?: T;
   expiresAt?: T;
@@ -1061,6 +1064,7 @@ export interface SiteDesign {
   spacingScale?: ('compact' | 'normal' | 'spacious') | null;
   buttonStyle?: ('sharp' | 'rounded' | 'pill') | null;
   animationsEnabled?: boolean | null;
+  sharpeningLevel?: ('none' | 'subtle' | 'moderate' | 'strong') | null;
   updatedAt?: string | null;
   createdAt?: string | null;
 }
@@ -1255,6 +1259,7 @@ export interface SiteDesignSelect<T extends boolean = true> {
   spacingScale?: T;
   buttonStyle?: T;
   animationsEnabled?: T;
+  sharpeningLevel?: T;
   updatedAt?: T;
   createdAt?: T;
   globalType?: T;

--- a/scripts/migrate-db.mjs
+++ b/scripts/migrate-db.mjs
@@ -726,6 +726,25 @@ async function run() {
     `)
 
     console.log('✓ email_templates table ready')
+
+    // ------------------------------------------------------------------
+    // Migration 20260720_100000: galleries.seo_indexable + site_design
+    // sharpening_level columns (TYN-325)
+    // seo_indexable controls whether a gallery is excluded from search-engine
+    // indexing (robots noindex), independent of `status`. sharpening_level
+    // is a sitewide default applied to newly-uploaded photos' web display
+    // sizes only (see app/lib/sharpening.ts) - the full original is untouched.
+    // ------------------------------------------------------------------
+
+    await client.query(`
+      ALTER TABLE "galleries" ADD COLUMN IF NOT EXISTS "seo_indexable" boolean DEFAULT true
+    `)
+    console.log('✓ galleries.seo_indexable column ready')
+
+    await client.query(`
+      ALTER TABLE "site_design" ADD COLUMN IF NOT EXISTS "sharpening_level" varchar DEFAULT 'none'
+    `)
+    console.log('✓ site_design.sharpening_level column ready')
   } finally {
     client.release()
     await pool.end()


### PR DESCRIPTION
## Summary
TYN-325 scoped Pixieset's Settings > Preferences tab against this site's architecture. Most of the list didn't apply (filename display, default collection language, RAW support all not applicable/out of scope). Builds the two real candidates the ticket identified, per Tynnell's confirmation to proceed:

- **Search Engine Visibility** - new `Gallery.seoIndexable` checkbox (default on), managed in the gallery editor's Settings tab next to Allow Downloads. When off, `/portfolio/[slug]` emits `robots: noindex` while still returning the real title/description/OG image for social shares - a plain indexing preference, independent of `status`, not a security gate like the existing password/expiry checks.
- **Photo Sharpening** - new `SiteDesign.sharpeningLevel` (None/Subtle/Moderate/Strong), editable from a new "Photo Sharpening" accordion in `/design`. Applied as a best-effort post-process step at photo ingest (`app/lib/sharpening.ts`), mirroring the existing watermark step's shape exactly: sharpens the thumbnail/card/hero preview sizes in place via sharp, never touches the full original, new uploads only. Runs before the watermark step so the watermark graphic itself is never re-sharpened.

Sharpening is a sitewide default rather than per-collection (unlike Pixieset's framing) - a Photo's preview sizes are generated once at ingest and shared across every gallery that later references it (many-to-many join, not ownership), so there's no single collection to scope it to at upload time.

Also extracted the R2 stream-to-buffer helper (previously duplicated verbatim between watermark.ts and the new sharpening.ts) into `app/lib/r2Stream.ts`.

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] Production build clean (after running `scripts/migrate-db.mjs` to add `galleries.seo_indexable` and `site_design.sharpening_level` columns)
- [x] `npx vitest run app/lib` - 166 tests pass
- [x] Verified live in a real logged-in session: `/design`'s Photo Sharpening dropdown renders all 4 options, saving persists across a full page reload (confirmed via DB round-trip, not just client state), reset back to "None" afterward
- [x] Verified live: gallery editor's Search Engine Visible checkbox defaults to checked; unchecking + saving causes `/portfolio/[slug]` to render `<meta name="robots" content="noindex">` while the real title still displays; re-checking removes it (`index, follow`) - toggled back to its original state afterward so the shared test gallery/site defaults are unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)