### PR TITLE
fix(builder): match hover toolbar to Pixieset's exact layout (TYN-328)

### DIFF
--- a/app/builder/SectionHoverToolbar.tsx
+++ b/app/builder/SectionHoverToolbar.tsx
@@ -2,16 +2,15 @@
 
 import { usePuck } from '@measured/puck'
 
-// TYN-328 (revised): the prior implementation split the hover toolbar across
-// two disconnected pieces (Puck's own default action bar top-right, a custom
-// Move Up/Down overlay top-left) - functionally complete but visually nothing
-// like Pixieset's actual reference, which is a single floating pill toolbar:
-// "Change Layout" + "Open Editor" buttons, then a connected icon row
-// (duplicate/delete/reorder). This rebuilds it as one unified toolbar
-// matching that reference.
+// TYN-328 (rebuilt to match the real Pixieset reference exactly, per screenshots
+// of website.pixieset.com/pages/... - not just loose inspiration): floating
+// toolbar top-RIGHT of the hovered section, "Change Layout" and "Open Editor"
+// as two SEPARATE pill buttons (not one merged pill), then a connected icon
+// pill: settings, duplicate, bookmark (save as template), share, trash, and a
+// combined up/down reorder control - six icons, in that exact order.
 //
 // Puck's default action bar is suppressed entirely (see EditorClient.tsx's
-// `actionBar: () => null`) since its Duplicate/Delete can't be relocated into
+// `actionBar: () => <></>`) since its Duplicate/Delete can't be relocated into
 // a custom layout without rebuilding them anyway. `componentOverlay` is the
 // only override that reliably identifies which block it's for
 // (componentId/componentType - `actionBar` only gets a display label), so
@@ -22,14 +21,14 @@ import { usePuck } from '@measured/puck'
 // unexported root-zone-id string.
 //
 // "Change Layout" only appears for blocks that actually have a layout picker
-// (Hero/SplitImageText/PhotoGallery per TYN-329) and, like "Open Editor",
-// just selects the block - the layout picker is the first field in each of
-// those blocks, so selecting surfaces it immediately. Not a separate
-// floating picker; an honest simplification, not a fake button.
+// (Hero/SplitImageText/PhotoGallery per TYN-329) and, like "Open Editor" and
+// the settings-gear icon, just selects the block - the layout picker is the
+// first field in each of those blocks, so selecting surfaces it immediately.
 //
-// Not included: Pixieset's "save as template" (bookmark) and "share" icons -
-// this site has no template system or section-sharing feature to back them,
-// and a button that does nothing would be worse than not having it.
+// Bookmark ("save as template") and share have no backing feature on this
+// site (no template system, no section-sharing) - included for visual parity
+// with the reference, rendered disabled with a title explaining why, rather
+// than either a fake working button or a missing icon that breaks the layout.
 export function SectionHoverToolbar({
   children,
   componentId,
@@ -100,50 +99,58 @@ export function SectionHoverToolbar({
           style={{
             position: 'absolute',
             top: 10,
-            left: 10,
+            right: 10,
             zIndex: 20,
             display: 'flex',
             gap: 8,
             pointerEvents: 'auto',
           }}
         >
-          <div style={pillStyle()}>
-            {hasLayout && (
-              <button
-                type="button"
-                style={textBtnStyle(true)}
-                onClick={(e) => {
-                  e.stopPropagation()
-                  select()
-                }}
-              >
-                Change Layout
-              </button>
-            )}
+          {hasLayout && (
             <button
               type="button"
-              style={textBtnStyle(false)}
+              style={soloBtnStyle()}
               onClick={(e) => {
                 e.stopPropagation()
                 select()
               }}
             >
-              Open Editor
+              Change Layout
             </button>
-          </div>
+          )}
+          <button
+            type="button"
+            style={soloBtnStyle()}
+            onClick={(e) => {
+              e.stopPropagation()
+              select()
+            }}
+          >
+            Open Editor
+          </button>
           <div style={pillStyle()}>
+            <IconButton title="Settings" onClick={select}>
+              <GearIcon />
+            </IconButton>
             <IconButton title="Duplicate" onClick={duplicate}>
               <CopyIcon />
+            </IconButton>
+            <IconButton title="Save as template - not available yet" disabled>
+              <BookmarkIcon />
+            </IconButton>
+            <IconButton title="Share - not available yet" disabled>
+              <ShareIcon />
             </IconButton>
             <IconButton title="Delete" onClick={remove}>
               <TrashIcon />
             </IconButton>
-            <IconButton title="Move up" disabled={index <= 0} onClick={() => move(-1)}>
-              <ArrowUpIcon />
-            </IconButton>
-            <IconButton title="Move down" disabled={index === -1 || index >= content.length - 1} onClick={() => move(1)} last>
-              <ArrowDownIcon />
-            </IconButton>
+            <ReorderButton
+              index={index}
+              length={content.length}
+              onUp={() => move(-1)}
+              onDown={() => move(1)}
+              last
+            />
           </div>
         </div>
       )}
@@ -162,18 +169,19 @@ function pillStyle(): React.CSSProperties {
   }
 }
 
-function textBtnStyle(bordered: boolean): React.CSSProperties {
+function soloBtnStyle(): React.CSSProperties {
   return {
     padding: '8px 14px',
-    background: 'transparent',
+    background: '#1a1a1a',
     color: '#e6e1de',
     fontSize: 12.5,
     fontWeight: 500,
     fontFamily: "var(--font-body, 'Roboto Mono', monospace)",
-    border: 'none',
-    borderRight: bordered ? '1px solid rgba(255,255,255,0.14)' : 'none',
+    border: '1px solid rgba(255,255,255,0.14)',
+    borderRadius: 8,
     cursor: 'pointer',
     whiteSpace: 'nowrap',
+    boxShadow: '0 4px 12px rgba(0,0,0,0.35)',
   }
 }
 
@@ -186,7 +194,7 @@ function IconButton({
 }: {
   children: React.ReactNode
   title: string
-  onClick: () => void
+  onClick?: () => void
   disabled?: boolean
   last?: boolean
 }) {
@@ -198,7 +206,7 @@ function IconButton({
       disabled={disabled}
       onClick={(e) => {
         e.stopPropagation()
-        onClick()
+        onClick?.()
       }}
       style={{
         width: 32,
@@ -207,7 +215,7 @@ function IconButton({
         alignItems: 'center',
         justifyContent: 'center',
         background: 'transparent',
-        color: disabled ? '#5a5a5a' : '#e6e1de',
+        color: disabled ? '#4a4a4a' : '#e6e1de',
         border: 'none',
         borderRight: last ? 'none' : '1px solid rgba(255,255,255,0.14)',
         cursor: disabled ? 'default' : 'pointer',
@@ -219,11 +227,106 @@ function IconButton({
   )
 }
 
+// Pixieset shows one combined up/down glyph rather than two separate arrow
+// buttons. Kept as one visual slot in the pill (matching the reference) while
+// staying two real, independently-working hit targets stacked top/bottom
+// inside it - not a fake merged control.
+function ReorderButton({
+  index,
+  length,
+  onUp,
+  onDown,
+  last,
+}: {
+  index: number
+  length: number
+  onUp: () => void
+  onDown: () => void
+  last?: boolean
+}) {
+  const canUp = index > 0
+  const canDown = index !== -1 && index < length - 1
+  return (
+    <div
+      style={{
+        position: 'relative',
+        width: 32,
+        height: 32,
+        borderRight: last ? 'none' : '1px solid rgba(255,255,255,0.14)',
+      }}
+    >
+      <span
+        style={{
+          position: 'absolute',
+          inset: 0,
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          color: '#e6e1de',
+          pointerEvents: 'none',
+        }}
+      >
+        <ReorderIcon />
+      </span>
+      <button
+        type="button"
+        title="Move up"
+        aria-label="Move up"
+        disabled={!canUp}
+        onClick={(e) => {
+          e.stopPropagation()
+          onUp()
+        }}
+        style={{ position: 'absolute', inset: '0 0 50% 0', background: 'transparent', border: 'none', cursor: canUp ? 'pointer' : 'default', padding: 0 }}
+      />
+      <button
+        type="button"
+        title="Move down"
+        aria-label="Move down"
+        disabled={!canDown}
+        onClick={(e) => {
+          e.stopPropagation()
+          onDown()
+        }}
+        style={{ position: 'absolute', inset: '50% 0 0 0', background: 'transparent', border: 'none', cursor: canDown ? 'pointer' : 'default', padding: 0 }}
+      />
+    </div>
+  )
+}
+
+function GearIcon() {
+  return (
+    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+      <circle cx="12" cy="12" r="3" />
+      <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 1 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 1 1-2.83-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 1 1 2.83-2.83l.06.06a1.65 1.65 0 0 0 1.82.33H9a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 1 1 2.83 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z" />
+    </svg>
+  )
+}
+
 function CopyIcon() {
   return (
     <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
       <rect x="9" y="9" width="13" height="13" rx="2" />
       <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1" />
+    </svg>
+  )
+}
+
+function BookmarkIcon() {
+  return (
+    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+      <path d="M19 21l-7-5-7 5V5a2 2 0 0 1 2-2h10a2 2 0 0 1 2 2z" />
+    </svg>
+  )
+}
+
+function ShareIcon() {
+  return (
+    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+      <circle cx="18" cy="5" r="3" />
+      <circle cx="6" cy="12" r="3" />
+      <circle cx="18" cy="19" r="3" />
+      <path d="M8.59 13.51l6.83 3.98M15.41 6.51L8.59 10.49" />
     </svg>
   )
 }
@@ -238,20 +341,11 @@ function TrashIcon() {
   )
 }
 
-function ArrowUpIcon() {
+function ReorderIcon() {
   return (
     <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-      <path d="M12 19V5" />
-      <path d="M5 12l7-7 7 7" />
-    </svg>
-  )
-}
-
-function ArrowDownIcon() {
-  return (
-    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-      <path d="M12 5v14" />
-      <path d="M19 12l-7 7-7-7" />
+      <path d="M8 7l4-4 4 4" />
+      <path d="M8 17l4 4 4-4" />
     </svg>
   )
 }


### PR DESCRIPTION
## Summary
The prior TYN-328 rebuild (PR #69, merged) still didn't match the real Pixieset reference: wrong position, merged buttons that should be separate, and only 4 of the 6 reference icons. Rebuilt against the actual screenshots to match exactly:

- Position: top-**right** of the hovered section (was top-left)
- "Change Layout" and "Open Editor" as two independent pill buttons (was one merged pill with a divider)
- One connected 6-icon pill: settings, duplicate, bookmark, share, delete, combined up/down reorder (was 4: duplicate, delete, and two separate arrow icons)
- Bookmark ("save as template") and share have no backing feature on this site - rendered disabled with an explanatory title, so the layout matches visually without faking functionality
- The combined reorder icon is one visual slot matching the reference, but internally two real, independently-working hit targets (top half = up, bottom half = down) - not a fake merged control

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] Production build clean
- [x] `npx vitest run app/lib` - 166 tests pass
- [x] Verified live in a real logged-in session: all 8 controls render with correct labels, toolbar's right edge sits exactly 10px inside the hovered block's own boundary (confirmed via computed layout, not just visual inspection), and the reorder control's up/down halves both actually move the block - tested moving a block up then back down and confirmed via the Outline panel's live order

🤖 Generated with [Claude Code](https://claude.com/claude-code)