### PR TITLE
feat(site): wire SiteConfig global into the public site (TYN-326)

### DIFF
--- a/app/(site)/about/page.tsx
+++ b/app/(site)/about/page.tsx
@@ -8,6 +8,7 @@ import { getPayload } from 'payload'
 import config from '@payload-config'
 import type { Photo } from '@/payload-types'
 import JsonLd from '@/app/components/JsonLd/JsonLd'
+import { getSiteConfig } from '@/app/lib/siteConfig'
 import styles from './page.module.css'
 
 // About content rarely changes - revalidate every 2 minutes
@@ -50,7 +51,7 @@ const DEFAULT_VALUES: AboutValue[] = [
 ]
 
 export default async function AboutPage() {
-  const about = await getAboutData()
+  const [about, siteConfig] = await Promise.all([getAboutData(), getSiteConfig()])
 
   const headshotPhoto = typeof about?.headshot === 'object' && about.headshot !== null
     ? about.headshot as Photo
@@ -69,10 +70,10 @@ export default async function AboutPage() {
     name: 'Tynnell Hollins',
     jobTitle: 'Photographer',
     url: 'https://tynnellhollinsphotography.com/about',
-    sameAs: ['https://instagram.com/tynnellhollinsphotography'],
+    sameAs: [siteConfig.instagramUrl].filter(Boolean),
     worksFor: {
       '@type': 'LocalBusiness',
-      name: 'Tynnell Hollins Photography',
+      name: siteConfig.title,
       url: 'https://tynnellhollinsphotography.com',
     },
     knowsAbout: ['Wedding Photography', 'Portrait Photography', 'Family Photography', 'Engagement Photography', 'Maternity Photography'],

--- a/app/(site)/blog/[slug]/page.tsx
+++ b/app/(site)/blog/[slug]/page.tsx
@@ -9,6 +9,7 @@ import config from '@payload-config'
 import type { Photo } from '@/payload-types'
 import JsonLd from '@/app/components/JsonLd/JsonLd'
 import { blogBlocksConfig } from '@/app/blog-editor/blog-blocks.config'
+import { getSiteConfig } from '@/app/lib/siteConfig'
 import styles from './page.module.css'
 
 // Post content rarely changes once published - revalidate every 2 minutes for fresh edits
@@ -60,7 +61,7 @@ export default async function BlogPostPage({ params }: Props) {
   const { slug } = await params
   const payload = await getPayload({ config })
 
-  const [{ docs }, { docs: relatedDocs }] = await Promise.all([
+  const [{ docs }, { docs: relatedDocs }, siteConfig] = await Promise.all([
     payload.find({
       collection: 'posts',
       where: { and: [{ slug: { equals: slug } }, { status: { equals: 'published' } }] },
@@ -79,6 +80,7 @@ export default async function BlogPostPage({ params }: Props) {
       depth: 1,
       limit: 3,
     }),
+    getSiteConfig(),
   ])
 
   const post = docs[0]
@@ -114,7 +116,7 @@ export default async function BlogPostPage({ params }: Props) {
     },
     publisher: {
       '@type': 'Organization',
-      name: 'Tynnell Hollins Photography',
+      name: siteConfig.title,
       url: 'https://tynnellhollinsphotography.com',
     },
     mainEntityOfPage: {

--- a/app/(site)/blog/page.tsx
+++ b/app/(site)/blog/page.tsx
@@ -9,8 +9,10 @@ import styles from './page.module.css'
 
 export const revalidate = 3600
 
+// Plain title - the (site) layout's dynamic template appends " | {business
+// name}" automatically (TYN-326), so this never needs its own config fetch.
 export const metadata: Metadata = {
-  title: 'Blog | Tynnell Hollins Photography',
+  title: 'Blog',
   description: 'Photography tips, session guides, and stories from behind the lens by Tynnell Hollins.',
 }
 

--- a/app/(site)/contact/ContactForm.tsx
+++ b/app/(site)/contact/ContactForm.tsx
@@ -61,12 +61,14 @@ const EMPTY_FORM: FormFields = {
   howHeard: '',
 }
 
-// minDate/maxDate are optional (TYN-332) so this component can be embedded
+// contactEmail is optional (TYN-326) so the builder's embedded ContactFormBlock
+// (which doesn't have Site Settings data threaded through it) still falls back
+// to the constants.ts value. minDate/maxDate are optional (TYN-332) so this component can be embedded
 // via the builder's Contact Form block without a server-side BookingSettings
 // fetch - the date input simply won't proactively restrict the calendar
 // widget in that case, but /api/contact still enforces the real lead-time/
 // booking-window rules server-side on submit regardless.
-export default function ContactForm({ minDate, maxDate }: { minDate?: string; maxDate?: string }) {
+export default function ContactForm({ minDate, maxDate, contactEmail = CONTACT_EMAIL }: { minDate?: string; maxDate?: string; contactEmail?: string }) {
   const [fields, setFields] = useState<FormFields>(EMPTY_FORM)
   const [status, setStatus] = useState<FormStatus>('idle')
   const [errorMessage, setErrorMessage] = useState<ReactNode>('')
@@ -124,8 +126,8 @@ export default function ContactForm({ minDate, maxDate }: { minDate?: string; ma
           message = (
             <>
               Something went wrong. Please try again or reach out directly at{' '}
-              <a href={`mailto:${CONTACT_EMAIL}`} style={{ color: 'inherit', textDecoration: 'underline', textUnderlineOffset: '3px' }}>
-                {CONTACT_EMAIL}
+              <a href={`mailto:${contactEmail}`} style={{ color: 'inherit', textDecoration: 'underline', textUnderlineOffset: '3px' }}>
+                {contactEmail}
               </a>
               .
             </>

--- a/app/(site)/contact/page.tsx
+++ b/app/(site)/contact/page.tsx
@@ -4,7 +4,7 @@ import config from '@payload-config'
 import ContactForm from './ContactForm'
 import JsonLd from '@/app/components/JsonLd/JsonLd'
 import styles from './page.module.css'
-import { CONTACT_EMAIL } from '@/app/lib/constants'
+import { getSiteConfig, instagramHandle } from '@/app/lib/siteConfig'
 import { getActiveOoo, type BlockedRange } from '@/app/lib/availability'
 import { MIN_LEAD_TIME_HOURS, MAX_BOOKING_MONTHS } from '@/app/lib/validation'
 
@@ -49,6 +49,8 @@ export default async function ContactPage() {
   let minDate: string
   let maxDate: string
 
+  const siteConfig = await getSiteConfig()
+
   try {
     const payload = await getPayload({ config })
     const [availability, bookingSettings] = await Promise.all([
@@ -83,13 +85,13 @@ export default async function ContactPage() {
   const contactPageSchema = {
     '@context': 'https://schema.org',
     '@type': 'ContactPage',
-    name: 'Contact Tynnell Hollins Photography',
+    name: `Contact ${siteConfig.title}`,
     description: 'Book a session or send an inquiry. Weddings, engagements, portraits, and more.',
     url: 'https://tynnellhollinsphotography.com/contact',
     mainEntity: {
       '@type': 'LocalBusiness',
-      name: 'Tynnell Hollins Photography',
-      email: CONTACT_EMAIL,
+      name: siteConfig.title,
+      email: siteConfig.email,
       url: 'https://tynnellhollinsphotography.com',
     },
   }
@@ -113,19 +115,23 @@ export default async function ContactPage() {
             Fill out the form and I&apos;ll be in touch within 48 hours.
           </p>
           <div className={styles.directContact}>
-            <a href={`mailto:${CONTACT_EMAIL}`} className={styles.contactLink}>
-              {CONTACT_EMAIL}
+            <a href={`mailto:${siteConfig.email}`} className={styles.contactLink}>
+              {siteConfig.email}
             </a>
-            <span className={styles.contactDivider}>·</span>
-            <a href="https://instagram.com/tynnellhollinsphotography" className={styles.contactLink} target="_blank" rel="noopener noreferrer">
-              @tynnellhollinsphotography
-            </a>
+            {siteConfig.instagramUrl && (
+              <>
+                <span className={styles.contactDivider}>·</span>
+                <a href={siteConfig.instagramUrl} className={styles.contactLink} target="_blank" rel="noopener noreferrer">
+                  {instagramHandle(siteConfig.instagramUrl)}
+                </a>
+              </>
+            )}
           </div>
         </div>
 
         {/* Right - form */}
         <div className={styles.formColumn}>
-          <ContactForm minDate={minDate} maxDate={maxDate} />
+          <ContactForm minDate={minDate} maxDate={maxDate} contactEmail={siteConfig.email} />
         </div>
 
       </div>

--- a/app/(site)/layout.tsx
+++ b/app/(site)/layout.tsx
@@ -6,6 +6,7 @@ import Navbar from '../components/Navbar/Navbar'
 import Footer from '../components/Footer/Footer'
 import { getBuilderNavLinks } from '@/app/lib/nav'
 import { getSiteDesign, themeToCssVars } from '@/app/lib/siteDesign'
+import { getSiteConfig } from '@/app/lib/siteConfig'
 import { DesignPreviewBridge } from '../components/DesignPreviewBridge'
 import { Analytics } from '@vercel/analytics/next'
 import { SpeedInsights } from '@vercel/speed-insights/next'
@@ -46,20 +47,20 @@ const abrialFatface = Abril_Fatface({
 // only allows one or the other per layout. getSiteDesign() is wrapped in
 // React's cache(), so this and the layout body's own call share one DB read.
 export async function generateMetadata(): Promise<Metadata> {
-  const theme = await getSiteDesign()
+  const [theme, siteConfig] = await Promise.all([getSiteDesign(), getSiteConfig()])
   return {
     metadataBase: new URL('https://tynnellhollinsphotography.com'),
     title: {
-      default: 'Tynnell Hollins Photography',
-      template: '%s | Tynnell Hollins Photography',
+      default: siteConfig.title,
+      template: `%s | ${siteConfig.title}`,
     },
     description:
       'Albuquerque, New Mexico wedding and portrait photographer. Tynnell Hollins captures authentic, timeless moments for couples, families, and engagements.',
     openGraph: {
       type: 'website',
-      siteName: 'Tynnell Hollins Photography',
+      siteName: siteConfig.title,
       locale: 'en_US',
-      images: [{ url: '/og-image.jpg', width: 1200, height: 630, alt: 'Tynnell Hollins Photography' }],
+      images: [{ url: '/og-image.jpg', width: 1200, height: 630, alt: siteConfig.title }],
     },
     twitter: {
       card: 'summary_large_image',

--- a/app/(site)/opengraph-image.tsx
+++ b/app/(site)/opengraph-image.tsx
@@ -1,5 +1,12 @@
 import { ImageResponse } from 'next/og'
 
+// Deliberately NOT wired to SiteConfig (TYN-326): this is a decorative
+// fallback OG image, not text metadata. The name is hand-split across two
+// visual lines below ("Tynnell Hollins" / "Photography") - an arbitrary
+// business name from Site Settings would need its own word-wrap/split logic
+// to render correctly, and reading the DB here would also mean dropping the
+// edge runtime (Payload's Postgres adapter doesn't run on it). If the
+// business name changes, update the two strings below by hand.
 export const runtime = 'edge'
 export const alt = 'Tynnell Hollins Photography'
 export const size = { width: 1200, height: 630 }

--- a/app/(site)/page.tsx
+++ b/app/(site)/page.tsx
@@ -5,7 +5,7 @@ import type { Data } from '@measured/puck'
 import config from '@payload-config'
 import { config as puckConfig } from '@/app/builder/puck.config'
 import JsonLd from '@/app/components/JsonLd/JsonLd'
-import { CONTACT_EMAIL } from '@/app/lib/constants'
+import { getSiteConfig } from '@/app/lib/siteConfig'
 import Hero from '@/app/components/Hero/Hero'
 import PortfolioTeaser from '@/app/components/PortfolioTeaser/PortfolioTeaser'
 import AboutPreview from '@/app/components/AboutPreview/AboutPreview'
@@ -37,12 +37,13 @@ export default async function Home() {
     return <Render config={puckConfig} data={data} />
   }
 
-  const [heroData, { docs: featuredPhotos }, { docs: testimonials }, aboutData] =
+  const [heroData, { docs: featuredPhotos }, { docs: testimonials }, aboutData, siteConfig] =
     await Promise.all([
       payload.findGlobal({ slug: 'hero-slides', depth: 1 }),
       payload.find({ collection: 'photos', where: { featured: { equals: true } }, sort: 'displayOrder', depth: 0, limit: 6 }),
       payload.find({ collection: 'testimonials', where: { featured: { equals: true } }, sort: 'displayOrder', depth: 0, limit: 20 }),
       payload.findGlobal({ slug: 'about-page', depth: 1 }),
+      getSiteConfig(),
     ])
 
   type RawSlide = { image: import('@/payload-types').Photo | string | number; caption?: string | null }
@@ -83,7 +84,7 @@ export default async function Home() {
 
   // Fall back to the static hero image if no slides have been configured in the admin yet.
   const fallbackSlide: HeroSlide[] = [
-    { id: 'revamp-bg', imageUrl: '/hero-background.jpg', alt: 'Tynnell Hollins Photography' },
+    { id: 'revamp-bg', imageUrl: '/hero-background.jpg', alt: siteConfig.title },
   ]
 
   // Preload the actual first hero image (admin slide or fallback) for LCP.
@@ -94,11 +95,11 @@ export default async function Home() {
   const localBusinessSchema = {
     '@context': 'https://schema.org',
     '@type': 'LocalBusiness',
-    name: 'Tynnell Hollins Photography',
+    name: siteConfig.title,
     description:
       'Tynnell Hollins is a wedding and portrait photographer capturing authentic moments for couples and families.',
     url: 'https://tynnellhollinsphotography.com',
-    email: CONTACT_EMAIL,
+    email: siteConfig.email,
     image: 'https://tynnellhollinsphotography.com/og-image.jpg',
     address: {
       '@type': 'PostalAddress',
@@ -111,8 +112,8 @@ export default async function Home() {
       { '@type': 'State', name: 'New Mexico' },
     ],
     sameAs: [
-      'https://instagram.com/tynnellhollinsphotography',
-    ],
+      siteConfig.instagramUrl,
+    ].filter(Boolean),
     founder: {
       '@type': 'Person',
       name: 'Tynnell Hollins',
@@ -123,7 +124,7 @@ export default async function Home() {
   return (
     <main>
       <JsonLd data={localBusinessSchema} />
-      <Hero slides={slides.length ? slides : fallbackSlide} />
+      <Hero slides={slides.length ? slides : fallbackSlide} defaultTagline={siteConfig.tagline} />
       <PortfolioTeaser photos={photos} />
       <AboutPreview about={about} />
       <Testimonials testimonials={testimonialItems} />

--- a/app/(site)/portfolio/[slug]/page.tsx
+++ b/app/(site)/portfolio/[slug]/page.tsx
@@ -12,6 +12,7 @@ import { GalleryViewer, type LightboxPhoto } from './GalleryViewer'
 import { GalleryPasswordGate } from './GalleryPasswordGate'
 import { GalleryExpiredNotice } from './GalleryExpiredNotice'
 import { isGalleryExpired } from '@/app/lib/galleryExpiry'
+import { getSiteConfig } from '@/app/lib/siteConfig'
 import { DownloadAllButtonLoader as DownloadAllButton } from './DownloadButtonLoader'
 import styles from './page.module.css'
 
@@ -68,10 +69,11 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
     ? gallery.coverPhoto as Photo
     : null
   const ogImageUrl = cover?.sizes?.hero?.url ?? cover?.url ?? null
+  const siteConfig = await getSiteConfig()
 
   return {
     title: `${gallery.title}`,
-    description: `${gallery.title}, a ${gallery.category} session by Tynnell Hollins Photography.`,
+    description: `${gallery.title}, a ${gallery.category} session by ${siteConfig.title}.`,
     ...(ogImageUrl && {
       openGraph: {
         images: [{ url: ogImageUrl, width: 1920, height: 1080, alt: gallery.title }],
@@ -95,12 +97,15 @@ export default async function GalleryPage({ params, searchParams }: Props) {
   const backHref = from ? `/portfolio?category=${from}` : '/portfolio'
   const backText = from ? `Back to ${from.charAt(0).toUpperCase() + from.slice(1)}` : 'Back to Portfolio'
   const payload = await getPayload({ config })
-  const { docs } = await payload.find({
-    collection: 'galleries',
-    where: { slug: { equals: slug } },
-    depth: 1,
-    limit: 1,
-  })
+  const [{ docs }, siteConfig] = await Promise.all([
+    payload.find({
+      collection: 'galleries',
+      where: { slug: { equals: slug } },
+      depth: 1,
+      limit: 1,
+    }),
+    getSiteConfig(),
+  ])
   const gallery = docs[0]
 
   if (!gallery || gallery.status === 'draft') notFound()
@@ -166,7 +171,7 @@ export default async function GalleryPage({ params, searchParams }: Props) {
     '@context': 'https://schema.org',
     '@type': 'ImageGallery',
     name: gallery.title,
-    description: `${gallery.title}, a ${gallery.category} session by Tynnell Hollins Photography.`,
+    description: `${gallery.title}, a ${gallery.category} session by ${siteConfig.title}.`,
     url: pageUrl,
     author: { '@type': 'Person', name: 'Tynnell Hollins' },
     ...(coverUrl && { thumbnailUrl: coverUrl }),

--- a/app/(site)/portfolio/page.tsx
+++ b/app/(site)/portfolio/page.tsx
@@ -5,13 +5,17 @@ import { getPayload } from 'payload'
 import config from '@payload-config'
 import type { Photo } from '@/payload-types'
 import JsonLd from '@/app/components/JsonLd/JsonLd'
+import { getSiteConfig } from '@/app/lib/siteConfig'
 import styles from './portfolio-landing.module.css'
 
 export const revalidate = 120
 
-export const metadata: Metadata = {
-  title: 'Portfolio',
-  description: 'Browse portraits, family sessions, and weddings by Tynnell Hollins Photography.',
+export async function generateMetadata(): Promise<Metadata> {
+  const siteConfig = await getSiteConfig()
+  return {
+    title: 'Portfolio',
+    description: `Browse portraits, family sessions, and weddings by ${siteConfig.title}.`,
+  }
 }
 
 const CATEGORIES = [
@@ -37,6 +41,7 @@ const CATEGORIES = [
 
 export default async function PortfolioPage() {
   const payload = await getPayload({ config })
+  const siteConfig = await getSiteConfig()
 
   const coverPhotos = await Promise.all(
     CATEGORIES.map(async cat => {
@@ -69,7 +74,7 @@ export default async function PortfolioPage() {
     '@context': 'https://schema.org',
     '@type': 'CollectionPage',
     name: 'Portfolio',
-    description: 'Browse portraits, family sessions, and weddings by Tynnell Hollins Photography.',
+    description: `Browse portraits, family sessions, and weddings by ${siteConfig.title}.`,
     url: 'https://tynnellhollinsphotography.com/portfolio',
     author: { '@type': 'Person', name: 'Tynnell Hollins', url: 'https://tynnellhollinsphotography.com/about' },
   }

--- a/app/(site)/services/page.tsx
+++ b/app/(site)/services/page.tsx
@@ -3,6 +3,7 @@ import Link from 'next/link'
 import { getPayload } from 'payload'
 import config from '@payload-config'
 import JsonLd from '@/app/components/JsonLd/JsonLd'
+import { getSiteConfig } from '@/app/lib/siteConfig'
 import styles from './page.module.css'
 
 // Service packages/pricing rarely change - revalidate every 2 minutes
@@ -15,12 +16,15 @@ export const metadata: Metadata = {
 
 export default async function ServicesPage() {
   const payload = await getPayload({ config })
-  const { docs: services } = await payload.find({
-    collection: 'services',
-    sort: 'displayOrder',
-    depth: 0,
-    limit: 50,
-  })
+  const [{ docs: services }, siteConfig] = await Promise.all([
+    payload.find({
+      collection: 'services',
+      sort: 'displayOrder',
+      depth: 0,
+      limit: 50,
+    }),
+    getSiteConfig(),
+  ])
 
   const servicesSchema = services.length > 0 ? {
     '@context': 'https://schema.org',
@@ -31,7 +35,7 @@ export default async function ServicesPage() {
       url: 'https://tynnellhollinsphotography.com/services',
       provider: {
         '@type': 'LocalBusiness',
-        name: 'Tynnell Hollins Photography',
+        name: siteConfig.title,
         url: 'https://tynnellhollinsphotography.com',
       },
       ...(s.price ? {

--- a/app/(site)/testimonials/page.tsx
+++ b/app/(site)/testimonials/page.tsx
@@ -4,24 +4,30 @@ import Image from 'next/image'
 import { getPayload } from 'payload'
 import config from '@payload-config'
 import JsonLd from '@/app/components/JsonLd/JsonLd'
+import { getSiteConfig } from '@/app/lib/siteConfig'
 import styles from './page.module.css'
 import type { Photo } from '@/payload-types'
 
 export const revalidate = 120
 
+// Plain title - the (site) layout's dynamic template appends " | {business
+// name}" automatically (TYN-326), so this never needs its own config fetch.
 export const metadata: Metadata = {
-  title: 'Client Words | Tynnell Hollins Photography',
+  title: 'Client Words',
   description: 'Kind words from couples, families, and portrait clients who have worked with Tynnell Hollins Photography.',
 }
 
 export default async function TestimonialsPage() {
   const payload = await getPayload({ config })
-  const { docs: testimonials } = await payload.find({
-    collection: 'testimonials',
-    sort: 'displayOrder',
-    depth: 1,
-    limit: 200,
-  })
+  const [{ docs: testimonials }, siteConfig] = await Promise.all([
+    payload.find({
+      collection: 'testimonials',
+      sort: 'displayOrder',
+      depth: 1,
+      limit: 200,
+    }),
+    getSiteConfig(),
+  ])
 
   const reviewSchema = testimonials.length > 0 ? {
     '@context': 'https://schema.org',
@@ -32,7 +38,7 @@ export default async function TestimonialsPage() {
       reviewRating: { '@type': 'Rating', ratingValue: '5', bestRating: '5' },
       itemReviewed: {
         '@type': 'LocalBusiness',
-        name: 'Tynnell Hollins Photography',
+        name: siteConfig.title,
         url: 'https://tynnellhollinsphotography.com',
       },
     })),

--- a/app/components/Footer/Footer.tsx
+++ b/app/components/Footer/Footer.tsx
@@ -2,23 +2,23 @@ import Link from 'next/link'
 import Image from 'next/image'
 import { getPayload } from 'payload'
 import config from '@payload-config'
-import { CONTACT_EMAIL } from '@/app/lib/constants'
+import { getSiteConfig, instagramHandle } from '@/app/lib/siteConfig'
 import styles from './Footer.module.css'
-
-const INSTAGRAM_URL = 'https://instagram.com/tynnellhollinsphotography'
-const TIKTOK_URL = 'https://tiktok.com/@tynnellhollinsphotography'
 
 export default async function Footer() {
   const year = new Date().getFullYear()
 
   const payload = await getPayload({ config })
-  const { docs: stripPhotos } = await payload.find({
-    collection: 'photos',
-    where: { featured: { equals: true } },
-    sort: '-updatedAt',
-    limit: 4,
-    depth: 0,
-  })
+  const [{ docs: stripPhotos }, siteConfig] = await Promise.all([
+    payload.find({
+      collection: 'photos',
+      where: { featured: { equals: true } },
+      sort: '-updatedAt',
+      limit: 4,
+      depth: 0,
+    }),
+    getSiteConfig(),
+  ])
 
   return (
     <footer className={styles.footer}>
@@ -33,76 +33,82 @@ export default async function Footer() {
       </div>
 
       {/* Instagram strip */}
-      <div className={styles.instagram}>
-        <div className={styles.igInfo}>
-          <p className={styles.igLabel}>Follow me on Instagram</p>
-          <a
-            href={INSTAGRAM_URL}
-            target="_blank"
-            rel="noopener noreferrer"
-            className={styles.igHandle}
-            aria-label="Tynnell Hollins Photography on Instagram"
-          >
-            @tynnellhollinsphotography
-          </a>
-        </div>
-        {stripPhotos.length > 0 && (
-          <div className={styles.igPhotos} aria-hidden="true">
-            {stripPhotos.map(photo => {
-              const src = photo.sizes?.card?.url ?? photo.url
-              if (!src) return null
-              return (
-                <div key={photo.id} className={styles.igPhoto}>
-                  <Image
-                    src={src}
-                    alt=""
-                    fill
-                    sizes="120px"
-                    className={styles.igPhotoImg}
-                  />
-                </div>
-              )
-            })}
+      {siteConfig.instagramUrl && (
+        <div className={styles.instagram}>
+          <div className={styles.igInfo}>
+            <p className={styles.igLabel}>Follow me on Instagram</p>
+            <a
+              href={siteConfig.instagramUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className={styles.igHandle}
+              aria-label={`${siteConfig.title} on Instagram`}
+            >
+              {instagramHandle(siteConfig.instagramUrl)}
+            </a>
           </div>
-        )}
-      </div>
+          {stripPhotos.length > 0 && (
+            <div className={styles.igPhotos} aria-hidden="true">
+              {stripPhotos.map(photo => {
+                const src = photo.sizes?.card?.url ?? photo.url
+                if (!src) return null
+                return (
+                  <div key={photo.id} className={styles.igPhoto}>
+                    <Image
+                      src={src}
+                      alt=""
+                      fill
+                      sizes="120px"
+                      className={styles.igPhotoImg}
+                    />
+                  </div>
+                )
+              })}
+            </div>
+          )}
+        </div>
+      )}
 
       {/* Bottom bar */}
       <div className={styles.bottom}>
         <div className={styles.socials}>
+          {siteConfig.instagramUrl && (
+            <a
+              href={siteConfig.instagramUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className={styles.socialLink}
+              aria-label="Instagram"
+            >
+              <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+                <path d="M12 2.163c3.204 0 3.584.012 4.85.07 3.252.148 4.771 1.691 4.919 4.919.058 1.265.069 1.645.069 4.849 0 3.205-.012 3.584-.069 4.849-.149 3.225-1.664 4.771-4.919 4.919-1.266.058-1.644.07-4.85.07-3.204 0-3.584-.012-4.849-.07-3.26-.149-4.771-1.699-4.919-4.92-.058-1.265-.07-1.644-.07-4.849 0-3.204.013-3.583.07-4.849.149-3.227 1.664-4.771 4.919-4.919 1.266-.057 1.645-.069 4.849-.069zm0-2.163c-3.259 0-3.667.014-4.947.072-4.358.2-6.78 2.618-6.98 6.98-.059 1.281-.073 1.689-.073 4.948 0 3.259.014 3.668.072 4.948.2 4.358 2.618 6.78 6.98 6.98 1.281.058 1.689.072 4.948.072 3.259 0 3.668-.014 4.948-.072 4.354-.2 6.782-2.618 6.979-6.98.059-1.28.073-1.689.073-4.948 0-3.259-.014-3.667-.072-4.947-.196-4.354-2.617-6.78-6.979-6.98-1.281-.059-1.69-.073-4.949-.073zm0 5.838c-3.403 0-6.162 2.759-6.162 6.162s2.759 6.163 6.162 6.163 6.162-2.759 6.162-6.163c0-3.403-2.759-6.162-6.162-6.162zm0 10.162c-2.209 0-4-1.79-4-4 0-2.209 1.791-4 4-4s4 1.791 4 4c0 2.21-1.791 4-4 4zm6.406-11.845c-.796 0-1.441.645-1.441 1.44s.645 1.44 1.441 1.44c.795 0 1.439-.645 1.439-1.44s-.644-1.44-1.439-1.44z" />
+              </svg>
+            </a>
+          )}
+          {siteConfig.tiktokUrl && (
+            <a
+              href={siteConfig.tiktokUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className={styles.socialLink}
+              aria-label="TikTok"
+            >
+              <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+                <path d="M19.59 6.69a4.83 4.83 0 0 1-3.77-4.25V2h-3.45v13.67a2.89 2.89 0 0 1-2.88 2.5 2.89 2.89 0 0 1-2.89-2.89 2.89 2.89 0 0 1 2.89-2.89c.28 0 .54.04.79.1V9.01a6.33 6.33 0 0 0-.79-.05 6.34 6.34 0 0 0-6.34 6.34 6.34 6.34 0 0 0 6.34 6.34 6.34 6.34 0 0 0 6.33-6.34V8.69a8.22 8.22 0 0 0 4.82 1.55V6.79a4.85 4.85 0 0 1-1.05-.1z" />
+              </svg>
+            </a>
+          )}
           <a
-            href={INSTAGRAM_URL}
-            target="_blank"
-            rel="noopener noreferrer"
+            href={`mailto:${siteConfig.email}`}
             className={styles.socialLink}
-            aria-label="Instagram"
-          >
-            <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
-              <path d="M12 2.163c3.204 0 3.584.012 4.85.07 3.252.148 4.771 1.691 4.919 4.919.058 1.265.069 1.645.069 4.849 0 3.205-.012 3.584-.069 4.849-.149 3.225-1.664 4.771-4.919 4.919-1.266.058-1.644.07-4.85.07-3.204 0-3.584-.012-4.849-.07-3.26-.149-4.771-1.699-4.919-4.92-.058-1.265-.07-1.644-.07-4.849 0-3.204.013-3.583.07-4.849.149-3.227 1.664-4.771 4.919-4.919 1.266-.057 1.645-.069 4.849-.069zm0-2.163c-3.259 0-3.667.014-4.947.072-4.358.2-6.78 2.618-6.98 6.98-.059 1.281-.073 1.689-.073 4.948 0 3.259.014 3.668.072 4.948.2 4.358 2.618 6.78 6.98 6.98 1.281.058 1.689.072 4.948.072 3.259 0 3.668-.014 4.948-.072 4.354-.2 6.782-2.618 6.979-6.98.059-1.28.073-1.689.073-4.948 0-3.259-.014-3.667-.072-4.947-.196-4.354-2.617-6.78-6.979-6.98-1.281-.059-1.69-.073-4.949-.073zm0 5.838c-3.403 0-6.162 2.759-6.162 6.162s2.759 6.163 6.162 6.163 6.162-2.759 6.162-6.163c0-3.403-2.759-6.162-6.162-6.162zm0 10.162c-2.209 0-4-1.79-4-4 0-2.209 1.791-4 4-4s4 1.791 4 4c0 2.21-1.791 4-4 4zm6.406-11.845c-.796 0-1.441.645-1.441 1.44s.645 1.44 1.441 1.44c.795 0 1.439-.645 1.439-1.44s-.644-1.44-1.439-1.44z" />
-            </svg>
-          </a>
-          <a
-            href={TIKTOK_URL}
-            target="_blank"
-            rel="noopener noreferrer"
-            className={styles.socialLink}
-            aria-label="TikTok"
-          >
-            <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
-              <path d="M19.59 6.69a4.83 4.83 0 0 1-3.77-4.25V2h-3.45v13.67a2.89 2.89 0 0 1-2.88 2.5 2.89 2.89 0 0 1-2.89-2.89 2.89 2.89 0 0 1 2.89-2.89c.28 0 .54.04.79.1V9.01a6.33 6.33 0 0 0-.79-.05 6.34 6.34 0 0 0-6.34 6.34 6.34 6.34 0 0 0 6.34 6.34 6.34 6.34 0 0 0 6.33-6.34V8.69a8.22 8.22 0 0 0 4.82 1.55V6.79a4.85 4.85 0 0 1-1.05-.1z" />
-            </svg>
-          </a>
-          <a
-            href={`mailto:${CONTACT_EMAIL}`}
-            className={styles.socialLink}
-            aria-label={`Email ${CONTACT_EMAIL}`}
+            aria-label={`Email ${siteConfig.email}`}
           >
             <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" aria-hidden="true">
               <path strokeLinecap="round" strokeLinejoin="round" d="M21.75 6.75v10.5a2.25 2.25 0 0 1-2.25 2.25h-15a2.25 2.25 0 0 1-2.25-2.25V6.75m19.5 0A2.25 2.25 0 0 0 19.5 4.5h-15a2.25 2.25 0 0 0-2.25 2.25m19.5 0v.243a2.25 2.25 0 0 1-1.07 1.916l-7.5 4.615a2.25 2.25 0 0 1-2.36 0L3.32 8.91a2.25 2.25 0 0 1-1.07-1.916V6.75" />
             </svg>
           </a>
         </div>
-        <p className={styles.copy}>&copy; {year} Tynnell Hollins Photography</p>
+        <p className={styles.copy}>&copy; {year} {siteConfig.title}</p>
       </div>
     </footer>
   )

--- a/app/lib/siteConfig.ts
+++ b/app/lib/siteConfig.ts
@@ -1,0 +1,74 @@
+import { cache } from 'react'
+import { getPayload } from 'payload'
+import config from '@payload-config'
+import { CONTACT_EMAIL } from './constants'
+
+// Server-only: reads the SiteConfig global (TYN-326) for the public site's
+// business name, tagline, contact info, and social links - previously
+// completely disconnected from the live site (every consuming page hardcoded
+// its own copy of these values). Falls back to those same hardcoded values on
+// any DB hiccup or before the global is ever saved, so a missing/broken
+// SiteConfig doc never takes down the public site - mirrors the pattern
+// already used for the Design global (app/lib/siteDesign.ts).
+//
+// EMAIL_FROM (the Resend "from" sender) and CONTACT_TO_EMAIL (the env var
+// contact-form submissions are actually delivered to) deliberately do NOT
+// read from this global - those are operational/deliverability config that
+// must match a domain verified in Resend, not editable display text. Only
+// CONTACT_EMAIL (the address shown to visitors) has a display counterpart
+// here, via the `email` field.
+export interface SiteConfigData {
+  title: string
+  tagline: string
+  email: string
+  phone: string
+  instagramUrl: string
+  facebookUrl: string
+  tiktokUrl: string
+  pinterestUrl: string
+}
+
+export const DEFAULT_SITE_CONFIG: SiteConfigData = {
+  title: 'Tynnell Hollins Photography',
+  tagline: 'Lost in the Moment, Found in Forever',
+  email: CONTACT_EMAIL,
+  phone: '',
+  instagramUrl: 'https://instagram.com/tynnellhollinsphotography',
+  facebookUrl: '',
+  tiktokUrl: 'https://tiktok.com/@tynnellhollinsphotography',
+  pinterestUrl: '',
+}
+
+// A few pages display "@handle" text alongside the Instagram link (not just
+// the link itself) - derive it from the URL so it never goes stale if the
+// URL changes but this text doesn't. Falls back to the raw URL if it can't
+// be parsed as one (e.g. blank, or someone pastes just a handle).
+export function instagramHandle(url: string): string {
+  try {
+    const path = new URL(url).pathname.replace(/^\/|\/$/g, '')
+    return path ? `@${path}` : url
+  } catch {
+    return url
+  }
+}
+
+// Wrapped in React's cache() so multiple call sites within one request (e.g.
+// a page's generateMetadata plus its own body) share one DB read.
+export const getSiteConfig = cache(async (): Promise<SiteConfigData> => {
+  try {
+    const payload = await getPayload({ config })
+    const doc = await payload.findGlobal({ slug: 'site-config' })
+    return {
+      title: doc.title || DEFAULT_SITE_CONFIG.title,
+      tagline: doc.tagline || DEFAULT_SITE_CONFIG.tagline,
+      email: doc.email || DEFAULT_SITE_CONFIG.email,
+      phone: doc.phone || DEFAULT_SITE_CONFIG.phone,
+      instagramUrl: doc.instagramUrl || DEFAULT_SITE_CONFIG.instagramUrl,
+      facebookUrl: doc.facebookUrl || DEFAULT_SITE_CONFIG.facebookUrl,
+      tiktokUrl: doc.tiktokUrl || DEFAULT_SITE_CONFIG.tiktokUrl,
+      pinterestUrl: doc.pinterestUrl || DEFAULT_SITE_CONFIG.pinterestUrl,
+    }
+  } catch {
+    return DEFAULT_SITE_CONFIG
+  }
+})

--- a/app/site-settings/SiteSettingsClient.tsx
+++ b/app/site-settings/SiteSettingsClient.tsx
@@ -309,22 +309,6 @@ export function SiteSettingsClient({
           Settings
         </h1>
 
-        <div
-          style={{
-            background: 'rgba(251,146,60,0.08)',
-            border: '1px solid rgba(251,146,60,0.25)',
-            borderRadius: 8,
-            padding: '0.85rem 1rem',
-            marginBottom: '2rem',
-            color: '#fb923c',
-            fontSize: '0.8rem',
-            lineHeight: 1.5,
-          }}
-        >
-          Not yet wired into the live site - these fields save to the database but the public site currently reads business
-          name, tagline, contact info, and social links from hardcoded values in the code instead. See TYN-326 to connect them.
-        </div>
-
         <Section title="Branding">
           <p style={{ margin: '0 0 1rem', color: '#9B9A9A', fontSize: '0.82rem', lineHeight: 1.5 }}>
             Logo and favicon are managed from the Design editor, alongside your site&apos;s colors and fonts.


### PR DESCRIPTION
## Summary
`SiteConfig` (business name, tagline, contact email, phone, social links) was completely disconnected from the live site: editing it via `/site-settings` saved to the database but had zero visible effect anywhere, since every consuming page hardcoded its own copy of these values.

- New `app/lib/siteConfig.ts` (mirrors the existing `siteDesign.ts` pattern): a cached `getSiteConfig()` with fallback defaults matching the exact values that were previously hardcoded, so nothing changes on the live site until Site Settings is actually edited.
- Wired into: `app/(site)/layout.tsx` (title template/default, OG siteName, image alt), every page's JSON-LD business name and description text that mentioned it (home, about, contact, services, testimonials, blog/[slug], portfolio, portfolio/[slug]), the homepage Hero's default tagline (previously always the hardcoded fallback despite the field existing), and Instagram/TikTok/contact-email links on the homepage, about, contact, and Footer.
- `blog/page.tsx` and `testimonials/page.tsx`'s `metadata.title` simplified to drop their own hardcoded business-name suffix, since the layout's dynamic title template already appends it.
- `ContactForm.tsx` (client component) gets `contactEmail` as a new optional prop, defaulting to the `constants.ts` value so the builder's embedded Contact Form block is unaffected.
- Removed the "Not yet wired into the live site" caveat notice from `/site-settings`.

**Deliberately NOT wired** (reasoning left in code comments):
- `EMAIL_FROM`/`CONTACT_TO_EMAIL` - operational/deliverability config, not display text; a typo in Site Settings shouldn't break outgoing email.
- `opengraph-image.tsx` - a decorative edge-runtime image with hand-drawn text split across two lines; making that dynamic needs its own word-wrap logic and dropping the edge runtime.
- `Navbar.tsx`'s 3-line text wordmark - splitting an arbitrary business name into exactly 3 balanced lines is a real design problem, not a data swap.
- Scope expanded slightly beyond the ticket's exact file list to include `Footer.tsx` (rendered sitewide, same hardcoded-business-name/social-URL bug), confirmed with the user before starting.

## Test plan
- [x] `npx tsc --noEmit` clean, `eslint` clean on all touched files
- [x] Production build clean
- [x] `npx vitest run app/lib` - 166 tests pass
- [x] Verified live: with the SiteConfig global's real (partially-blank) saved state, homepage title/tagline/JSON-LD, `/blog` and `/testimonials` titles (single suffix, not doubled), `/contact` page's email/Instagram links, and Footer all render correctly and match pre-change output exactly (fallback defaults working as intended)
- [x] Verified the actual fix: edited the homepage tagline in `/site-settings`, saved, confirmed it updated live on `/` - then reverted it back to its original blank value afterward since this runs against the shared production database

🤖 Generated with [Claude Code](https://claude.com/claude-code)