### PR TITLE
fix(builder): allow galleries to be created without a cover photo (TYN-312)

### DIFF
--- a/app/builder/PortfolioTab.tsx
+++ b/app/builder/PortfolioTab.tsx
@@ -1,5 +1,6 @@
 'use client'
 import { useState, useRef, useEffect, useCallback } from 'react'
+import { extractPayloadErrorMessage } from '@/app/lib/payloadError'
 
 const ui = "Inter, system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif"
 const teal = '#0d9488'
@@ -162,7 +163,8 @@ function NewCollectionModal({ onClose, onCreated }: { onClose: () => void; onCre
           onClose()
         }
       } else {
-        setError('Could not create collection. Please try again.')
+        const body = await res.json().catch(() => null)
+        setError(extractPayloadErrorMessage(body, 'Could not create collection. Please try again.'))
         setCreating(false)
       }
     } catch { setError('Connection error.'); setCreating(false) }

--- a/app/gallery-editor/[id]/GalleryEditorClient.tsx
+++ b/app/gallery-editor/[id]/GalleryEditorClient.tsx
@@ -3,6 +3,7 @@ import { useEffect, useRef, useState, useCallback } from 'react'
 import Link from 'next/link'
 import { isUnsupportedImage, uploadPhotoToLibrary } from '@/app/lib/uploadPhoto'
 import { isValidEmail } from '@/app/lib/validation'
+import { extractPayloadErrorMessage } from '@/app/lib/payloadError'
 import type { PhotoItem, GalleryListItem } from './page'
 
 const CATEGORIES = ['weddings', 'portraits', 'families', 'couples', 'brands'] as const
@@ -151,7 +152,8 @@ export function GalleryEditorClient({
         const newId = data?.doc?.id ?? data?.id
         if (newId) window.location.href = `/gallery-editor/${newId}`
       } else {
-        setError('Could not duplicate gallery. Please try again.')
+        const body = await res.json().catch(() => null)
+        setError(extractPayloadErrorMessage(body, 'Could not duplicate gallery. Please try again.'))
       }
     } catch {
       setError('Duplicate failed. Check your connection.')
@@ -223,7 +225,8 @@ export function GalleryEditorClient({
         const id = data.doc?.id
         if (id) window.location.href = `/gallery-editor/${id}`
       } else {
-        setCreateError('Could not create gallery. Please try again.')
+        const body = await res.json().catch(() => null)
+        setCreateError(extractPayloadErrorMessage(body, 'Could not create gallery. Please try again.'))
       }
     } catch {
       setCreateError('Could not create gallery. Check your connection.')

--- a/app/lib/payloadError.ts
+++ b/app/lib/payloadError.ts
@@ -1,0 +1,30 @@
+// Payload's REST API returns validation failures as
+// { errors: [{ message, data: { errors: [{ label, message, path }] } }] } -
+// confirmed against a live POST /api/galleries response (TYN-312). The
+// top-level message is a readable summary ("The following field is invalid:
+// Category"); the nested per-field messages are more specific when several
+// fields fail at once. Used anywhere a raw Payload collection route (not one
+// of this app's own /api/* wrappers, which already return { error: string })
+// is called directly from client code, so a validation failure is never a
+// silent, unexplained "please try again."
+export function extractPayloadErrorMessage(body: unknown, fallback: string): string {
+  if (!body || typeof body !== 'object') return fallback
+  const errors = (body as { errors?: unknown }).errors
+  if (!Array.isArray(errors) || errors.length === 0) return fallback
+
+  const first = errors[0] as { message?: unknown; data?: { errors?: unknown } }
+  const fieldErrors = first.data?.errors
+  if (Array.isArray(fieldErrors) && fieldErrors.length > 0) {
+    const detail = fieldErrors
+      .map((e) => {
+        const fe = e as { label?: unknown; message?: unknown }
+        if (typeof fe.label === 'string' && typeof fe.message === 'string') return `${fe.label}: ${fe.message}`
+        return typeof fe.message === 'string' ? fe.message : null
+      })
+      .filter((s): s is string => s !== null)
+      .join(', ')
+    if (detail) return detail
+  }
+
+  return typeof first.message === 'string' ? first.message : fallback
+}

--- a/collections/Galleries.ts
+++ b/collections/Galleries.ts
@@ -167,11 +167,18 @@ export const Galleries: CollectionConfig = {
       },
     },
     {
+      // Not required (TYN-312): a brand-new gallery starts with no photos at
+      // all, so requiring a cover at creation time made "New Collection"
+      // impossible to complete. Every read site already renders a "No cover"
+      // placeholder for a missing cover (GalleryGridView, CoverPhotoCell, the
+      // public Weddings album grid, the Studio dashboard's recent-activity
+      // strip), so this was purely a schema oversight, not a UI gap. A cover
+      // gets set from the gallery editor's photo grid ("Set as cover") once
+      // photos are added, or picked manually here.
       name: 'coverPhoto',
       type: 'relationship',
       label: 'Cover Photo',
       relationTo: 'photos',
-      required: true,
       admin: {
         description:
           'The photo shown as the preview for this gallery on your portfolio page. Must be a photo already uploaded to All Photos.',

--- a/components/admin/CoverPhotoPicker.tsx
+++ b/components/admin/CoverPhotoPicker.tsx
@@ -6,8 +6,7 @@ export function CoverPhotoPicker() {
     <PhotoPickerField
       fieldPath="coverPhoto"
       label="Cover Photo"
-      hint="Required - shown on your portfolio page"
-      required
+      hint="Shown on your portfolio page. Add photos below and use Set as Cover, or pick one here."
     />
   )
 }

--- a/payload-types.ts
+++ b/payload-types.ts
@@ -276,7 +276,7 @@ export interface Gallery {
   /**
    * The photo shown as the preview for this gallery on your portfolio page. Must be a photo already uploaded to All Photos.
    */
-  coverPhoto: number | Photo;
+  coverPhoto?: (number | Photo) | null;
   /**
    * Use the button above to add multiple photos at once, or add one at a time with the row picker below. Drag the handle on the left to reorder. The order here is exactly how photos appear on the site.
    */

--- a/scripts/migrate-db.mjs
+++ b/scripts/migrate-db.mjs
@@ -745,6 +745,19 @@ async function run() {
       ALTER TABLE "site_design" ADD COLUMN IF NOT EXISTS "sharpening_level" varchar DEFAULT 'none'
     `)
     console.log('✓ site_design.sharpening_level column ready')
+
+    // ------------------------------------------------------------------
+    // Migration 20260721_100000: drop NOT NULL on galleries.cover_photo_id
+    // (TYN-312). A brand-new gallery has no photos yet, so requiring a cover
+    // at creation time made "New Collection" fail every time - every read
+    // site already renders a "No cover" placeholder for a missing cover, so
+    // this was a schema oversight, not a UI gap.
+    // ------------------------------------------------------------------
+
+    await client.query(`
+      ALTER TABLE "galleries" ALTER COLUMN "cover_photo_id" DROP NOT NULL
+    `)
+    console.log('✓ galleries.cover_photo_id now nullable')
   } finally {
     client.release()
     await pool.end()


### PR DESCRIPTION
## Summary
Creating a new collection from Studio's "New Collection" button (either modal - `PortfolioTab.tsx` or `GalleryEditorClient.tsx`) has always failed with a generic error, 100% of the time, with no workaround. Root cause confirmed via a live REST call: `Gallery.coverPhoto` was a required relationship field, but a brand-new gallery has no photos yet, so the create request (which never sends `coverPhoto`) always failed Payload's schema validation.

- Made `coverPhoto` optional (`collections/Galleries.ts`, DB migration to drop the `NOT NULL` constraint on `galleries.cover_photo_id`, `payload-types.ts` hand-patch). Every read site already renders a "No cover" placeholder for a missing cover - `GalleryGridView`, `CoverPhotoCell`, the public Weddings album grid, `PortfolioTab`'s own SVG placeholder, the Studio dashboard's recent-activity strip - so this was a schema oversight, not a UI gap that needed building. A cover gets set from the gallery editor's photo grid ("Set as cover") once photos are added, or picked manually.
- `duplicateGallery` (in `GalleryEditorClient.tsx`) hit the exact same 400 for the same reason - also fixed by the schema change.
- Fixed the ticket's second, compounding issue: all three call sites that POST to `/api/galleries` directly (both New Collection modals, plus duplicate) only ever showed a hardcoded generic error string, never Payload's real validation message. New `app/lib/payloadError.ts` parses Payload's actual REST error shape (confirmed against a live response: `{errors:[{message, data:{errors:[{label, message, path}]}}]}`) and falls back to the generic message only if parsing fails - so any future validation error is self-explanatory instead of a black box.
- Updated `CoverPhotoPicker.tsx`'s hint text to match the new optional status.

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] Production build clean (after running `scripts/migrate-db.mjs`)
- [x] `npx vitest run app/lib` - 166 tests pass
- [x] Verified live in a real logged-in session: created a new collection from Studio's "New Collection" modal with just a title - `201 Created`, redirected into the gallery editor showing "No cover photo set" / "0 photos" / "Add photos first" (correctly disabled), no crash anywhere it's rendered
- [x] Verified `duplicateGallery` on an existing gallery (with photos and a cover) - previously would have 400'd for the same reason, now `201 Created`
- [x] Test galleries deleted afterward

🤖 Generated with [Claude Code](https://claude.com/claude-code)