### PR TITLE
Promote Portfolio/Portraits/Family to real block-editor pages (TYN-341 phase 2)

### DIFF
--- a/app/(site)/portfolio/family/page.tsx
+++ b/app/(site)/portfolio/family/page.tsx
@@ -1,20 +1,61 @@
+import { cache } from 'react'
 import type { Metadata } from 'next'
 import Image from 'next/image'
 import Link from 'next/link'
 import { getPayload } from 'payload'
+import { Render, resolveAllData } from '@measured/puck/rsc'
+import type { Data } from '@measured/puck'
 import config from '@payload-config'
+import { config as puckConfig } from '@/app/builder/puck.config'
 import type { Photo } from '@/payload-types'
+import JsonLd from '@/app/components/JsonLd/JsonLd'
 import CategoryPhotoGrid, { type CategoryPhoto } from '../_components/CategoryPhotoGrid'
 import styles from '../_components/CategoryPage.module.css'
 
 export const revalidate = 120
 
-export const metadata: Metadata = {
-  title: 'Family',
+// A builder page can be promoted to replace this real route - same pattern
+// as About (see collections/Pages.ts, app/(site)/about/page.tsx).
+const getPromotedPage = cache(async () => {
+  const payload = await getPayload({ config })
+  const { docs } = await payload.find({
+    collection: 'pages',
+    where: { and: [{ promotedRoute: { equals: 'portfolio/family' } }, { published: { equals: true } }] },
+    limit: 1,
+    depth: 0,
+  })
+  return docs[0] ?? null
+})
+
+const PROMOTED_SCHEMA = {
+  '@context': 'https://schema.org',
+  '@type': 'CollectionPage',
+  name: 'Family',
   description: 'Family portrait photography in Albuquerque and Seattle. Real connection, real moments, real laughter.',
+  url: 'https://tynnellhollinsphotography.com/portfolio/family',
+}
+
+export async function generateMetadata(): Promise<Metadata> {
+  const promoted = await getPromotedPage()
+  if (promoted) return { title: promoted.title }
+  return {
+    title: 'Family',
+    description: 'Family portrait photography in Albuquerque and Seattle. Real connection, real moments, real laughter.',
+  }
 }
 
 export default async function FamilyPage() {
+  const promoted = await getPromotedPage()
+  if (promoted) {
+    const data = (promoted.content as Data | undefined) ?? { content: [], root: {} }
+    return (
+      <>
+        <JsonLd data={PROMOTED_SCHEMA} />
+        <Render config={puckConfig} data={await resolveAllData(data, puckConfig)} />
+      </>
+    )
+  }
+
   const payload = await getPayload({ config })
 
   const { docs: rawPhotos } = await payload.find({

--- a/app/(site)/portfolio/page.tsx
+++ b/app/(site)/portfolio/page.tsx
@@ -1,17 +1,38 @@
+import { cache } from 'react'
 import type { Metadata } from 'next'
 import Image from 'next/image'
 import Link from 'next/link'
 import { getPayload } from 'payload'
+import { Render, resolveAllData } from '@measured/puck/rsc'
+import type { Data } from '@measured/puck'
 import config from '@payload-config'
+import { config as puckConfig } from '@/app/builder/puck.config'
 import type { Photo } from '@/payload-types'
 import JsonLd from '@/app/components/JsonLd/JsonLd'
 import styles from './portfolio-landing.module.css'
 
 export const revalidate = 120
 
-export const metadata: Metadata = {
-  title: 'Portfolio',
-  description: 'Browse portraits, family sessions, and weddings by Tynnell Hollins Photography.',
+// A builder page can be promoted to replace this real route - same pattern
+// as About (see collections/Pages.ts, app/(site)/about/page.tsx).
+const getPromotedPage = cache(async () => {
+  const payload = await getPayload({ config })
+  const { docs } = await payload.find({
+    collection: 'pages',
+    where: { and: [{ promotedRoute: { equals: 'portfolio' } }, { published: { equals: true } }] },
+    limit: 1,
+    depth: 0,
+  })
+  return docs[0] ?? null
+})
+
+export async function generateMetadata(): Promise<Metadata> {
+  const promoted = await getPromotedPage()
+  if (promoted) return { title: promoted.title }
+  return {
+    title: 'Portfolio',
+    description: 'Browse portraits, family sessions, and weddings by Tynnell Hollins Photography.',
+  }
 }
 
 const CATEGORIES = [
@@ -35,7 +56,31 @@ const CATEGORIES = [
   },
 ]
 
+// Static schema used for the promoted (Puck) branch - see about/page.tsx's
+// PROMOTED_PERSON_SCHEMA for the same reasoning (no schema-aware block
+// convention exists in this codebase, so this mirrors the hardcoded
+// branch's portfolioSchema below rather than deriving from Puck props).
+const PROMOTED_PORTFOLIO_SCHEMA = {
+  '@context': 'https://schema.org',
+  '@type': 'CollectionPage',
+  name: 'Portfolio',
+  description: 'Browse portraits, family sessions, and weddings by Tynnell Hollins Photography.',
+  url: 'https://tynnellhollinsphotography.com/portfolio',
+  author: { '@type': 'Person', name: 'Tynnell Hollins', url: 'https://tynnellhollinsphotography.com/about' },
+}
+
 export default async function PortfolioPage() {
+  const promoted = await getPromotedPage()
+  if (promoted) {
+    const data = (promoted.content as Data | undefined) ?? { content: [], root: {} }
+    return (
+      <>
+        <JsonLd data={PROMOTED_PORTFOLIO_SCHEMA} />
+        <Render config={puckConfig} data={await resolveAllData(data, puckConfig)} />
+      </>
+    )
+  }
+
   const payload = await getPayload({ config })
 
   const coverPhotos = await Promise.all(

--- a/app/(site)/portfolio/portraits/page.tsx
+++ b/app/(site)/portfolio/portraits/page.tsx
@@ -1,20 +1,61 @@
+import { cache } from 'react'
 import type { Metadata } from 'next'
 import Image from 'next/image'
 import Link from 'next/link'
 import { getPayload } from 'payload'
+import { Render, resolveAllData } from '@measured/puck/rsc'
+import type { Data } from '@measured/puck'
 import config from '@payload-config'
+import { config as puckConfig } from '@/app/builder/puck.config'
 import type { Photo } from '@/payload-types'
+import JsonLd from '@/app/components/JsonLd/JsonLd'
 import CategoryPhotoGrid, { type CategoryPhoto } from '../_components/CategoryPhotoGrid'
 import styles from '../_components/CategoryPage.module.css'
 
 export const revalidate = 120
 
-export const metadata: Metadata = {
-  title: 'Portraits',
+// A builder page can be promoted to replace this real route - same pattern
+// as About (see collections/Pages.ts, app/(site)/about/page.tsx).
+const getPromotedPage = cache(async () => {
+  const payload = await getPayload({ config })
+  const { docs } = await payload.find({
+    collection: 'pages',
+    where: { and: [{ promotedRoute: { equals: 'portfolio/portraits' } }, { published: { equals: true } }] },
+    limit: 1,
+    depth: 0,
+  })
+  return docs[0] ?? null
+})
+
+const PROMOTED_SCHEMA = {
+  '@context': 'https://schema.org',
+  '@type': 'CollectionPage',
+  name: 'Portraits',
   description: 'Intimate portrait photography in Albuquerque and Seattle. Tynnell Hollins captures the real you.',
+  url: 'https://tynnellhollinsphotography.com/portfolio/portraits',
+}
+
+export async function generateMetadata(): Promise<Metadata> {
+  const promoted = await getPromotedPage()
+  if (promoted) return { title: promoted.title }
+  return {
+    title: 'Portraits',
+    description: 'Intimate portrait photography in Albuquerque and Seattle. Tynnell Hollins captures the real you.',
+  }
 }
 
 export default async function PortraitsPage() {
+  const promoted = await getPromotedPage()
+  if (promoted) {
+    const data = (promoted.content as Data | undefined) ?? { content: [], root: {} }
+    return (
+      <>
+        <JsonLd data={PROMOTED_SCHEMA} />
+        <Render config={puckConfig} data={await resolveAllData(data, puckConfig)} />
+      </>
+    )
+  }
+
   const payload = await getPayload({ config })
 
   const { docs: rawPhotos } = await payload.find({

--- a/app/api/portfolio-photos/route.ts
+++ b/app/api/portfolio-photos/route.ts
@@ -1,0 +1,47 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { getPayload } from 'payload'
+import config from '@payload-config'
+import type { Photo } from '@/payload-types'
+
+// Public, read-only, category-scoped photo listing for the builder's
+// PortfolioGrid block (app/builder/puck.config.tsx). Deliberately NOT the
+// same as Payload's auto-generated `/api/photos` REST route - that route
+// requires auth (Photos has no public `read` access) and would return every
+// field on every photo. This route uses the local API server-side (same
+// zero-HTTP-overhead query app/(site)/portfolio/[category]/page.tsx already
+// runs) and only ever returns the handful of fields a public grid needs -
+// the same data already visible on the hardcoded category pages today, not
+// a new exposure.
+const VALID_CATEGORIES = ['weddings', 'portraits', 'families', 'couples', 'brands'] as const
+
+export async function GET(req: NextRequest) {
+  const category = req.nextUrl.searchParams.get('category')
+  if (!category || !(VALID_CATEGORIES as readonly string[]).includes(category)) {
+    return NextResponse.json({ photos: [] })
+  }
+
+  const payload = await getPayload({ config })
+  const { docs } = await payload.find({
+    collection: 'photos',
+    where: { category: { equals: category } },
+    sort: 'displayOrder',
+    depth: 0,
+    limit: 500,
+  })
+
+  const photos = docs
+    .filter((p) => p.url)
+    .map((p) => {
+      const photo = p as Photo
+      return {
+        id: String(photo.id),
+        title: photo.title,
+        alt: photo.alt ?? null,
+        caption: photo.caption ?? null,
+        imageUrl: photo.sizes?.card?.url ?? photo.url ?? null,
+        fullUrl: photo.sizes?.hero?.url ?? photo.url ?? null,
+      }
+    })
+
+  return NextResponse.json({ photos })
+}

--- a/app/builder/SiteEditorClient.tsx
+++ b/app/builder/SiteEditorClient.tsx
@@ -23,11 +23,13 @@ export interface SitePage {
   updatedAt?: string | null
 }
 
-// Kept in sync by hand with collections/Pages.ts's PROMOTABLE_ROUTES - the
-// only route promotable today is About, per the phased rollout plan (see
-// app/(site)/about/page.tsx). Add an entry here when a new route is promoted.
+// Kept in sync by hand with collections/Pages.ts's PROMOTABLE_ROUTES.
+// 'portfolio/weddings' isn't here yet - see the comment in Pages.ts on why.
 const PROMOTABLE_ROUTES: { route: string; label: string }[] = [
   { route: 'about', label: 'About' },
+  { route: 'portfolio', label: 'Portfolio' },
+  { route: 'portfolio/portraits', label: 'Portfolio - Portraits' },
+  { route: 'portfolio/family', label: 'Portfolio - Family' },
 ]
 
 // ---------------------------------------------------------------------------
@@ -404,7 +406,7 @@ function PuckPageRow({ page, onDelete, onToggleNav, onTogglePromote, onRefresh }
           {[
             { label: 'Edit in builder', action: () => { window.location.href = `/builder/${page.slug ?? ''}` } },
             { label: page.showInNav ? 'Remove from menu' : 'Add to menu', action: () => { void onToggleNav(page.id, Boolean(page.showInNav)); onRefresh(); setMenuOpen(false); setHovered(false) } },
-            ...PROMOTABLE_ROUTES.map(({ route, label }) => {
+            ...PROMOTABLE_ROUTES.map(({ route }) => {
               const isThisRoute = page.promotedRoute === route
               return {
                 label: isThisRoute ? `Un-promote (currently /${route})` : `Replace /${route} with this page`,

--- a/app/builder/puck.config.tsx
+++ b/app/builder/puck.config.tsx
@@ -15,6 +15,7 @@ import type { ReactNode } from 'react'
 import type { Config } from '@measured/puck'
 import { ImagePickerField } from './ImagePickerField'
 import { PhotoCarouselBlock } from './PhotoCarouselBlock'
+import CategoryPhotoGrid from '@/app/(site)/portfolio/_components/CategoryPhotoGrid'
 import { AccordionBlock } from './AccordionBlock'
 import { TypewriterText } from './TypewriterText'
 import ContactForm from '@/app/(site)/contact/ContactForm'
@@ -369,7 +370,7 @@ export const config: Config = {
   categories: {
     layout: { title: 'Layout', components: ['SectionHeading', 'Spacer', 'Shape', 'Line', 'SocialLinks'] },
     content: { title: 'Content', components: ['RichText', 'TypewriterHeading', 'SplitImageText', 'Services', 'Testimonials', 'Accordion', 'ContactFormBlock', 'CTA'] },
-    media: { title: 'Media', components: ['Hero', 'PhotoGallery', 'PhotoCarousel', 'ImageGrid', 'FullWidthImage', 'Video', 'Map', 'InstagramFeed', 'TikTokFeed'] },
+    media: { title: 'Media', components: ['Hero', 'PhotoGallery', 'PortfolioGrid', 'PhotoCarousel', 'ImageGrid', 'FullWidthImage', 'Video', 'Map', 'InstagramFeed', 'TikTokFeed'] },
   },
 
   components: {
@@ -969,6 +970,64 @@ export const config: Config = {
           </section>
         )
       },
+    },
+
+    // ------------------------------------------------------- PortfolioGrid
+    // Live-bound to the real photos collection by category, unlike
+    // PhotoGallery above (which is a manually-picked, static list of
+    // images baked into the page content). This is what lets /portfolio's
+    // category pages be promoted to the block editor (see TYN-341 phase 2)
+    // without losing the real, always-current photo grid - matching
+    // Pixieset's reference, where the Portfolio pages are ordinary editable
+    // canvases with a live photo grid inside, not a locked preview.
+    //
+    // resolveData (not a plain fetch inside render) because this same
+    // config runs in two environments: the interactive editor (browser)
+    // and the public page's server render (@measured/puck/rsc's
+    // resolveAllData, wired in app/(site)/page.tsx and
+    // app/(site)/[...slug]/page.tsx). It fetches the dedicated
+    // /api/portfolio-photos route rather than Payload's own /api/photos:
+    // the Photos collection has no public `read` access (confirmed - a
+    // direct request returns 403), and even if it did, that endpoint
+    // returns every field on every photo where this only needs a handful
+    // for display. /api/portfolio-photos runs the same local-API query the
+    // hardcoded category pages already use, just exposed as a small public,
+    // read-only, category-scoped JSON endpoint.
+    PortfolioGrid: {
+      label: 'Portfolio Photo Grid',
+      fields: {
+        category: {
+          type: 'select',
+          label: 'Category',
+          options: [
+            { label: 'Portraits', value: 'portraits' },
+            { label: 'Family', value: 'families' },
+            { label: 'Weddings', value: 'weddings' },
+            { label: 'Couples', value: 'couples' },
+            { label: 'Brands', value: 'brands' },
+          ],
+        },
+        ...styleFields,
+        ...responsiveFields,
+      },
+      defaultProps: { category: 'portraits', ...styleDefaults, ...responsiveDefaults },
+      resolveData: async ({ props }: any) => {
+        const category = props.category ?? 'portraits'
+        const base = typeof window === 'undefined' ? 'https://tynnellhollinsphotography.com' : ''
+        try {
+          const res = await fetch(`${base}/api/portfolio-photos?category=${category}`)
+          if (!res.ok) return { props: { resolvedPhotos: [] } }
+          const data = await res.json()
+          return { props: { resolvedPhotos: data.photos ?? [] } }
+        } catch {
+          return { props: { resolvedPhotos: [] } }
+        }
+      },
+      render: ({ resolvedPhotos, background, backgroundImage, backgroundFade, spacing, hideOnMobile, hideOnDesktop }: any) => (
+        <Section background={background} backgroundImage={backgroundImage} backgroundFade={backgroundFade} spacing={spacing} className={visClass(hideOnMobile, hideOnDesktop)}>
+          <CategoryPhotoGrid photos={resolvedPhotos ?? []} />
+        </Section>
+      ),
     },
 
     // ------------------------------------------------------- PhotoCarousel

--- a/collections/Pages.ts
+++ b/collections/Pages.ts
@@ -15,7 +15,12 @@ import { revalidatePath } from 'next/cache'
 //   Home into its options - isHomepage already shipped and works, and Home's
 //   check lives in a different file (app/(site)/page.tsx) than every other
 //   promoted route would, so unifying them isn't worth the migration risk.
-const PROMOTABLE_ROUTES = ['about'] as const
+// 'portfolio/weddings' is deliberately NOT here yet: unlike Portraits/Family,
+// that page also renders real Gallery album cards (a distinct display mode
+// from a plain photo grid) - promoting it today, before a matching "album
+// grid" block exists, would silently drop that feature. Add it once that
+// block is built.
+const PROMOTABLE_ROUTES = ['about', 'portfolio', 'portfolio/portraits', 'portfolio/family'] as const
 
 // Only one page may claim a given real route at a time - unlike isHomepage
 // (which has no such guard and silently first-match-wins if ever duplicated),

--- a/payload-types.ts
+++ b/payload-types.ts
@@ -468,7 +468,7 @@ export interface Page {
   /**
    * Make this page render at one of your real site routes instead of its own URL. Only one page can be promoted to a given route at a time.
    */
-  promotedRoute?: 'about' | null;
+  promotedRoute?: ('about' | 'portfolio' | 'portfolio/portraits' | 'portfolio/family') | null;
   updatedAt: string;
   createdAt: string;
 }


### PR DESCRIPTION
## Summary
- Extends the page-promotion mechanism (PR #74, About) to `/portfolio`, `/portfolio/portraits`, and `/portfolio/family`, following the same pattern: `promotedRoute` on a Puck page, a `preventDuplicatePromotion` guard, and a Promote/Un-promote control in `/builder`'s Pages sidebar.
- This directly addresses feedback that these pages must match Pixieset exactly: there, Portfolio and its category sub-pages are ordinary editable canvases with a live photo grid inside, not a locked read-only preview like ours were.
- New **PortfolioGrid** Puck block (`app/builder/puck.config.tsx`): a `category` select field, live-bound to the real `photos` collection via Puck's `resolveData` hook, reusing the exact same `CategoryPhotoGrid` component (lightbox, load-more) the hardcoded category pages already use - so promoting a page doesn't lose any of that UX.
- New `/api/portfolio-photos` route: `resolveData` runs in two environments (the interactive browser editor and the server render), so it can't use Payload's local API directly (Node-only) or Payload's own `/api/photos` REST endpoint (confirmed via direct request: no public `read` access, returns 403, and would expose every field anyway). This route runs the same local-API category query the hardcoded pages already use and returns only the handful of fields a public grid needs - not a new data exposure.
- `/portfolio/weddings` is deliberately **not** promotable yet - unlike Portraits/Family, it also renders real Gallery album cards (a distinct display mode), and promoting it before a matching "album grid" live block exists would silently drop that feature. Flagged in code comments as follow-up work.
- Hand-patches `payload-types.ts`'s `promotedRoute` union to include the 3 new route values (no DB migration needed - the column is already a nullable varchar).

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] Production build succeeds
- [x] Confirmed anonymously (curl, no auth) that Payload's own `/api/photos` returns 403, motivating the dedicated `/api/portfolio-photos` route
- [x] Added a PortfolioGrid block in the live editor, confirmed it renders real photos (set to a category with existing data) with the full hover toolbar
- [x] Promoted a test page to `/portfolio/portraits`, published, confirmed the real route renders the Puck content (with correct title, JSON-LD, and the category's actual empty/coming-soon state matching live data)
- [x] Confirmed a second promotion attempt to the same route is rejected with a clear validation error
- [x] Un-promoted and confirmed `/portfolio/portraits` reverts cleanly to the original hardcoded page
- [x] Regression-checked `/portfolio` and `/portfolio/family` (unpromoted) still render correctly, no console/server errors
- [x] Cleaned up all test pages created during verification

🤖 Generated with [Claude Code](https://claude.com/claude-code)