### PR TITLE
fix(builder): match Puck editor back button to Pixieset's native style (TYN-342)

### DIFF
--- a/app/builder/[slug]/EditorClient.tsx
+++ b/app/builder/[slug]/EditorClient.tsx
@@ -170,8 +170,25 @@ export function EditorClient({
               <button type="button" style={headerBtn} aria-pressed={showHelp} onClick={() => setShowHelp((v) => !v)} title="How the builder works">
                 <span aria-hidden="true">?</span> Help
               </button>
-              <Link href="/builder" style={headerBtn} onClick={guardLeave}>
-                <span aria-hidden="true">&#8592;</span> Pages
+              <Link
+                href="/builder"
+                onClick={guardLeave}
+                aria-label="Back to Pages"
+                title="Back to Pages"
+                style={{
+                  display: 'inline-flex',
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                  width: '34px',
+                  height: '34px',
+                  borderRadius: '4px',
+                  border: 'none',
+                  background: 'transparent',
+                  color: 'inherit',
+                  cursor: 'pointer',
+                }}
+              >
+                <BackArrowIcon />
               </Link>
               {isPublished && (
                 <Link
@@ -290,6 +307,15 @@ function HelpPanel({ onClose, isPublished }: { onClose: () => void; isPublished:
         </p>
       </div>
     </div>
+  )
+}
+
+function BackArrowIcon() {
+  return (
+    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+      <path d="M19 12H5" />
+      <path d="M12 19l-7-7 7-7" />
+    </svg>
   )
 }
 


### PR DESCRIPTION
## Summary
- Replaces the bordered `<- Pages>` text-pill back button in the Puck editor header with a 34x34 icon-only button, matching Pixieset's native `fb-design-mode-header__back-button` (icon-only, no border, no label) confirmed directly from Tynnell's reference markup.
- Reuses the same borderless icon-button visual language already shipped in SectionHoverToolbar (TYN-328), so the editor's back control and its hover-toolbar icons read as one design system.

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] Production build succeeds
- [x] Verified in a local production build (dev mode hits the known TYN-303 hydration hang, unrelated to this change): opened the real, promoted About page in the editor, confirmed the back button renders icon-only (34x34, transparent background, no border, arrow-left SVG, no text) and correctly navigates back to /builder on click