### PR TITLE
feat(builder): promote Services and Testimonials via live blocks (TYN-341 phase 4)

### DIFF
--- a/app/(site)/book/BookClient.tsx
+++ b/app/(site)/book/BookClient.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect, useRef } from 'react'
 import { useSearchParams } from 'next/navigation'
 import Link from 'next/link'
+import { slugifyServiceTitle } from '@/app/lib/slug'
 import styles from './page.module.css'
 
 export type BookingPackage = {
@@ -19,14 +20,10 @@ type BookingState = {
   sessionDate: string
 }
 
-function slugify(title: string): string {
-  return title.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '')
-}
-
 export default function BookClient({ packages, minDate, maxDate }: { packages: BookingPackage[]; minDate: string; maxDate: string }) {
   const searchParams = useSearchParams()
   const packageParam = searchParams.get('package')
-  const matched = packageParam ? packages.find(p => slugify(p.title) === packageParam) : null
+  const matched = packageParam ? packages.find(p => slugifyServiceTitle(p.title) === packageParam) : null
 
   const [activeId, setActiveId] = useState<string | null>(matched?.id ?? null)
   const [fields, setFields] = useState<BookingState>({ name: '', email: '', sessionDate: '' })

--- a/app/(site)/services/_components/ServicesGrid.module.css
+++ b/app/(site)/services/_components/ServicesGrid.module.css
@@ -1,0 +1,169 @@
+/* Extracted from services/page.module.css's "Service cards" + "Empty state"
+   sections, so the same card markup can be reused by the LiveServices
+   builder block (app/builder/puck.config.tsx) without duplicating styles. */
+
+.cards {
+  max-width: 900px;
+  margin: 0 auto;
+  padding: 5rem var(--padding-x) 4rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+}
+
+.card {
+  padding: 4rem 0;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.07);
+}
+
+.card:first-child {
+  border-top: 1px solid rgba(255, 255, 255, 0.07);
+}
+
+.cardBody {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.cardEyebrow {
+  font-family: var(--font-body);
+  font-size: 0.65rem;
+  font-weight: 400;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+  color: var(--color-detail);
+  margin: 0;
+}
+
+.cardTitle {
+  font-family: var(--font-heading);
+  font-size: clamp(1.75rem, 3.5vw, 2.5rem);
+  font-weight: 700;
+  color: var(--color-heading);
+  margin: 0;
+  letter-spacing: -0.02em;
+  line-height: 1.1;
+}
+
+.cardPrice {
+  font-family: var(--font-body);
+  font-size: 0.75rem;
+  font-weight: 400;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--color-detail);
+  margin: 0;
+}
+
+.cardDescription {
+  font-family: var(--font-body);
+  font-size: 0.9rem;
+  font-weight: 300;
+  line-height: 1.8;
+  color: var(--color-body);
+  margin: 0;
+  max-width: 640px;
+}
+
+.featureList {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.55rem;
+}
+
+.featureItem {
+  display: flex;
+  align-items: baseline;
+  gap: 0.75rem;
+  font-family: var(--font-body);
+  font-size: 0.8rem;
+  font-weight: 300;
+  color: var(--color-body);
+  line-height: 1.5;
+}
+
+.featureDot {
+  width: 4px;
+  height: 4px;
+  border-radius: 50%;
+  background: var(--color-detail);
+  flex-shrink: 0;
+  margin-top: 0.45em;
+  opacity: 0.5;
+}
+
+.cardActions {
+  display: flex;
+  align-items: center;
+  gap: 1.5rem;
+  flex-wrap: wrap;
+  padding-top: 0.5rem;
+}
+
+.bookBtn {
+  font-family: var(--font-body);
+  font-size: 0.68rem;
+  font-weight: 400;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  color: var(--color-btn-text);
+  background: var(--color-btn-bg);
+  padding: 0.85rem 2.25rem;
+  text-decoration: none;
+  transition: background 0.2s ease;
+  display: inline-block;
+}
+
+.bookBtn:hover {
+  background: var(--color-btn-hover);
+}
+
+.depositNote {
+  font-family: var(--font-body);
+  font-size: 0.68rem;
+  font-weight: 300;
+  letter-spacing: 0.08em;
+  color: var(--color-detail);
+  margin: 0;
+}
+
+.emptyState {
+  padding: 5rem 0;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 1.25rem;
+}
+
+.emptyEyebrow {
+  font-family: var(--font-body);
+  font-size: 0.65rem;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+  color: var(--color-detail);
+  margin: 0;
+}
+
+.emptyText {
+  font-family: var(--font-body);
+  font-size: 0.9rem;
+  font-weight: 300;
+  line-height: 1.8;
+  color: var(--color-body);
+  margin: 0;
+  max-width: 500px;
+}
+
+@media (max-width: 768px) {
+  .cards {
+    padding-top: 3.5rem;
+  }
+
+  .card {
+    padding: 2.75rem 0;
+  }
+}

--- a/app/(site)/services/_components/ServicesGrid.tsx
+++ b/app/(site)/services/_components/ServicesGrid.tsx
@@ -1,0 +1,80 @@
+import Link from 'next/link'
+import { slugifyServiceTitle } from '@/app/lib/slug'
+import styles from './ServicesGrid.module.css'
+
+export type ServiceItem = {
+  id: string | number
+  eyebrow?: string | null
+  title: string
+  price?: string | null
+  description?: string | null
+  features: string[]
+  depositAmount?: number | null
+}
+
+// Extracted from the original services/page.tsx inline markup (unchanged
+// behavior, including the empty state) so the same card grid can be reused
+// by the LiveServices builder block (app/builder/puck.config.tsx) without
+// duplicating markup.
+export default function ServicesGrid({ services }: { services: ServiceItem[] }) {
+  if (services.length === 0) {
+    return (
+      <section className={styles.cards} aria-label="Service packages">
+        <div className={styles.emptyState}>
+          <p className={styles.emptyEyebrow}>Coming Soon</p>
+          <p className={styles.emptyText}>Packages are being finalised. Reach out directly to discuss your vision.</p>
+          <Link href="/contact" className={styles.bookBtn}>Get in Touch</Link>
+        </div>
+      </section>
+    )
+  }
+
+  return (
+    <section className={styles.cards} aria-label="Service packages">
+      {services.map((service, i) => (
+        <article key={service.id} className={styles.card}>
+          <div className={styles.cardBody}>
+            {service.eyebrow && (
+              <p className={styles.cardEyebrow}>{service.eyebrow}</p>
+            )}
+            <h2 className={styles.cardTitle}>{service.title}</h2>
+
+            {service.price && (
+              <p className={styles.cardPrice}>{service.price}</p>
+            )}
+
+            {service.description && (
+              <p className={styles.cardDescription}>{service.description}</p>
+            )}
+
+            {service.features.length > 0 && (
+              <ul className={styles.featureList}>
+                {service.features.map((item, fi) => (
+                  <li key={fi} className={styles.featureItem}>
+                    <span className={styles.featureDot} aria-hidden="true" />
+                    {item}
+                  </li>
+                ))}
+              </ul>
+            )}
+
+            <div className={styles.cardActions}>
+              <Link
+                href={`/book?package=${slugifyServiceTitle(service.title)}`}
+                className={styles.bookBtn}
+                aria-label={`Book ${service.title} session`}
+              >
+                Reserve Your Date
+              </Link>
+              {service.depositAmount != null && (
+                <p className={styles.depositNote}>
+                  ${service.depositAmount.toLocaleString()} deposit to secure
+                </p>
+              )}
+            </div>
+          </div>
+        </article>
+      ))}
+    </section>
+  )
+}

--- a/app/(site)/services/page.tsx
+++ b/app/(site)/services/page.tsx
@@ -1,19 +1,42 @@
+import { cache } from 'react'
 import type { Metadata } from 'next'
 import Link from 'next/link'
 import { getPayload } from 'payload'
+import { Render, resolveAllData } from '@measured/puck/rsc'
+import type { Data } from '@measured/puck'
 import config from '@payload-config'
+import { config as puckConfig } from '@/app/builder/puck.config'
 import JsonLd from '@/app/components/JsonLd/JsonLd'
+import ServicesGrid from './_components/ServicesGrid'
 import styles from './page.module.css'
 
 // Service packages/pricing rarely change - revalidate every 2 minutes
 export const revalidate = 120
 
-export const metadata: Metadata = {
-  title: 'Services',
-  description: "Photography packages for weddings, portraits, families, couples, and brands. View pricing and what's included.",
+// A builder page can be promoted to replace this real route - same pattern
+// as About/Portfolio (see collections/Pages.ts, app/(site)/about/page.tsx).
+const getPromotedPage = cache(async () => {
+  const payload = await getPayload({ config })
+  const { docs } = await payload.find({
+    collection: 'pages',
+    where: { and: [{ promotedRoute: { equals: 'services' } }, { published: { equals: true } }] },
+    limit: 1,
+    depth: 0,
+  })
+  return docs[0] ?? null
+})
+
+export async function generateMetadata(): Promise<Metadata> {
+  const promoted = await getPromotedPage()
+  if (promoted) return { title: promoted.title }
+  return {
+    title: 'Services',
+    description: "Photography packages for weddings, portraits, families, couples, and brands. View pricing and what's included.",
+  }
 }
 
 export default async function ServicesPage() {
+  const promoted = await getPromotedPage()
   const payload = await getPayload({ config })
   const { docs: services } = await payload.find({
     collection: 'services',
@@ -45,6 +68,16 @@ export default async function ServicesPage() {
     })),
   } : null
 
+  if (promoted) {
+    const data = (promoted.content as Data | undefined) ?? { content: [], root: {} }
+    return (
+      <>
+        {servicesSchema && <JsonLd data={servicesSchema} />}
+        <Render config={puckConfig} data={await resolveAllData(data, puckConfig)} />
+      </>
+    )
+  }
+
   return (
     <main className={styles.main}>
       {servicesSchema && <JsonLd data={servicesSchema} />}
@@ -58,59 +91,17 @@ export default async function ServicesPage() {
         </div>
       </section>
 
-      {/* Service cards */}
-      <section className={styles.cards} aria-label="Service packages">
-        {services.length > 0 ? services.map((service, i) => (
-          <article key={service.id} className={`${styles.card} ${i % 2 === 1 ? styles.cardAlt : ''}`}>
-            <div className={styles.cardBody}>
-              {service.eyebrow && (
-                <p className={styles.cardEyebrow}>{service.eyebrow}</p>
-              )}
-              <h2 className={styles.cardTitle}>{service.title}</h2>
-
-              {service.price && (
-                <p className={styles.cardPrice}>{service.price}</p>
-              )}
-
-              {service.description && (
-                <p className={styles.cardDescription}>{service.description}</p>
-              )}
-
-              {service.features && service.features.length > 0 && (
-                <ul className={styles.featureList}>
-                  {service.features.map((item, fi) => (
-                    <li key={fi} className={styles.featureItem}>
-                      <span className={styles.featureDot} aria-hidden="true" />
-                      {item.feature}
-                    </li>
-                  ))}
-                </ul>
-              )}
-
-              <div className={styles.cardActions}>
-                <Link
-                  href={`/book?package=${service.title.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '')}`}
-                  className={styles.bookBtn}
-                  aria-label={`Book ${service.title} session`}
-                >
-                  Reserve Your Date
-                </Link>
-                {service.depositAmount != null && (
-                  <p className={styles.depositNote}>
-                    ${service.depositAmount.toLocaleString()} deposit to secure
-                  </p>
-                )}
-              </div>
-            </div>
-          </article>
-        )) : (
-          <div className={styles.emptyState}>
-            <p className={styles.emptyEyebrow}>Coming Soon</p>
-            <p className={styles.emptyText}>Packages are being finalised. Reach out directly to discuss your vision.</p>
-            <Link href="/contact" className={styles.bookBtn}>Get in Touch</Link>
-          </div>
-        )}
-      </section>
+      <ServicesGrid
+        services={services.map((s) => ({
+          id: s.id,
+          eyebrow: s.eyebrow ?? null,
+          title: s.title,
+          price: s.price ?? null,
+          description: s.description ?? null,
+          features: (s.features ?? []).map((f) => f.feature),
+          depositAmount: s.depositAmount ?? null,
+        }))}
+      />
 
       {/* Bottom CTA */}
       <section className={styles.cta}>

--- a/app/(site)/testimonials/_components/TestimonialsList.module.css
+++ b/app/(site)/testimonials/_components/TestimonialsList.module.css
@@ -1,0 +1,121 @@
+/* Extracted from testimonials/page.module.css's "Testimonial list" +
+   "Text block" + "Photo" + "Empty state" sections, so the same list markup
+   can be reused by the LiveTestimonials builder block
+   (app/builder/puck.config.tsx) without duplicating styles. */
+
+.list {
+  max-width: 860px;
+  margin: 0 auto;
+  padding: 0 var(--padding-x) 6rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+}
+
+.item {
+  padding: 3.5rem 0;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.07);
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+}
+
+.item:first-child {
+  border-top: 1px solid rgba(255, 255, 255, 0.07);
+}
+
+.textBlock {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.badge {
+  font-family: var(--font-body);
+  font-size: 0.65rem;
+  font-weight: 400;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+  color: var(--color-detail);
+  margin: 0;
+}
+
+.clientName {
+  font-family: var(--font-heading);
+  font-size: clamp(1.4rem, 3vw, 2rem);
+  font-weight: 600;
+  color: var(--color-heading);
+  font-style: normal;
+  letter-spacing: -0.01em;
+  line-height: 1.2;
+  display: block;
+}
+
+.quote {
+  font-family: var(--font-heading);
+  font-size: clamp(1rem, 2.2vw, 1.35rem);
+  font-weight: 400;
+  line-height: 1.65;
+  color: var(--color-body);
+  margin: 0;
+  font-style: italic;
+}
+
+.quoteOpen,
+.quoteClose {
+  font-family: var(--font-display);
+  font-size: 1.4em;
+  line-height: 0;
+  vertical-align: -0.25em;
+  color: var(--color-detail);
+  opacity: 0.6;
+}
+
+.quoteOpen {
+  margin-right: 0.1em;
+}
+
+.quoteClose {
+  margin-left: 0.1em;
+}
+
+.photoWrap {
+  width: 100%;
+  overflow: hidden;
+}
+
+.photo {
+  width: 100%;
+  height: auto;
+  display: block;
+  object-fit: cover;
+  max-height: 600px;
+}
+
+.empty {
+  font-family: var(--font-body);
+  font-size: 0.8rem;
+  font-weight: 300;
+  color: var(--color-detail);
+  text-align: center;
+  padding: 4rem 0 6rem;
+  margin: 0;
+}
+
+@media (max-width: 768px) {
+  .list {
+    padding-bottom: 4rem;
+  }
+
+  .item {
+    padding: 2.5rem 0;
+  }
+
+  .quote {
+    font-size: 1rem;
+  }
+
+  .photo {
+    max-height: 400px;
+  }
+}

--- a/app/(site)/testimonials/_components/TestimonialsList.tsx
+++ b/app/(site)/testimonials/_components/TestimonialsList.tsx
@@ -1,0 +1,65 @@
+import Image from 'next/image'
+import styles from './TestimonialsList.module.css'
+
+export type TestimonialItem = {
+  id: string | number
+  sessionType?: string | null
+  clientName: string
+  quote: string
+  photoUrl?: string | null
+  photoWidth?: number | null
+  photoHeight?: number | null
+}
+
+// Extracted from the original testimonials/page.tsx inline markup (unchanged
+// behavior, including the empty state) so the same list can be reused by the
+// LiveTestimonials builder block (app/builder/puck.config.tsx) without
+// duplicating markup.
+export default function TestimonialsList({ testimonials }: { testimonials: TestimonialItem[] }) {
+  if (testimonials.length === 0) {
+    return <p className={styles.empty}>Kind words are on their way.</p>
+  }
+
+  return (
+    <div className={styles.list}>
+      {testimonials.map((t) => (
+        <article key={t.id} className={styles.item} aria-label={`Review from ${t.clientName}`}>
+          <div className={styles.textBlock}>
+            {t.sessionType && (
+              <p className={styles.badge}>{t.sessionType} Testimonial</p>
+            )}
+            <cite className={styles.clientName}>{t.clientName}</cite>
+            <blockquote className={styles.quote}>
+              <span className={styles.quoteOpen} aria-hidden="true">&ldquo;</span>
+              {t.quote}
+              <span className={styles.quoteClose} aria-hidden="true">&rdquo;</span>
+            </blockquote>
+          </div>
+
+          {t.photoUrl && (
+            <div className={styles.photoWrap}>
+              {t.photoWidth && t.photoHeight ? (
+                <Image
+                  src={t.photoUrl}
+                  alt={`${t.clientName} session`}
+                  width={t.photoWidth}
+                  height={t.photoHeight}
+                  sizes="(max-width: 768px) 100vw, 50vw"
+                  className={styles.photo}
+                />
+              ) : (
+                // eslint-disable-next-line @next/next/no-img-element
+                <img
+                  src={t.photoUrl}
+                  alt={`${t.clientName} session`}
+                  className={styles.photo}
+                  loading="lazy"
+                />
+              )}
+            </div>
+          )}
+        </article>
+      ))}
+    </div>
+  )
+}

--- a/app/(site)/testimonials/page.tsx
+++ b/app/(site)/testimonials/page.tsx
@@ -1,20 +1,42 @@
+import { cache } from 'react'
 import type { Metadata } from 'next'
 import Link from 'next/link'
-import Image from 'next/image'
 import { getPayload } from 'payload'
+import { Render, resolveAllData } from '@measured/puck/rsc'
+import type { Data } from '@measured/puck'
 import config from '@payload-config'
+import { config as puckConfig } from '@/app/builder/puck.config'
 import JsonLd from '@/app/components/JsonLd/JsonLd'
+import TestimonialsList from './_components/TestimonialsList'
 import styles from './page.module.css'
 import type { Photo } from '@/payload-types'
 
 export const revalidate = 120
 
-export const metadata: Metadata = {
-  title: 'Client Words | Tynnell Hollins Photography',
-  description: 'Kind words from couples, families, and portrait clients who have worked with Tynnell Hollins Photography.',
+// A builder page can be promoted to replace this real route - same pattern
+// as About/Portfolio/Services (see collections/Pages.ts, app/(site)/about/page.tsx).
+const getPromotedPage = cache(async () => {
+  const payload = await getPayload({ config })
+  const { docs } = await payload.find({
+    collection: 'pages',
+    where: { and: [{ promotedRoute: { equals: 'testimonials' } }, { published: { equals: true } }] },
+    limit: 1,
+    depth: 0,
+  })
+  return docs[0] ?? null
+})
+
+export async function generateMetadata(): Promise<Metadata> {
+  const promoted = await getPromotedPage()
+  if (promoted) return { title: promoted.title }
+  return {
+    title: 'Client Words | Tynnell Hollins Photography',
+    description: 'Kind words from couples, families, and portrait clients who have worked with Tynnell Hollins Photography.',
+  }
 }
 
 export default async function TestimonialsPage() {
+  const promoted = await getPromotedPage()
   const payload = await getPayload({ config })
   const { docs: testimonials } = await payload.find({
     collection: 'testimonials',
@@ -38,6 +60,16 @@ export default async function TestimonialsPage() {
     })),
   } : null
 
+  if (promoted) {
+    const data = (promoted.content as Data | undefined) ?? { content: [], root: {} }
+    return (
+      <>
+        {reviewSchema && <JsonLd data={reviewSchema} />}
+        <Render config={puckConfig} data={await resolveAllData(data, puckConfig)} />
+      </>
+    )
+  }
+
   return (
     <main className={styles.page}>
       {reviewSchema && <JsonLd data={reviewSchema} />}
@@ -59,60 +91,20 @@ export default async function TestimonialsPage() {
         </div>
       </div>
 
-      {/* Testimonials */}
-      <div className={styles.list}>
-        {testimonials.length > 0 ? (
-          testimonials.map((t) => {
-            const photo = t.photo && typeof t.photo === 'object' ? t.photo as Photo : null
-            const photoUrl = photo?.sizes?.card?.url ?? photo?.sizes?.thumbnail?.url ?? photo?.url ?? null
-            const photoWidth = photo?.sizes?.card?.width ?? photo?.sizes?.thumbnail?.width ?? photo?.width ?? null
-            const photoHeight = photo?.sizes?.card?.height ?? photo?.sizes?.thumbnail?.height ?? photo?.height ?? null
-
-            return (
-              <article key={t.id} className={styles.item} aria-label={`Review from ${t.clientName}`}>
-                {/* Text block */}
-                <div className={styles.textBlock}>
-                  {t.sessionType && (
-                    <p className={styles.badge}>{t.sessionType} Testimonial</p>
-                  )}
-                  <cite className={styles.clientName}>{t.clientName}</cite>
-                  <blockquote className={styles.quote}>
-                    <span className={styles.quoteOpen} aria-hidden="true">&ldquo;</span>
-                    {t.quote}
-                    <span className={styles.quoteClose} aria-hidden="true">&rdquo;</span>
-                  </blockquote>
-                </div>
-
-                {/* Photo (when set) */}
-                {photoUrl && (
-                  <div className={styles.photoWrap}>
-                    {photoWidth && photoHeight ? (
-                      <Image
-                        src={photoUrl}
-                        alt={`${t.clientName} session`}
-                        width={photoWidth}
-                        height={photoHeight}
-                        sizes="(max-width: 768px) 100vw, 50vw"
-                        className={styles.photo}
-                      />
-                    ) : (
-                      // eslint-disable-next-line @next/next/no-img-element
-                      <img
-                        src={photoUrl}
-                        alt={`${t.clientName} session`}
-                        className={styles.photo}
-                        loading="lazy"
-                      />
-                    )}
-                  </div>
-                )}
-              </article>
-            )
-          })
-        ) : (
-          <p className={styles.empty}>Kind words are on their way.</p>
-        )}
-      </div>
+      <TestimonialsList
+        testimonials={testimonials.map((t) => {
+          const photo = t.photo && typeof t.photo === 'object' ? t.photo as Photo : null
+          return {
+            id: t.id,
+            sessionType: t.sessionType ?? null,
+            clientName: t.clientName,
+            quote: t.quote,
+            photoUrl: photo?.sizes?.card?.url ?? photo?.sizes?.thumbnail?.url ?? photo?.url ?? null,
+            photoWidth: photo?.sizes?.card?.width ?? photo?.sizes?.thumbnail?.width ?? photo?.width ?? null,
+            photoHeight: photo?.sizes?.card?.height ?? photo?.sizes?.thumbnail?.height ?? photo?.height ?? null,
+          }
+        })}
+      />
 
       {/* CTA */}
       <div className={styles.cta}>

--- a/app/api/public-services/route.ts
+++ b/app/api/public-services/route.ts
@@ -1,0 +1,31 @@
+import { NextResponse } from 'next/server'
+import { getPayload } from 'payload'
+import config from '@payload-config'
+
+// Public, read-only service listing for the builder's LiveServices block
+// (app/builder/puck.config.tsx). Deliberately NOT Payload's auto-generated
+// `/api/services` REST route - that requires auth. Runs the same local-API
+// query the hardcoded /services page already uses (sort: displayOrder, all
+// services, no filter) and only returns the fields a public grid needs -
+// the same data already visible on that page today, not a new exposure.
+export async function GET() {
+  const payload = await getPayload({ config })
+  const { docs } = await payload.find({
+    collection: 'services',
+    sort: 'displayOrder',
+    depth: 0,
+    limit: 50,
+  })
+
+  const services = docs.map((s) => ({
+    id: s.id,
+    eyebrow: s.eyebrow ?? null,
+    title: s.title,
+    price: s.price ?? null,
+    description: s.description ?? null,
+    features: (s.features ?? []).map((f) => f.feature),
+    depositAmount: s.depositAmount ?? null,
+  }))
+
+  return NextResponse.json({ services })
+}

--- a/app/api/public-testimonials/route.ts
+++ b/app/api/public-testimonials/route.ts
@@ -1,0 +1,36 @@
+import { NextResponse } from 'next/server'
+import { getPayload } from 'payload'
+import config from '@payload-config'
+import type { Photo } from '@/payload-types'
+
+// Public, read-only testimonial listing for the builder's LiveTestimonials
+// block (app/builder/puck.config.tsx). Deliberately NOT Payload's
+// auto-generated `/api/testimonials` REST route - that requires auth. Runs
+// the same local-API query the hardcoded /testimonials page already uses
+// (sort: displayOrder, ALL testimonials, no "featured" filter - that flag
+// only governs the homepage teaser, not this page) and only returns the
+// fields a public list needs.
+export async function GET() {
+  const payload = await getPayload({ config })
+  const { docs } = await payload.find({
+    collection: 'testimonials',
+    sort: 'displayOrder',
+    depth: 1,
+    limit: 200,
+  })
+
+  const testimonials = docs.map((t) => {
+    const photo = t.photo && typeof t.photo === 'object' ? t.photo as Photo : null
+    return {
+      id: t.id,
+      sessionType: t.sessionType ?? null,
+      clientName: t.clientName,
+      quote: t.quote,
+      photoUrl: photo?.sizes?.card?.url ?? photo?.sizes?.thumbnail?.url ?? photo?.url ?? null,
+      photoWidth: photo?.sizes?.card?.width ?? photo?.sizes?.thumbnail?.width ?? photo?.width ?? null,
+      photoHeight: photo?.sizes?.card?.height ?? photo?.sizes?.thumbnail?.height ?? photo?.height ?? null,
+    }
+  })
+
+  return NextResponse.json({ testimonials })
+}

--- a/app/builder/SiteEditorClient.tsx
+++ b/app/builder/SiteEditorClient.tsx
@@ -30,6 +30,8 @@ const PROMOTABLE_ROUTES: { route: string; label: string }[] = [
   { route: 'portfolio/portraits', label: 'Portfolio - Portraits' },
   { route: 'portfolio/family', label: 'Portfolio - Family' },
   { route: 'portfolio/weddings', label: 'Portfolio - Weddings' },
+  { route: 'services', label: 'Services' },
+  { route: 'testimonials', label: 'Testimonials' },
 ]
 
 // ---------------------------------------------------------------------------

--- a/app/builder/puck.config.tsx
+++ b/app/builder/puck.config.tsx
@@ -18,6 +18,8 @@ import { FreeformPhotoCanvasField } from './FreeformPhotoCanvasField'
 import { PhotoCarouselBlock } from './PhotoCarouselBlock'
 import CategoryPhotoGrid from '@/app/(site)/portfolio/_components/CategoryPhotoGrid'
 import AlbumGridComponent from '@/app/(site)/portfolio/_components/AlbumGrid'
+import ServicesGridComponent from '@/app/(site)/services/_components/ServicesGrid'
+import TestimonialsListComponent from '@/app/(site)/testimonials/_components/TestimonialsList'
 import { AccordionBlock } from './AccordionBlock'
 import { TypewriterText } from './TypewriterText'
 import ContactForm from '@/app/(site)/contact/ContactForm'
@@ -371,7 +373,7 @@ export const config: Config = {
 
   categories: {
     layout: { title: 'Layout', components: ['SectionHeading', 'Spacer', 'Shape', 'Line', 'SocialLinks'] },
-    content: { title: 'Content', components: ['RichText', 'TypewriterHeading', 'SplitImageText', 'Services', 'Testimonials', 'Accordion', 'ContactFormBlock', 'CTA'] },
+    content: { title: 'Content', components: ['RichText', 'TypewriterHeading', 'SplitImageText', 'Services', 'LiveServices', 'Testimonials', 'LiveTestimonials', 'Accordion', 'ContactFormBlock', 'CTA'] },
     media: { title: 'Media', components: ['Hero', 'PhotoGallery', 'PortfolioGrid', 'AlbumGrid', 'PhotoCarousel', 'ImageGrid', 'FreeformPhotoCanvas', 'FullWidthImage', 'Video', 'Map', 'InstagramFeed', 'TikTokFeed'] },
   },
 
@@ -715,6 +717,42 @@ export const config: Config = {
       ),
     },
 
+    // ------------------------------------------------------- LiveServices
+    // TYN-341 phase 4: live-bound to the real services collection, unlike
+    // Services above (a manually-picked, static list baked into the page
+    // content). This is what lets /services be promoted to the block editor
+    // without losing the real, always-current pricing - matching Pixieset's
+    // reference where every page is an ordinary editable canvas with live
+    // data inside, not a locked preview. Same resolveData pattern as
+    // PortfolioGrid/AlbumGrid above: fetches /api/public-services rather
+    // than Payload's own /api/services (requires auth), and reuses the
+    // exact card component (ServicesGridComponent) the real /services page
+    // now also uses, so there is one markup implementation, not two.
+    LiveServices: {
+      label: 'Services (Live)',
+      fields: {
+        ...styleFields,
+        ...responsiveFields,
+      },
+      defaultProps: { ...styleDefaults, ...responsiveDefaults },
+      resolveData: async () => {
+        const base = typeof window === 'undefined' ? 'https://tynnellhollinsphotography.com' : ''
+        try {
+          const res = await fetch(`${base}/api/public-services`)
+          if (!res.ok) return { props: { resolvedServices: [] } }
+          const data = await res.json()
+          return { props: { resolvedServices: data.services ?? [] } }
+        } catch {
+          return { props: { resolvedServices: [] } }
+        }
+      },
+      render: ({ resolvedServices, background, backgroundImage, backgroundFade, spacing, hideOnMobile, hideOnDesktop }: any) => (
+        <Section background={background} backgroundImage={backgroundImage} backgroundFade={backgroundFade} spacing={spacing} className={visClass(hideOnMobile, hideOnDesktop)}>
+          <ServicesGridComponent services={resolvedServices ?? []} />
+        </Section>
+      ),
+    },
+
     // ----------------------------------------------------------- Testimonials
     Testimonials: {
       label: 'Testimonials',
@@ -753,6 +791,39 @@ export const config: Config = {
               </figure>
             ))}
           </div>
+        </Section>
+      ),
+    },
+
+    // ------------------------------------------------------- LiveTestimonials
+    // TYN-341 phase 4: live-bound to the real testimonials collection
+    // (ALL of them, sorted by displayOrder - matching /testimonials, not the
+    // homepage's "featured" subset), unlike Testimonials above (a manually-
+    // picked, static list). Same resolveData pattern as LiveServices above,
+    // fetching /api/public-testimonials and reusing the exact list
+    // component (TestimonialsListComponent) the real /testimonials page now
+    // also uses.
+    LiveTestimonials: {
+      label: 'Testimonials (Live)',
+      fields: {
+        ...styleFields,
+        ...responsiveFields,
+      },
+      defaultProps: { ...styleDefaults, ...responsiveDefaults },
+      resolveData: async () => {
+        const base = typeof window === 'undefined' ? 'https://tynnellhollinsphotography.com' : ''
+        try {
+          const res = await fetch(`${base}/api/public-testimonials`)
+          if (!res.ok) return { props: { resolvedTestimonials: [] } }
+          const data = await res.json()
+          return { props: { resolvedTestimonials: data.testimonials ?? [] } }
+        } catch {
+          return { props: { resolvedTestimonials: [] } }
+        }
+      },
+      render: ({ resolvedTestimonials, background, backgroundImage, backgroundFade, spacing, hideOnMobile, hideOnDesktop }: any) => (
+        <Section background={background} backgroundImage={backgroundImage} backgroundFade={backgroundFade} spacing={spacing} className={visClass(hideOnMobile, hideOnDesktop)}>
+          <TestimonialsListComponent testimonials={resolvedTestimonials ?? []} />
         </Section>
       ),
     },

--- a/app/lib/slug.ts
+++ b/app/lib/slug.ts
@@ -1,0 +1,7 @@
+// Shared slugify for a Service's booking link (/book?package=<slug>). Was
+// duplicated identically in services/page.tsx and book/BookClient.tsx; also
+// used by the LiveServices builder block (app/builder/puck.config.tsx) so
+// all three stay in sync without copy-pasting the regex a third time.
+export function slugifyServiceTitle(title: string): string {
+  return title.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '')
+}

--- a/collections/Pages.ts
+++ b/collections/Pages.ts
@@ -19,7 +19,10 @@ import { revalidatePath } from 'next/cache'
 // Puck block (app/builder/puck.config.tsx), alongside PortfolioGrid for its
 // individual wedding photos - together they match what the hardcoded page
 // already shows, so promoting it doesn't drop either feature.
-const PROMOTABLE_ROUTES = ['about', 'portfolio', 'portfolio/portraits', 'portfolio/family', 'portfolio/weddings'] as const
+// 'services' and 'testimonials' promote via the LiveServices/LiveTestimonials
+// blocks, live-bound to the real collections (not the static, manually-typed
+// Services/Testimonials blocks already used on Home) - phase 4 of TYN-341.
+const PROMOTABLE_ROUTES = ['about', 'portfolio', 'portfolio/portraits', 'portfolio/family', 'portfolio/weddings', 'services', 'testimonials'] as const
 
 // Only one page may claim a given real route at a time - unlike isHomepage
 // (which has no such guard and silently first-match-wins if ever duplicated),

--- a/payload-types.ts
+++ b/payload-types.ts
@@ -468,7 +468,7 @@ export interface Page {
   /**
    * Make this page render at one of your real site routes instead of its own URL. Only one page can be promoted to a given route at a time.
    */
-  promotedRoute?: ('about' | 'portfolio' | 'portfolio/portraits' | 'portfolio/family' | 'portfolio/weddings') | null;
+  promotedRoute?: ('about' | 'portfolio' | 'portfolio/portraits' | 'portfolio/family' | 'portfolio/weddings' | 'services' | 'testimonials') | null;
   updatedAt: string;
   createdAt: string;
 }

--- a/scripts/migrate-db.mjs
+++ b/scripts/migrate-db.mjs
@@ -771,6 +771,22 @@ async function run() {
       ALTER TABLE "pages" ADD COLUMN IF NOT EXISTS "promoted_route" varchar
     `)
     console.log('✓ pages.promoted_route column ready')
+
+    // ------------------------------------------------------------------
+    // Migration 20260722_180000: services/testimonials promotable routes
+    // Payload's Postgres adapter backs this select field with a real
+    // Postgres enum type (enum_pages_promoted_route), not the plain varchar
+    // the migration above adds - the column had already been created as an
+    // enum by Payload's own schema management before this ran. New select
+    // options need the enum type itself extended, or saving a page with
+    // promotedRoute: 'services' fails with "invalid input value for enum".
+    // ADD VALUE IF NOT EXISTS runs outside a transaction block here (no
+    // surrounding BEGIN in this script), which Postgres requires.
+    // ------------------------------------------------------------------
+
+    await client.query(`ALTER TYPE "enum_pages_promoted_route" ADD VALUE IF NOT EXISTS 'services'`)
+    await client.query(`ALTER TYPE "enum_pages_promoted_route" ADD VALUE IF NOT EXISTS 'testimonials'`)
+    console.log('✓ enum_pages_promoted_route has services/testimonials')
   } finally {
     client.release()
     await pool.end()


### PR DESCRIPTION
## Summary
- Adds LiveServices and LiveTestimonials Puck blocks, live-bound to the real `services`/`testimonials` collections (unlike the existing static Services/Testimonials blocks, which hold a manually-typed list) - same resolveData pattern as PortfolioGrid/AlbumGrid.
- Adds `/api/public-services` and `/api/public-testimonials`, public read-only routes (Payload's own `/api/services`/`/api/testimonials` require auth).
- Extracts the real pages' markup into shared components (`ServicesGrid`, `TestimonialsList`) reused by both the hardcoded page and the new blocks.
- Extracts the Services-to-Book slugify logic (duplicated in `services/page.tsx` and `book/BookClient.tsx`) into `app/lib/slug.ts`.
- Adds `services`/`testimonials` to `PROMOTABLE_ROUTES`, with promotion checks in both real pages (same pattern as About/Portfolio).
- DB migration: `promotedRoute` is backed by a real Postgres enum, not a plain varchar as originally assumed - added `ALTER TYPE ... ADD VALUE` for the two new options.

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] Production build succeeds
- [x] Ran migration against the database, confirmed enum extended
- [x] Verified end-to-end in a local production build: confirmed real `/services` and `/testimonials` pages still render unchanged (regression check), confirmed both new API routes return correct data, built a real test page with each new block, published, promoted it live to `/services` and `/testimonials` respectively, confirmed both routes rendered the promoted Puck content correctly, then un-promoted and deleted the test pages so the real hardcoded pages are live again