### PR TITLE
Promote builder pages to real routes + gallery hover-action pill (TYN-341)

### DIFF
--- a/app/(site)/[...slug]/page.tsx
+++ b/app/(site)/[...slug]/page.tsx
@@ -2,7 +2,7 @@ import { cache } from 'react'
 import { notFound } from 'next/navigation'
 import type { Metadata } from 'next'
 import { getPayload } from 'payload'
-import { Render } from '@measured/puck/rsc'
+import { Render, resolveAllData } from '@measured/puck/rsc'
 import type { Data } from '@measured/puck'
 import payloadConfig from '@payload-config'
 import { config as puckConfig } from '@/app/builder/puck.config'
@@ -47,5 +47,6 @@ export default async function BuilderPublicPage({ params }: { params: Promise<{ 
   if (!page) notFound()
 
   const data = (page.content as Data | undefined) ?? { content: [], root: {} }
-  return <Render config={puckConfig} data={data} />
+  // See app/(site)/page.tsx's comment on resolveAllData - same reasoning here.
+  return <Render config={puckConfig} data={await resolveAllData(data, puckConfig)} />
 }

--- a/app/(site)/about/page.tsx
+++ b/app/(site)/about/page.tsx
@@ -5,7 +5,10 @@ import Image from 'next/image'
 import { RichText } from '@payloadcms/richtext-lexical/react'
 import type { SerializedEditorState } from 'lexical'
 import { getPayload } from 'payload'
+import { Render, resolveAllData } from '@measured/puck/rsc'
+import type { Data } from '@measured/puck'
 import config from '@payload-config'
+import { config as puckConfig } from '@/app/builder/puck.config'
 import type { Photo } from '@/payload-types'
 import JsonLd from '@/app/components/JsonLd/JsonLd'
 import styles from './page.module.css'
@@ -18,7 +21,26 @@ const getAboutData = cache(async () => {
   return payload.findGlobal({ slug: 'about-page', depth: 1 })
 })
 
+// A builder page can be promoted to replace this real route (same idea as
+// isHomepage's promotion of "/", generalized - see collections/Pages.ts).
+// Shared via cache() so generateMetadata and the page body see one DB read.
+const getPromotedAboutPage = cache(async () => {
+  const payload = await getPayload({ config })
+  const { docs } = await payload.find({
+    collection: 'pages',
+    where: { and: [{ promotedRoute: { equals: 'about' } }, { published: { equals: true } }] },
+    limit: 1,
+    depth: 0,
+  })
+  return docs[0] ?? null
+})
+
 export async function generateMetadata(): Promise<Metadata> {
+  const promoted = await getPromotedAboutPage()
+  if (promoted) {
+    return { title: promoted.title }
+  }
+
   const about = await getAboutData()
   const headshotPhoto = typeof about?.headshot === 'object' && about.headshot !== null
     ? about.headshot as Photo
@@ -49,7 +71,44 @@ const DEFAULT_VALUES: AboutValue[] = [
   { heading: 'Events' },
 ]
 
+// Static Person schema used for the promoted (Puck) branch - deliberately not
+// derived from the about-page global or any Puck block props (no "schema-
+// aware block" convention exists in this codebase). Kept separate from the
+// hardcoded branch's personSchema below, which additionally includes the
+// live headshot image.
+const PROMOTED_PERSON_SCHEMA = {
+  '@context': 'https://schema.org',
+  '@type': 'Person',
+  name: 'Tynnell Hollins',
+  jobTitle: 'Photographer',
+  url: 'https://tynnellhollinsphotography.com/about',
+  sameAs: ['https://instagram.com/tynnellhollinsphotography'],
+  worksFor: {
+    '@type': 'LocalBusiness',
+    name: 'Tynnell Hollins Photography',
+    url: 'https://tynnellhollinsphotography.com',
+  },
+  knowsAbout: ['Wedding Photography', 'Portrait Photography', 'Family Photography', 'Engagement Photography', 'Maternity Photography'],
+  address: {
+    '@type': 'PostalAddress',
+    addressLocality: 'Albuquerque',
+    addressRegion: 'NM',
+    addressCountry: 'US',
+  },
+}
+
 export default async function AboutPage() {
+  const promoted = await getPromotedAboutPage()
+  if (promoted) {
+    const data = (promoted.content as Data | undefined) ?? { content: [], root: {} }
+    return (
+      <>
+        <JsonLd data={PROMOTED_PERSON_SCHEMA} />
+        <Render config={puckConfig} data={await resolveAllData(data, puckConfig)} />
+      </>
+    )
+  }
+
   const about = await getAboutData()
 
   const headshotPhoto = typeof about?.headshot === 'object' && about.headshot !== null

--- a/app/(site)/page.tsx
+++ b/app/(site)/page.tsx
@@ -1,6 +1,6 @@
 import { preload } from 'react-dom'
 import { getPayload } from 'payload'
-import { Render } from '@measured/puck/rsc'
+import { Render, resolveAllData } from '@measured/puck/rsc'
 import type { Data } from '@measured/puck'
 import config from '@payload-config'
 import { config as puckConfig } from '@/app/builder/puck.config'
@@ -34,7 +34,12 @@ export default async function Home() {
   const homepage = homepageDocs[0]
   if (homepage) {
     const data = (homepage.content as Data | undefined) ?? { content: [], root: {} }
-    return <Render config={puckConfig} data={data} />
+    // resolveAllData runs each block's own resolveData hook (if it defines
+    // one) before render - Render() itself does not do this automatically.
+    // No block defines resolveData yet, so this is currently a no-op; it's
+    // the prerequisite plumbing future data-bound blocks (e.g. live
+    // Services/Testimonials) depend on.
+    return <Render config={puckConfig} data={await resolveAllData(data, puckConfig)} />
   }
 
   const [heroData, { docs: featuredPhotos }, { docs: testimonials }, aboutData] =

--- a/app/builder/SiteEditorClient.tsx
+++ b/app/builder/SiteEditorClient.tsx
@@ -3,6 +3,7 @@ import { useState, useCallback, useRef, useEffect } from 'react'
 import { PortfolioTab } from './PortfolioTab'
 import { ImagePickerField } from './ImagePickerField'
 import { DesignSections, useDesignPreviewSync } from './DesignPanelShared'
+import { getTemplateContent } from './templates'
 import type { SiteTheme } from '@/app/lib/siteTheme'
 
 // System font stack matches Pixieset's clean UI look
@@ -17,9 +18,17 @@ export interface SitePage {
   published?: boolean | null
   showInNav?: boolean | null
   isHomepage?: boolean | null
+  promotedRoute?: string | null
   displayOrder?: number | null
   updatedAt?: string | null
 }
+
+// Kept in sync by hand with collections/Pages.ts's PROMOTABLE_ROUTES - the
+// only route promotable today is About, per the phased rollout plan (see
+// app/(site)/about/page.tsx). Add an entry here when a new route is promoted.
+const PROMOTABLE_ROUTES: { route: string; label: string }[] = [
+  { route: 'about', label: 'About' },
+]
 
 // ---------------------------------------------------------------------------
 // Hardcoded site navigation - mirrors the actual public site structure
@@ -328,10 +337,11 @@ function SubPageRow({ child, isActive, onSelect }: {
 // Custom Puck page row (NOT IN MENU section)
 // ---------------------------------------------------------------------------
 
-function PuckPageRow({ page, onDelete, onToggleNav, onRefresh }: {
+function PuckPageRow({ page, onDelete, onToggleNav, onTogglePromote, onRefresh }: {
   page: SitePage
   onDelete: (id: string | number) => void
   onToggleNav: (id: string | number, current: boolean) => void
+  onTogglePromote: (id: string | number, route: string | null) => void
   onRefresh: () => void
 }) {
   const [menuOpen, setMenuOpen] = useState(false)
@@ -363,6 +373,14 @@ function PuckPageRow({ page, onDelete, onToggleNav, onRefresh }: {
       <span style={{ flex: 1, fontSize: '0.875rem', fontFamily: ui, color: '#c0bcb8', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', minWidth: 0 }}>
         {page.title ?? 'Untitled'}
       </span>
+      {page.promotedRoute && (
+        <span
+          title={`Live at /${page.promotedRoute} instead of its own URL`}
+          style={{ flexShrink: 0, fontSize: '0.62rem', fontFamily: mono, color: teal, background: 'rgba(29,180,142,0.12)', border: '1px solid rgba(29,180,142,0.3)', borderRadius: 4, padding: '0.1rem 0.35rem' }}
+        >
+          /{page.promotedRoute}
+        </span>
+      )}
       {hovered && (
         <button
           type="button"
@@ -386,6 +404,13 @@ function PuckPageRow({ page, onDelete, onToggleNav, onRefresh }: {
           {[
             { label: 'Edit in builder', action: () => { window.location.href = `/builder/${page.slug ?? ''}` } },
             { label: page.showInNav ? 'Remove from menu' : 'Add to menu', action: () => { void onToggleNav(page.id, Boolean(page.showInNav)); onRefresh(); setMenuOpen(false); setHovered(false) } },
+            ...PROMOTABLE_ROUTES.map(({ route, label }) => {
+              const isThisRoute = page.promotedRoute === route
+              return {
+                label: isThisRoute ? `Un-promote (currently /${route})` : `Replace /${route} with this page`,
+                action: () => { onTogglePromote(page.id, isThisRoute ? null : route); setMenuOpen(false); setHovered(false) },
+              }
+            }),
             { label: 'Delete', danger: true, action: () => { onDelete(page.id); setMenuOpen(false); setHovered(false) } },
           ].map(item => (
             <button
@@ -424,7 +449,18 @@ function NewPageModal({ onClose }: { onClose: () => void }) {
       const res = await fetch('/api/pages', {
         method: 'POST', credentials: 'include',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ title: title.trim(), slug, published: false, displayOrder: Date.now(), template }),
+        body: JSON.stringify({
+          title: title.trim(),
+          slug,
+          published: false,
+          displayOrder: Date.now(),
+          // `template` picks starter content client-side (getTemplateContent) -
+          // the Pages collection has no such field, so it must be resolved into
+          // `content` here rather than sent as-is (it was previously sent raw
+          // and silently dropped by Payload, leaving every new page blank
+          // regardless of the template chosen).
+          content: getTemplateContent(template),
+        }),
       })
       if (res.ok) {
         window.location.href = `/builder/${slug}`
@@ -636,6 +672,25 @@ export function SiteEditorClient({ initialPages, initialProduct = 'website', ini
     reload()
   }
 
+  // Promote this page to replace a real route (e.g. /about), or un-promote it
+  // (route: null). Payload's preventDuplicatePromotion hook (collections/Pages.ts)
+  // rejects the request if another page already claims that route - surfaced
+  // here as a plain alert since this is the only place a non-technical user can
+  // trigger that collision.
+  const togglePromote = async (id: string | number, route: string | null) => {
+    const res = await fetch(`/api/pages/${id}`, {
+      method: 'PATCH', credentials: 'include',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ promotedRoute: route }),
+    })
+    if (!res.ok) {
+      const body = await res.json().catch(() => null) as { errors?: { message?: string }[] } | null
+      alert(body?.errors?.[0]?.message ?? 'Could not update this page. Please try again.')
+      return
+    }
+    reload()
+  }
+
   const publishAll = async () => {
     setPublishing(true)
     await Promise.all(
@@ -802,7 +857,7 @@ export function SiteEditorClient({ initialPages, initialProduct = 'website', ini
                   <>
                     <p style={{ margin: '1.25rem 0 0.3rem 0.75rem', fontFamily: mono, fontSize: '0.58rem', letterSpacing: '0.12em', color: '#4a4a4a', textTransform: 'uppercase' }}>Not in Menu</p>
                     {customPages.map(p => (
-                      <PuckPageRow key={String(p.id)} page={p} onDelete={deletePage} onToggleNav={toggleNav} onRefresh={reload} />
+                      <PuckPageRow key={String(p.id)} page={p} onDelete={deletePage} onToggleNav={toggleNav} onTogglePromote={togglePromote} onRefresh={reload} />
                     ))}
                   </>
                 )}

--- a/app/builder/[slug]/EditorClient.tsx
+++ b/app/builder/[slug]/EditorClient.tsx
@@ -23,12 +23,19 @@ export function EditorClient({
   title,
   published,
   initialData,
+  promotedRoute,
 }: {
   slug: string
   title: string
   published: boolean
   initialData: Data
+  promotedRoute: string | null
 }) {
+  // When this page replaces a real route (see collections/Pages.ts), it goes
+  // live at that route, not at its own slug - "View Page" and the header path
+  // must point there, or an editor clicking "View Page" on a promoted page
+  // would land on the still-hardcoded original instead of their own edits.
+  const publicPath = promotedRoute ? `/${promotedRoute}` : `/${slug}`
   const savedJson = useRef<string>(JSON.stringify(initialData))
   const [dirty, setDirty] = useState(false)
   const [isPublished, setIsPublished] = useState(published)
@@ -127,7 +134,7 @@ export function EditorClient({
         onPublish={onPublish}
         iframe={{ enabled: false }}
         headerTitle={title}
-        headerPath={`/${slug}`}
+        headerPath={publicPath}
         overrides={{
           // Puck's own default action bar (Duplicate/Delete, top-right) is
           // suppressed entirely - SectionHoverToolbar rebuilds those actions
@@ -154,7 +161,7 @@ export function EditorClient({
                 }}
                 title={
                   isPublished
-                    ? `This page is live at /${slug}`
+                    ? `This page is live at ${publicPath}`
                     : 'Click Publish to make this page live on your site'
                 }
               >
@@ -168,11 +175,11 @@ export function EditorClient({
               </Link>
               {isPublished && (
                 <Link
-                  href={`/${slug}`}
+                  href={publicPath}
                   target="_blank"
                   rel="noopener noreferrer"
                   style={headerBtn}
-                  title={`Open the live page at /${slug}`}
+                  title={`Open the live page at ${publicPath}`}
                 >
                   View Page <span aria-hidden="true">&#8599;</span>
                 </Link>

--- a/app/builder/[slug]/EditorLoader.tsx
+++ b/app/builder/[slug]/EditorLoader.tsx
@@ -31,6 +31,6 @@ const EditorClient = dynamic(() => import('./EditorClient').then((m) => m.Editor
   loading: () => <LoadingShell />,
 })
 
-export function EditorLoader(props: { slug: string; title: string; published: boolean; initialData: Data }) {
+export function EditorLoader(props: { slug: string; title: string; published: boolean; initialData: Data; promotedRoute: string | null }) {
   return <EditorClient {...props} />
 }

--- a/app/builder/[slug]/page.tsx
+++ b/app/builder/[slug]/page.tsx
@@ -22,5 +22,13 @@ export default async function EditPage({ params }: { params: Promise<{ slug: str
 
   const data = (page.content as Data | undefined) ?? EMPTY
 
-  return <EditorLoader slug={slug} title={page.title} published={Boolean(page.published)} initialData={data} />
+  return (
+    <EditorLoader
+      slug={slug}
+      title={page.title}
+      published={Boolean(page.published)}
+      initialData={data}
+      promotedRoute={typeof page.promotedRoute === 'string' ? page.promotedRoute : null}
+    />
+  )
 }

--- a/app/builder/page.tsx
+++ b/app/builder/page.tsx
@@ -35,6 +35,7 @@ export default async function BuilderHome({
     published: p.published,
     showInNav: p.showInNav,
     isHomepage: p.isHomepage,
+    promotedRoute: p.promotedRoute,
     displayOrder: p.displayOrder,
     updatedAt: p.updatedAt,
   }))

--- a/app/gallery-editor/[id]/GalleryEditorClient.tsx
+++ b/app/gallery-editor/[id]/GalleryEditorClient.tsx
@@ -1357,48 +1357,23 @@ export function GalleryEditorClient({
                                 </div>
                               </div>
                             )}
-                            {/* Controls overlay (hidden in select mode). Rendered unconditionally
+                            {/* Consolidated hover pill (reorder/set-cover/remove) - matches
+                                SectionHoverToolbar's visual language in the page builder
+                                (app/builder/SectionHoverToolbar.tsx). Rendered unconditionally
                                 (not just on hover) so a keyboard user tabbing through can reach
-                                Remove/Set cover - opacity is the only hover-driven part. */}
+                                it - opacity is the only hover-driven part. */}
                             {!selectMode && (
-                              <div style={{ position: 'absolute', inset: 0, background: 'rgba(0,0,0,0.5)', display: 'flex', alignItems: 'center', justifyContent: 'center', gap: '0.5rem', opacity: (isHovered || isCover) ? 1 : 0, transition: 'opacity .15s', pointerEvents: (isHovered || isCover) ? 'auto' : 'none' }}>
-                                {isCover ? (
-                                  <span style={{ fontSize: '0.65rem', color: 'rgba(201,162,39,0.95)', fontWeight: 700, letterSpacing: '0.06em', textTransform: 'uppercase' }}>
-                                    <span aria-hidden="true">&#9733; </span>Cover
-                                  </span>
-                                ) : (
-                                  <button type="button" onClick={() => setCover(photo)} onFocus={() => setFocusedIdx(i)} style={{ fontSize: '0.65rem', color: '#fff', background: 'none', border: '1px solid rgba(255,255,255,0.4)', padding: '0.2rem 0.5rem', borderRadius: 3, cursor: 'pointer' }}>Set cover</button>
-                                )}
-                                <button type="button" onClick={() => removePhoto(i)} onFocus={() => setFocusedIdx(i)} aria-label="Remove" style={{ fontSize: '0.75rem', color: '#fff', background: 'rgba(0,0,0,0.5)', border: 'none', width: 22, height: 22, borderRadius: '50%', cursor: 'pointer', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>&times;</button>
-                              </div>
-                            )}
-
-                            {/* Keyboard/screen-reader equivalent of drag-to-reorder (hidden in select mode).
-                                Rendered unconditionally (not just on hover) so a keyboard user tabbing
-                                through can actually reach these - opacity is the only hover-driven part. */}
-                            {!selectMode && (
-                              <div style={{ position: 'absolute', top: '0.4rem', left: '50%', transform: 'translateX(-50%)', zIndex: 3, display: 'flex', gap: '0.25rem', opacity: isHovered ? 1 : 0, transition: 'opacity .15s' }}>
-                                <button
-                                  type="button"
-                                  onClick={() => move(i, i - 1)}
-                                  onFocus={() => setFocusedIdx(i)}
-                                  disabled={i === 0}
-                                  aria-label={`Move photo ${i + 1} earlier`}
-                                  style={{ width: 20, height: 20, borderRadius: '50%', border: 'none', background: 'rgba(0,0,0,0.6)', color: '#fff', fontSize: '0.7rem', cursor: i === 0 ? 'default' : 'pointer', opacity: i === 0 ? 0.35 : 1, display: 'flex', alignItems: 'center', justifyContent: 'center' }}
-                                >
-                                  &#8592;
-                                </button>
-                                <button
-                                  type="button"
-                                  onClick={() => move(i, i + 1)}
-                                  onFocus={() => setFocusedIdx(i)}
-                                  disabled={i === photos.length - 1}
-                                  aria-label={`Move photo ${i + 1} later`}
-                                  style={{ width: 20, height: 20, borderRadius: '50%', border: 'none', background: 'rgba(0,0,0,0.6)', color: '#fff', fontSize: '0.7rem', cursor: i === photos.length - 1 ? 'default' : 'pointer', opacity: i === photos.length - 1 ? 0.35 : 1, display: 'flex', alignItems: 'center', justifyContent: 'center' }}
-                                >
-                                  &#8594;
-                                </button>
-                              </div>
+                              <PhotoHoverPill
+                                visible={isHovered || isCover}
+                                isCover={isCover}
+                                canMoveLeft={i > 0}
+                                canMoveRight={i < photos.length - 1}
+                                onSetCover={() => setCover(photo)}
+                                onMoveLeft={() => move(i, i - 1)}
+                                onMoveRight={() => move(i, i + 1)}
+                                onRemove={() => removePhoto(i)}
+                                onFocusAny={() => setFocusedIdx(i)}
+                              />
                             )}
                           </div>
                         </div>
@@ -1454,60 +1429,23 @@ export function GalleryEditorClient({
                       {/* Position number (hidden in select mode) */}
                       {!selectMode && <span style={{ position: 'absolute', top: '0.4rem', left: '0.4rem', fontSize: '0.6rem', fontWeight: 700, background: 'rgba(0,0,0,0.65)', color: '#d6d1ce', padding: '0.15rem 0.35rem', borderRadius: 3 }}>{i + 1}</span>}
 
-                      {/* Remove button (hidden in select mode) */}
+                      {/* Consolidated hover pill (reorder/set-cover/remove) - matches
+                          SectionHoverToolbar's visual language in the page builder
+                          (app/builder/SectionHoverToolbar.tsx). Rendered unconditionally
+                          (not just on hover) so a keyboard user tabbing through can reach
+                          it - opacity is the only hover-driven part. */}
                       {!selectMode && (
-                        <button
-                          type="button"
-                          onClick={() => removePhoto(i)}
-                          onFocus={() => setFocusedIdx(i)}
-                          aria-label={`Remove photo ${i + 1}`}
-                          style={{ position: 'absolute', top: '0.4rem', right: '0.4rem', width: 24, height: 24, borderRadius: '50%', border: 'none', background: 'rgba(0,0,0,0.7)', color: '#fff', fontSize: '1rem', cursor: 'pointer', display: 'flex', alignItems: 'center', justifyContent: 'center', opacity: isHovered ? 1 : 0, transition: 'opacity .15s' }}
-                        >
-                          &times;
-                        </button>
-                      )}
-
-                      {/* Keyboard/screen-reader equivalent of drag-to-reorder (hidden in select mode).
-                          Rendered unconditionally (not just on hover) so a keyboard user tabbing
-                          through can actually reach these - opacity is the only hover-driven part. */}
-                      {!selectMode && (
-                        <div style={{ position: 'absolute', top: '0.4rem', left: '50%', transform: 'translateX(-50%)', display: 'flex', gap: '0.25rem', opacity: isHovered ? 1 : 0, transition: 'opacity .15s' }}>
-                          <button
-                            type="button"
-                            onClick={() => move(i, i - 1)}
-                            onFocus={() => setFocusedIdx(i)}
-                            disabled={i === 0}
-                            aria-label={`Move photo ${i + 1} earlier`}
-                            style={{ width: 20, height: 20, borderRadius: '50%', border: 'none', background: 'rgba(0,0,0,0.7)', color: '#fff', fontSize: '0.7rem', cursor: i === 0 ? 'default' : 'pointer', opacity: i === 0 ? 0.35 : 1, display: 'flex', alignItems: 'center', justifyContent: 'center' }}
-                          >
-                            &#8592;
-                          </button>
-                          <button
-                            type="button"
-                            onClick={() => move(i, i + 1)}
-                            onFocus={() => setFocusedIdx(i)}
-                            disabled={i === photos.length - 1}
-                            aria-label={`Move photo ${i + 1} later`}
-                            style={{ width: 20, height: 20, borderRadius: '50%', border: 'none', background: 'rgba(0,0,0,0.7)', color: '#fff', fontSize: '0.7rem', cursor: i === photos.length - 1 ? 'default' : 'pointer', opacity: i === photos.length - 1 ? 0.35 : 1, display: 'flex', alignItems: 'center', justifyContent: 'center' }}
-                          >
-                            &#8594;
-                          </button>
-                        </div>
-                      )}
-
-                      {/* Cover / set cover (hidden in select mode) */}
-                      {!selectMode && (
-                        <div style={{ position: 'absolute', bottom: 0, left: 0, right: 0, padding: '0.4rem 0.6rem', background: 'linear-gradient(transparent, rgba(0,0,0,0.75))', display: 'flex', alignItems: 'center', justifyContent: 'center', opacity: (isHovered || isCover) ? 1 : 0, transition: 'opacity .15s' }}>
-                          {isCover ? (
-                            <span style={{ fontSize: '0.6rem', fontWeight: 700, color: 'rgba(201,162,39,0.95)', letterSpacing: '0.06em', textTransform: 'uppercase' }}>
-                              <span aria-hidden="true">&#9733; </span>Cover photo
-                            </span>
-                          ) : (
-                            <button type="button" onClick={() => setCover(photo)} style={{ fontSize: '0.62rem', color: '#d6d1ce', background: 'none', border: '1px solid rgba(214,209,206,0.4)', borderRadius: 3, padding: '0.15rem 0.4rem', cursor: 'pointer' }}>
-                              Set as cover
-                            </button>
-                          )}
-                        </div>
+                        <PhotoHoverPill
+                          visible={isHovered || isCover}
+                          isCover={isCover}
+                          canMoveLeft={i > 0}
+                          canMoveRight={i < photos.length - 1}
+                          onSetCover={() => setCover(photo)}
+                          onMoveLeft={() => move(i, i - 1)}
+                          onMoveRight={() => move(i, i + 1)}
+                          onRemove={() => removePhoto(i)}
+                          onFocusAny={() => setFocusedIdx(i)}
+                        />
                       )}
 
                       {/* Drag grip dots (hidden in select mode) */}
@@ -1564,5 +1502,176 @@ export function GalleryEditorClient({
         </div>
       </footer>
     </div>
+  )
+}
+
+// Consolidated hover-action pill for the photo grid (Tynnell asked for the
+// toolbar "on my Portfolio Galleries" too, not just builder pages) - matches
+// SectionHoverToolbar's visual language in the page builder
+// (app/builder/SectionHoverToolbar.tsx) so the two editors read as one design
+// language. Same three actions the grid already had scattered across
+// separate buttons (reorder/remove/set-cover), just restyled and grouped -
+// no new functionality or state.
+function PhotoHoverPill({
+  visible,
+  isCover,
+  canMoveLeft,
+  canMoveRight,
+  onSetCover,
+  onMoveLeft,
+  onMoveRight,
+  onRemove,
+  onFocusAny,
+}: {
+  visible: boolean
+  isCover: boolean
+  canMoveLeft: boolean
+  canMoveRight: boolean
+  onSetCover: () => void
+  onMoveLeft: () => void
+  onMoveRight: () => void
+  onRemove: () => void
+  onFocusAny: () => void
+}) {
+  return (
+    <div
+      style={{
+        position: 'absolute',
+        top: 8,
+        right: 8,
+        zIndex: 3,
+        display: 'flex',
+        background: '#1a1a1a',
+        border: '1px solid rgba(255,255,255,0.14)',
+        borderRadius: 8,
+        overflow: 'hidden',
+        boxShadow: '0 4px 12px rgba(0,0,0,0.35)',
+        opacity: visible ? 1 : 0,
+        transition: 'opacity .15s',
+        pointerEvents: visible ? 'auto' : 'none',
+      }}
+    >
+      <PillIconButton title={isCover ? 'Cover photo' : 'Set as cover'} onClick={onSetCover} onFocus={onFocusAny} active={isCover}>
+        <StarIcon filled={isCover} />
+      </PillIconButton>
+      <PillReorderButton canLeft={canMoveLeft} canRight={canMoveRight} onLeft={onMoveLeft} onRight={onMoveRight} onFocus={onFocusAny} />
+      <PillIconButton title="Remove" onClick={onRemove} onFocus={onFocusAny} last>
+        <TrashIcon />
+      </PillIconButton>
+    </div>
+  )
+}
+
+function PillIconButton({
+  children,
+  title,
+  onClick,
+  onFocus,
+  active,
+  last,
+}: {
+  children: React.ReactNode
+  title: string
+  onClick?: () => void
+  onFocus?: () => void
+  active?: boolean
+  last?: boolean
+}) {
+  return (
+    <button
+      type="button"
+      title={title}
+      aria-label={title}
+      onFocus={onFocus}
+      onClick={(e) => {
+        e.stopPropagation()
+        onClick?.()
+      }}
+      style={{
+        width: 30,
+        height: 30,
+        display: 'inline-flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        background: 'transparent',
+        color: active ? 'rgba(201,162,39,0.95)' : '#e6e1de',
+        border: 'none',
+        borderRight: last ? 'none' : '1px solid rgba(255,255,255,0.14)',
+        cursor: 'pointer',
+        padding: 0,
+      }}
+    >
+      {children}
+    </button>
+  )
+}
+
+// One combined visual slot with two independently-clickable halves (left/
+// right) - matches SectionHoverToolbar's up/down ReorderButton, just rotated
+// 90deg since these tiles reorder left-to-right in a grid, not top-to-bottom.
+function PillReorderButton({
+  canLeft,
+  canRight,
+  onLeft,
+  onRight,
+  onFocus,
+}: {
+  canLeft: boolean
+  canRight: boolean
+  onLeft: () => void
+  onRight: () => void
+  onFocus?: () => void
+}) {
+  return (
+    <div style={{ position: 'relative', width: 30, height: 30, borderRight: '1px solid rgba(255,255,255,0.14)' }}>
+      <span style={{ position: 'absolute', inset: 0, display: 'flex', alignItems: 'center', justifyContent: 'center', color: '#e6e1de', pointerEvents: 'none' }}>
+        <ReorderIcon />
+      </span>
+      <button
+        type="button"
+        title="Move earlier"
+        aria-label="Move earlier"
+        disabled={!canLeft}
+        onFocus={onFocus}
+        onClick={(e) => { e.stopPropagation(); onLeft() }}
+        style={{ position: 'absolute', inset: '0 50% 0 0', background: 'transparent', border: 'none', cursor: canLeft ? 'pointer' : 'default', padding: 0 }}
+      />
+      <button
+        type="button"
+        title="Move later"
+        aria-label="Move later"
+        disabled={!canRight}
+        onFocus={onFocus}
+        onClick={(e) => { e.stopPropagation(); onRight() }}
+        style={{ position: 'absolute', inset: '0 0 0 50%', background: 'transparent', border: 'none', cursor: canRight ? 'pointer' : 'default', padding: 0 }}
+      />
+    </div>
+  )
+}
+
+function StarIcon({ filled }: { filled: boolean }) {
+  return (
+    <svg width="14" height="14" viewBox="0 0 24 24" fill={filled ? 'currentColor' : 'none'} stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+      <polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2" />
+    </svg>
+  )
+}
+
+function TrashIcon() {
+  return (
+    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+      <path d="M3 6h18" />
+      <path d="M8 6V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2" />
+      <path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6" />
+    </svg>
+  )
+}
+
+function ReorderIcon() {
+  return (
+    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+      <path d="M7 8l-4 4 4 4" />
+      <path d="M17 8l4 4-4 4" />
+    </svg>
   )
 }

--- a/collections/Pages.ts
+++ b/collections/Pages.ts
@@ -1,4 +1,5 @@
-import type { CollectionConfig } from 'payload'
+import type { CollectionBeforeChangeHook, CollectionConfig } from 'payload'
+import { APIError } from 'payload'
 import { revalidatePath } from 'next/cache'
 
 // Builder pages (TYN-216). Each row is one page composed in the visual builder.
@@ -7,6 +8,39 @@ import { revalidatePath } from 'next/cache'
 // Placement flags (TYN-226 / TYN-227):
 // - `showInNav` adds the page to the public site menu (Navbar + mobile menu).
 // - `isHomepage` makes the page render at "/" instead of the built-in home.
+// - `promotedRoute` makes the page render at that real, hand-coded route instead
+//   of its own hardcoded body (same idea as isHomepage, generalized to more
+//   than one route so each new promotable page doesn't need its own boolean
+//   field). Deliberately a separate field from isHomepage rather than folding
+//   Home into its options - isHomepage already shipped and works, and Home's
+//   check lives in a different file (app/(site)/page.tsx) than every other
+//   promoted route would, so unifying them isn't worth the migration risk.
+const PROMOTABLE_ROUTES = ['about'] as const
+
+// Only one page may claim a given real route at a time - unlike isHomepage
+// (which has no such guard and silently first-match-wins if ever duplicated),
+// this makes a collision a clear save-time validation error instead of an
+// undefined "whichever Payload returns first" race.
+const preventDuplicatePromotion: CollectionBeforeChangeHook = async ({ data, originalDoc, req }) => {
+  const route = data.promotedRoute as string | undefined
+  if (!route) return data
+  if (originalDoc?.promotedRoute === route) return data
+  const { docs } = await req.payload.find({
+    collection: 'pages',
+    where: { promotedRoute: { equals: route } },
+    limit: 1,
+    depth: 0,
+  })
+  const conflict = docs.find((d) => d.id !== originalDoc?.id)
+  if (conflict) {
+    throw new APIError(
+      `"${conflict.title}" is already promoted to /${route}. Un-promote it first before promoting another page to the same route.`,
+      400,
+    )
+  }
+  return data
+}
+
 export const Pages: CollectionConfig = {
   slug: 'pages',
   labels: { singular: 'Site Page', plural: 'Site Pages' },
@@ -15,6 +49,7 @@ export const Pages: CollectionConfig = {
     hidden: true,
   },
   hooks: {
+    beforeChange: [preventDuplicatePromotion],
     afterChange: [
       ({ doc }) => {
         revalidatePath('/', 'layout')
@@ -36,5 +71,14 @@ export const Pages: CollectionConfig = {
     { name: 'displayOrder', type: 'number' },
     { name: 'showInNav', type: 'checkbox', defaultValue: false },
     { name: 'isHomepage', type: 'checkbox', defaultValue: false },
+    {
+      name: 'promotedRoute',
+      type: 'select',
+      label: 'Replace a real page',
+      admin: {
+        description: 'Make this page render at one of your real site routes instead of its own URL. Only one page can be promoted to a given route at a time.',
+      },
+      options: PROMOTABLE_ROUTES.map((r) => ({ label: `/${r}`, value: r })),
+    },
   ],
 }

--- a/payload-types.ts
+++ b/payload-types.ts
@@ -465,6 +465,10 @@ export interface Page {
   displayOrder?: number | null;
   showInNav?: boolean | null;
   isHomepage?: boolean | null;
+  /**
+   * Make this page render at one of your real site routes instead of its own URL. Only one page can be promoted to a given route at a time.
+   */
+  promotedRoute?: 'about' | null;
   updatedAt: string;
   createdAt: string;
 }
@@ -814,6 +818,9 @@ export interface PagesSelect<T extends boolean = true> {
   content?: T;
   published?: T;
   displayOrder?: T;
+  showInNav?: T;
+  isHomepage?: T;
+  promotedRoute?: T;
   updatedAt?: T;
   createdAt?: T;
 }

--- a/scripts/migrate-db.mjs
+++ b/scripts/migrate-db.mjs
@@ -758,6 +758,19 @@ async function run() {
       ALTER TABLE "galleries" ALTER COLUMN "cover_photo_id" DROP NOT NULL
     `)
     console.log('✓ galleries.cover_photo_id now nullable')
+
+    // ------------------------------------------------------------------
+    // Migration 20260721_200000: pages.promoted_route column
+    // Lets a builder page replace a real, hand-coded route (e.g. /about)
+    // instead of rendering at its own slug - same idea as is_homepage's
+    // promotion of "/", generalized so each new promotable route doesn't
+    // need its own boolean column. See collections/Pages.ts.
+    // ------------------------------------------------------------------
+
+    await client.query(`
+      ALTER TABLE "pages" ADD COLUMN IF NOT EXISTS "promoted_route" varchar
+    `)
+    console.log('✓ pages.promoted_route column ready')
   } finally {
     client.release()
     await pool.end()


### PR DESCRIPTION
## Summary
- Adds a `promotedRoute` field + duplicate-promotion guard to the `pages` collection, letting a Puck builder page replace a real, hand-coded route instead of rendering at its own URL. About is the first promotable route (`app/(site)/about/page.tsx`), following the same pattern Home already used for `isHomepage`.
- Adds a Promote / Un-promote control to the `/builder` Pages sidebar (row options menu), with a small `/about` badge on promoted pages, so this is usable without touching Payload's admin UI.
- Wires `resolveAllData` into both existing Puck render call sites (Home, catch-all custom pages) - prerequisite plumbing for any future data-bound block, currently a no-op since no block defines `resolveData` yet.
- Fixes `EditorClient.tsx`'s "View Page" link and header path to point at the promoted route (e.g. `/about`) instead of the builder slug when a page is promoted.
- Consolidates the gallery photo grid's scattered reorder/remove/set-cover buttons (`GalleryEditorClient.tsx`) into one hover pill matching the builder's `SectionHoverToolbar` visual language - same existing handlers, no new functionality.
- Fixes a real pre-existing bug found during verification: the "Add Page" template picker never actually applied a template's starter content (the `template` field was sent to Payload's own REST endpoint, which silently dropped it since it isn't a real field - `content` was never populated). Now resolved client-side via `getTemplateContent()` before the create request.
- DB migration: adds `pages.promoted_route` (nullable varchar), already run against the shared dev/production database.
- Hand-patches `payload-types.ts` for the new field (and fills in `showInNav`/`isHomepage` in `PagesSelect`, which had been missing).

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] Production build (`next build`) succeeds
- [x] Migration run, `pages.promoted_route` column confirmed
- [x] Created a page from the About template, confirmed real starter content now loads (previously blank)
- [x] Promoted it to `/about`, confirmed `/about` renders the Puck content with the full hover toolbar, correct page title, and Person JSON-LD
- [x] Confirmed "View Page" / header path show `/about`, not the builder slug
- [x] Attempted to promote a second page to `/about` - confirmed a clear validation error, not a silent collision
- [x] Un-promoted and confirmed `/about` regresses to the original hardcoded page exactly
- [x] Verified the gallery hover pill's reorder/set-cover/remove all work on a real gallery (unsaved changes discarded, no persisted mutation)
- [x] Cleaned up all test pages created during verification

🤖 Generated with [Claude Code](https://claude.com/claude-code)