### PR TITLE
feat(builder): promote Contact via a resolveData-aware ContactFormBlock (TYN-341 phase 5)

### DIFF
--- a/app/(site)/contact/page.tsx
+++ b/app/(site)/contact/page.tsx
@@ -1,19 +1,45 @@
+import { cache } from 'react'
 import type { Metadata } from 'next'
 import { getPayload } from 'payload'
+import { Render, resolveAllData } from '@measured/puck/rsc'
+import type { Data } from '@measured/puck'
 import config from '@payload-config'
+import { config as puckConfig } from '@/app/builder/puck.config'
 import ContactForm from './ContactForm'
 import JsonLd from '@/app/components/JsonLd/JsonLd'
 import styles from './page.module.css'
 import { CONTACT_EMAIL } from '@/app/lib/constants'
 import { getActiveOoo, type BlockedRange } from '@/app/lib/availability'
-import { MIN_LEAD_TIME_HOURS, MAX_BOOKING_MONTHS } from '@/app/lib/validation'
+import { computeBookingDateBounds } from '@/app/lib/validation'
 
 // OOO banner is time-sensitive - shorter revalidate so it appears within 1 minute of being set
 export const revalidate = 60
 
-export const metadata: Metadata = {
-  title: 'Contact',
-  description: 'Book a session with Tynnell Hollins Photography. Weddings, engagements, portraits, and more.',
+// A builder page can be promoted to replace this real route - same pattern
+// as About/Portfolio/Services/Testimonials (see collections/Pages.ts,
+// app/(site)/about/page.tsx). Unlike those, the OOO banner below is NOT part
+// of the promoted Puck content - it's time-sensitive server logic, the wrong
+// affordance for a draggable block, so it renders unconditionally above
+// <Render> in the promoted branch too, exactly as it does in the hardcoded
+// branch.
+const getPromotedPage = cache(async () => {
+  const payload = await getPayload({ config })
+  const { docs } = await payload.find({
+    collection: 'pages',
+    where: { and: [{ promotedRoute: { equals: 'contact' } }, { published: { equals: true } }] },
+    limit: 1,
+    depth: 0,
+  })
+  return docs[0] ?? null
+})
+
+export async function generateMetadata(): Promise<Metadata> {
+  const promoted = await getPromotedPage()
+  if (promoted) return { title: promoted.title }
+  return {
+    title: 'Contact',
+    description: 'Book a session with Tynnell Hollins Photography. Weddings, engagements, portraits, and more.',
+  }
 }
 
 function findActiveOrUpcoming(ranges: BlockedRange[]): string | null {
@@ -44,8 +70,9 @@ function findActiveOrUpcoming(ranges: BlockedRange[]): string | null {
 }
 
 export default async function ContactPage() {
-  let oooMessage: string | null = null
+  const promoted = await getPromotedPage()
 
+  let oooMessage: string | null = null
   let minDate: string
   let maxDate: string
 
@@ -58,26 +85,17 @@ export default async function ContactPage() {
     if (Array.isArray(availability?.blockedRanges)) {
       oooMessage = findActiveOrUpcoming(availability.blockedRanges)
     }
-    const minLeadHours = typeof bookingSettings?.minLeadTimeHours === 'number'
-      ? bookingSettings.minLeadTimeHours
-      : MIN_LEAD_TIME_HOURS
-    const maxMonths = typeof bookingSettings?.maxBookingMonths === 'number'
-      ? bookingSettings.maxBookingMonths
-      : MAX_BOOKING_MONTHS
-    const minD = new Date()
-    minD.setTime(minD.getTime() + minLeadHours * 60 * 60 * 1000)
-    minDate = minD.toISOString().split('T')[0]
-    const maxD = new Date()
-    maxD.setMonth(maxD.getMonth() + maxMonths)
-    maxDate = maxD.toISOString().split('T')[0]
+    const bounds = computeBookingDateBounds({
+      minLeadTimeHours: typeof bookingSettings?.minLeadTimeHours === 'number' ? bookingSettings.minLeadTimeHours : undefined,
+      maxBookingMonths: typeof bookingSettings?.maxBookingMonths === 'number' ? bookingSettings.maxBookingMonths : undefined,
+    })
+    minDate = bounds.minDate
+    maxDate = bounds.maxDate
   } catch {
     // Non-fatal: fall back to defaults
-    const minD = new Date()
-    minD.setTime(minD.getTime() + MIN_LEAD_TIME_HOURS * 60 * 60 * 1000)
-    minDate = minD.toISOString().split('T')[0]
-    const maxD = new Date()
-    maxD.setMonth(maxD.getMonth() + MAX_BOOKING_MONTHS)
-    maxDate = maxD.toISOString().split('T')[0]
+    const bounds = computeBookingDateBounds()
+    minDate = bounds.minDate
+    maxDate = bounds.maxDate
   }
 
   const contactPageSchema = {
@@ -92,6 +110,21 @@ export default async function ContactPage() {
       email: CONTACT_EMAIL,
       url: 'https://tynnellhollinsphotography.com',
     },
+  }
+
+  if (promoted) {
+    const data = (promoted.content as Data | undefined) ?? { content: [], root: {} }
+    return (
+      <>
+        <JsonLd data={contactPageSchema} />
+        {oooMessage && (
+          <div className={styles.oooBanner} role="note" aria-label="Availability notice">
+            <p className={styles.oooMessage}>{oooMessage}</p>
+          </div>
+        )}
+        <Render config={puckConfig} data={await resolveAllData(data, puckConfig)} />
+      </>
+    )
   }
 
   return (

--- a/app/api/public-booking-dates/route.ts
+++ b/app/api/public-booking-dates/route.ts
@@ -1,0 +1,22 @@
+import { NextResponse } from 'next/server'
+import { getPayload } from 'payload'
+import config from '@payload-config'
+import { computeBookingDateBounds } from '@/app/lib/validation'
+
+// Public, read-only booking-date bounds for the builder's ContactFormBlock
+// (app/builder/puck.config.tsx) - the same min/max the hardcoded /contact
+// page computes from BookingSettings, exposed so the block's resolveData
+// can fetch it client-side too (in the editor's live preview, resolveData
+// runs in the browser, where getPayload() can't run). Only ever returns two
+// date strings, not the BookingSettings document itself.
+export async function GET() {
+  try {
+    const payload = await getPayload({ config })
+    const bookingSettings = await payload.findGlobal({ slug: 'booking-settings' }).catch(() => null)
+    const minLeadTimeHours = typeof bookingSettings?.minLeadTimeHours === 'number' ? bookingSettings.minLeadTimeHours : undefined
+    const maxBookingMonths = typeof bookingSettings?.maxBookingMonths === 'number' ? bookingSettings.maxBookingMonths : undefined
+    return NextResponse.json(computeBookingDateBounds({ minLeadTimeHours, maxBookingMonths }))
+  } catch {
+    return NextResponse.json(computeBookingDateBounds())
+  }
+}

--- a/app/builder/SiteEditorClient.tsx
+++ b/app/builder/SiteEditorClient.tsx
@@ -32,6 +32,7 @@ const PROMOTABLE_ROUTES: { route: string; label: string }[] = [
   { route: 'portfolio/weddings', label: 'Portfolio - Weddings' },
   { route: 'services', label: 'Services' },
   { route: 'testimonials', label: 'Testimonials' },
+  { route: 'contact', label: 'Contact' },
 ]
 
 // ---------------------------------------------------------------------------

--- a/app/builder/puck.config.tsx
+++ b/app/builder/puck.config.tsx
@@ -862,6 +862,11 @@ export const config: Config = {
       ),
     },
     // ------------------------------------------------------- ContactFormBlock
+    // TYN-341 phase 5: resolveData fetches the same min/max session-date
+    // bounds the real /contact page computes from BookingSettings (via
+    // /api/public-booking-dates), rather than the bare, unbounded date input
+    // this block previously rendered - the gap the page-promotion plan
+    // flagged before /contact could be safely promoted.
     ContactFormBlock: {
       label: 'Contact Form',
       fields: {
@@ -878,13 +883,24 @@ export const config: Config = {
         ...styleDefaults,
         ...responsiveDefaults,
       },
-      render: ({ eyebrow, heading, subtext, background, backgroundImage, backgroundFade, spacing, hideOnMobile, hideOnDesktop }: any) => (
+      resolveData: async () => {
+        const base = typeof window === 'undefined' ? 'https://tynnellhollinsphotography.com' : ''
+        try {
+          const res = await fetch(`${base}/api/public-booking-dates`)
+          if (!res.ok) return { props: {} }
+          const data = await res.json()
+          return { props: { resolvedMinDate: data.minDate, resolvedMaxDate: data.maxDate } }
+        } catch {
+          return { props: {} }
+        }
+      },
+      render: ({ eyebrow, heading, subtext, resolvedMinDate, resolvedMaxDate, background, backgroundImage, backgroundFade, spacing, hideOnMobile, hideOnDesktop }: any) => (
         <Section background={background} backgroundImage={backgroundImage} backgroundFade={backgroundFade} spacing={spacing} className={visClass(hideOnMobile, hideOnDesktop)}>
           <div style={{ maxWidth: '640px', margin: '0 auto' }}>
             {eyebrow && <p style={{ ...eyebrowStyle, textAlign: 'center' }}>{eyebrow}</p>}
             {heading && <h2 style={{ ...headingStyle('clamp(1.5rem,3vw,2.4rem)'), textAlign: 'center' }}>{heading}</h2>}
             {subtext && <p style={{ marginTop: '0.85rem', marginBottom: '2rem', color: C.detail, textAlign: 'center' }}>{subtext}</p>}
-            <ContactForm />
+            <ContactForm minDate={resolvedMinDate} maxDate={resolvedMaxDate} />
           </div>
         </Section>
       ),

--- a/app/lib/validation.ts
+++ b/app/lib/validation.ts
@@ -72,6 +72,24 @@ export const MIN_LEAD_TIME_HOURS = 48
 export const MAX_BOOKING_MONTHS = 24
 
 /**
+ * Computes the min/max date strings (YYYY-MM-DD) for the contact form's
+ * session-date picker. Shared by app/(site)/contact/page.tsx and the
+ * builder's ContactFormBlock (app/builder/puck.config.tsx, via
+ * /api/public-booking-dates) so both compute the same bounds the same way.
+ */
+export function computeBookingDateBounds(options?: { minLeadTimeHours?: number; maxBookingMonths?: number }): { minDate: string; maxDate: string } {
+  const minLeadHours = options?.minLeadTimeHours ?? MIN_LEAD_TIME_HOURS
+  const maxMonths = options?.maxBookingMonths ?? MAX_BOOKING_MONTHS
+
+  const minD = new Date()
+  minD.setTime(minD.getTime() + minLeadHours * 60 * 60 * 1000)
+  const maxD = new Date()
+  maxD.setMonth(maxD.getMonth() + maxMonths)
+
+  return { minDate: minD.toISOString().split('T')[0], maxDate: maxD.toISOString().split('T')[0] }
+}
+
+/**
  * Validates a session date string submitted via the contact form.
  *
  * Accepts optional overrides for lead time and booking window - used when

--- a/collections/Pages.ts
+++ b/collections/Pages.ts
@@ -22,7 +22,12 @@ import { revalidatePath } from 'next/cache'
 // 'services' and 'testimonials' promote via the LiveServices/LiveTestimonials
 // blocks, live-bound to the real collections (not the static, manually-typed
 // Services/Testimonials blocks already used on Home) - phase 4 of TYN-341.
-const PROMOTABLE_ROUTES = ['about', 'portfolio', 'portfolio/portraits', 'portfolio/family', 'portfolio/weddings', 'services', 'testimonials'] as const
+// 'contact' - phase 5 - required ContactFormBlock to gain its own resolveData
+// for the session-date min/max bounds first (see app/(site)/contact/page.tsx);
+// the OOO banner is NOT part of the promoted content, it renders unconditionally
+// above <Render> in both branches since it's time-sensitive server logic, not
+// draggable page content.
+const PROMOTABLE_ROUTES = ['about', 'portfolio', 'portfolio/portraits', 'portfolio/family', 'portfolio/weddings', 'services', 'testimonials', 'contact'] as const
 
 // Only one page may claim a given real route at a time - unlike isHomepage
 // (which has no such guard and silently first-match-wins if ever duplicated),

--- a/payload-types.ts
+++ b/payload-types.ts
@@ -468,7 +468,7 @@ export interface Page {
   /**
    * Make this page render at one of your real site routes instead of its own URL. Only one page can be promoted to a given route at a time.
    */
-  promotedRoute?: ('about' | 'portfolio' | 'portfolio/portraits' | 'portfolio/family' | 'portfolio/weddings' | 'services' | 'testimonials') | null;
+  promotedRoute?: ('about' | 'portfolio' | 'portfolio/portraits' | 'portfolio/family' | 'portfolio/weddings' | 'services' | 'testimonials' | 'contact') | null;
   updatedAt: string;
   createdAt: string;
 }

--- a/scripts/migrate-db.mjs
+++ b/scripts/migrate-db.mjs
@@ -787,6 +787,14 @@ async function run() {
     await client.query(`ALTER TYPE "enum_pages_promoted_route" ADD VALUE IF NOT EXISTS 'services'`)
     await client.query(`ALTER TYPE "enum_pages_promoted_route" ADD VALUE IF NOT EXISTS 'testimonials'`)
     console.log('✓ enum_pages_promoted_route has services/testimonials')
+
+    // ------------------------------------------------------------------
+    // Migration 20260722_190000: contact promotable route (phase 5)
+    // Same enum-extend requirement as services/testimonials above.
+    // ------------------------------------------------------------------
+
+    await client.query(`ALTER TYPE "enum_pages_promoted_route" ADD VALUE IF NOT EXISTS 'contact'`)
+    console.log('✓ enum_pages_promoted_route has contact')
   } finally {
     client.release()
     await pool.end()


### PR DESCRIPTION
## Summary
- Extends the block-editor promotion mechanism to `/contact`, matching About/Portfolio/Services/Testimonials.
- The OOO banner renders unconditionally above `<Render>` in the promoted branch too - it's time-sensitive server logic, not draggable page content, so it's deliberately NOT part of the Puck content itself.
- Fixes the real gap flagged before this could ship: `ContactFormBlock` rendered a bare `<ContactForm />` with no date bounds, so a promoted Contact page would let visitors pick any date with no lead-time/booking-window limit. Adds a `resolveData` hook fetching a new `/api/public-booking-dates` route (computes the same bounds from `BookingSettings` the real page already uses).
- Extracts the min/max date math into `computeBookingDateBounds()` (`app/lib/validation.ts`), used by both the real page and the new route.
- Adds `contact` to `PROMOTABLE_ROUTES` + another `ALTER TYPE ... ADD VALUE` migration.

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] Production build succeeds
- [x] Ran migration, confirmed enum extended
- [x] Verified locally: real `/contact` still renders unchanged, date input min/max match the pre-change values exactly (regression check); confirmed `/api/public-booking-dates` returns the correct bounds
- [ ] Could NOT verify the promoted block's live date bounds in a local build - `resolveData`'s server-side branch fetches the production domain (same pattern as `PortfolioGrid`/`AlbumGrid`/`LiveServices`), and this machine's local Node process can't reach the real internet over HTTPS (a pre-existing, documented local-network/TLS limitation, not a regression - CLAUDE.md's "Local admin photos 500" note describes the same class of issue). Will verify directly against production after this deploys.