### PR TITLE
feat(builder): promote Blog index via a LiveBlog block (TYN-341 phase 6)

### DIFF
--- a/app/(site)/blog/page.tsx
+++ b/app/(site)/blog/page.tsx
@@ -1,7 +1,11 @@
+import { cache } from 'react'
 import type { Metadata } from 'next'
 import Image from 'next/image'
 import { getPayload } from 'payload'
+import { Render, resolveAllData } from '@measured/puck/rsc'
+import type { Data } from '@measured/puck'
 import config from '@payload-config'
+import { config as puckConfig } from '@/app/builder/puck.config'
 import type { Photo } from '@/payload-types'
 import JsonLd from '@/app/components/JsonLd/JsonLd'
 import BlogClient from './BlogClient'
@@ -9,12 +13,32 @@ import styles from './page.module.css'
 
 export const revalidate = 3600
 
-export const metadata: Metadata = {
-  title: 'Blog | Tynnell Hollins Photography',
-  description: 'Photography tips, session guides, and stories from behind the lens by Tynnell Hollins.',
+// A builder page can be promoted to replace this real route - same pattern
+// as About/Portfolio/Services/Testimonials/Contact (see collections/Pages.ts,
+// app/(site)/about/page.tsx).
+const getPromotedPage = cache(async () => {
+  const payload = await getPayload({ config })
+  const { docs } = await payload.find({
+    collection: 'pages',
+    where: { and: [{ promotedRoute: { equals: 'blog' } }, { published: { equals: true } }] },
+    limit: 1,
+    depth: 0,
+  })
+  return docs[0] ?? null
+})
+
+export async function generateMetadata(): Promise<Metadata> {
+  const promoted = await getPromotedPage()
+  if (promoted) return { title: promoted.title }
+  return {
+    title: 'Blog | Tynnell Hollins Photography',
+    description: 'Photography tips, session guides, and stories from behind the lens by Tynnell Hollins.',
+  }
 }
 
 export default async function BlogPage() {
+  const promoted = await getPromotedPage()
+
   const payload = await getPayload({ config })
   const { docs } = await payload.find({
     collection: 'posts',
@@ -57,6 +81,16 @@ export default async function BlogPage() {
       url: `https://tynnellhollinsphotography.com/blog/${p.slug}`,
     })),
   } : null
+
+  if (promoted) {
+    const data = (promoted.content as Data | undefined) ?? { content: [], root: {} }
+    return (
+      <>
+        {blogSchema && <JsonLd data={blogSchema} />}
+        <Render config={puckConfig} data={await resolveAllData(data, puckConfig)} />
+      </>
+    )
+  }
 
   return (
     <main className={styles.main}>

--- a/app/api/public-posts/route.ts
+++ b/app/api/public-posts/route.ts
@@ -1,0 +1,40 @@
+import { NextResponse } from 'next/server'
+import { getPayload } from 'payload'
+import config from '@payload-config'
+import type { Photo } from '@/payload-types'
+
+// Public, read-only published-post listing for the builder's LiveBlog block
+// (app/builder/puck.config.tsx). Deliberately NOT Payload's auto-generated
+// `/api/posts` REST route - that requires auth. Runs the same local-API
+// query the hardcoded /blog page already uses (published only, sort by
+// -publishedAt) and returns exactly the shape BlogClient.tsx expects, so the
+// same component renders both the hardcoded page and the promoted block.
+const CAT_ORDER = ['style-guide', 'portrait-sessions', 'weddings', 'behind-the-lens', 'client-education']
+
+export async function GET() {
+  const payload = await getPayload({ config })
+  const { docs } = await payload.find({
+    collection: 'posts',
+    where: { status: { equals: 'published' } },
+    sort: '-publishedAt',
+    depth: 1,
+    limit: 200,
+  })
+
+  const posts = docs.map((p) => {
+    const coverImage = typeof p.coverImage === 'object' && p.coverImage !== null ? p.coverImage as Photo : null
+    return {
+      id: p.id,
+      title: p.title,
+      slug: typeof p.slug === 'string' ? p.slug : '',
+      publishedAt: p.publishedAt ?? null,
+      category: p.category ?? null,
+      excerpt: p.excerpt ?? null,
+      coverImage,
+    }
+  })
+
+  const categories = CAT_ORDER.filter((c) => posts.some((p) => p.category === c))
+
+  return NextResponse.json({ posts, categories })
+}

--- a/app/builder/SiteEditorClient.tsx
+++ b/app/builder/SiteEditorClient.tsx
@@ -33,6 +33,7 @@ const PROMOTABLE_ROUTES: { route: string; label: string }[] = [
   { route: 'services', label: 'Services' },
   { route: 'testimonials', label: 'Testimonials' },
   { route: 'contact', label: 'Contact' },
+  { route: 'blog', label: 'Blog' },
 ]
 
 // ---------------------------------------------------------------------------

--- a/app/builder/puck.config.tsx
+++ b/app/builder/puck.config.tsx
@@ -20,6 +20,7 @@ import CategoryPhotoGrid from '@/app/(site)/portfolio/_components/CategoryPhotoG
 import AlbumGridComponent from '@/app/(site)/portfolio/_components/AlbumGrid'
 import ServicesGridComponent from '@/app/(site)/services/_components/ServicesGrid'
 import TestimonialsListComponent from '@/app/(site)/testimonials/_components/TestimonialsList'
+import BlogClientComponent from '@/app/(site)/blog/BlogClient'
 import { AccordionBlock } from './AccordionBlock'
 import { TypewriterText } from './TypewriterText'
 import ContactForm from '@/app/(site)/contact/ContactForm'
@@ -374,7 +375,7 @@ export const config: Config = {
   categories: {
     layout: { title: 'Layout', components: ['SectionHeading', 'Spacer', 'Shape', 'Line', 'SocialLinks'] },
     content: { title: 'Content', components: ['RichText', 'TypewriterHeading', 'SplitImageText', 'Services', 'LiveServices', 'Testimonials', 'LiveTestimonials', 'Accordion', 'ContactFormBlock', 'CTA'] },
-    media: { title: 'Media', components: ['Hero', 'PhotoGallery', 'PortfolioGrid', 'AlbumGrid', 'PhotoCarousel', 'ImageGrid', 'FreeformPhotoCanvas', 'FullWidthImage', 'Video', 'Map', 'InstagramFeed', 'TikTokFeed'] },
+    media: { title: 'Media', components: ['Hero', 'PhotoGallery', 'PortfolioGrid', 'AlbumGrid', 'LiveBlog', 'PhotoCarousel', 'ImageGrid', 'FreeformPhotoCanvas', 'FullWidthImage', 'Video', 'Map', 'InstagramFeed', 'TikTokFeed'] },
   },
 
   components: {
@@ -1162,6 +1163,41 @@ export const config: Config = {
       render: ({ resolvedAlbums, background, backgroundImage, backgroundFade, spacing, hideOnMobile, hideOnDesktop }: any) => (
         <Section background={background} backgroundImage={backgroundImage} backgroundFade={backgroundFade} spacing={spacing} className={visClass(hideOnMobile, hideOnDesktop)}>
           <AlbumGridComponent albums={resolvedAlbums ?? []} />
+        </Section>
+      ),
+    },
+
+    // ----------------------------------------------------------- LiveBlog
+    // TYN-341 phase 6: live-bound to the real posts collection, making
+    // /blog promotable. Unlike the other Live* blocks, this reuses
+    // BlogClient.tsx directly (not a newly-extracted shared component) -
+    // it was already a self-contained 'use client' component taking only
+    // posts/categories props with no server-only dependency, so the same
+    // category-filter + Load More behavior works identically here and on
+    // the hardcoded page with zero markup duplication. Fetches
+    // /api/public-posts rather than Payload's own /api/posts (requires
+    // auth), same reasoning as every other Live* block's route.
+    LiveBlog: {
+      label: 'Blog Posts (Live)',
+      fields: {
+        ...styleFields,
+        ...responsiveFields,
+      },
+      defaultProps: { ...styleDefaults, ...responsiveDefaults },
+      resolveData: async () => {
+        const base = typeof window === 'undefined' ? 'https://tynnellhollinsphotography.com' : ''
+        try {
+          const res = await fetch(`${base}/api/public-posts`)
+          if (!res.ok) return { props: { resolvedPosts: [], resolvedCategories: [] } }
+          const data = await res.json()
+          return { props: { resolvedPosts: data.posts ?? [], resolvedCategories: data.categories ?? [] } }
+        } catch {
+          return { props: { resolvedPosts: [], resolvedCategories: [] } }
+        }
+      },
+      render: ({ resolvedPosts, resolvedCategories, background, backgroundImage, backgroundFade, spacing, hideOnMobile, hideOnDesktop }: any) => (
+        <Section background={background} backgroundImage={backgroundImage} backgroundFade={backgroundFade} spacing={spacing} className={visClass(hideOnMobile, hideOnDesktop)}>
+          <BlogClientComponent posts={resolvedPosts ?? []} categories={resolvedCategories ?? []} />
         </Section>
       ),
     },

--- a/collections/Pages.ts
+++ b/collections/Pages.ts
@@ -27,7 +27,10 @@ import { revalidatePath } from 'next/cache'
 // the OOO banner is NOT part of the promoted content, it renders unconditionally
 // above <Render> in both branches since it's time-sensitive server logic, not
 // draggable page content.
-const PROMOTABLE_ROUTES = ['about', 'portfolio', 'portfolio/portraits', 'portfolio/family', 'portfolio/weddings', 'services', 'testimonials', 'contact'] as const
+// 'blog' - phase 6 - promotes via the LiveBlog block, which reuses
+// BlogClient.tsx directly (already a self-contained client component with no
+// server-only dependency, so no markup extraction was needed).
+const PROMOTABLE_ROUTES = ['about', 'portfolio', 'portfolio/portraits', 'portfolio/family', 'portfolio/weddings', 'services', 'testimonials', 'contact', 'blog'] as const
 
 // Only one page may claim a given real route at a time - unlike isHomepage
 // (which has no such guard and silently first-match-wins if ever duplicated),

--- a/payload-types.ts
+++ b/payload-types.ts
@@ -468,7 +468,7 @@ export interface Page {
   /**
    * Make this page render at one of your real site routes instead of its own URL. Only one page can be promoted to a given route at a time.
    */
-  promotedRoute?: ('about' | 'portfolio' | 'portfolio/portraits' | 'portfolio/family' | 'portfolio/weddings' | 'services' | 'testimonials' | 'contact') | null;
+  promotedRoute?: ('about' | 'portfolio' | 'portfolio/portraits' | 'portfolio/family' | 'portfolio/weddings' | 'services' | 'testimonials' | 'contact' | 'blog') | null;
   updatedAt: string;
   createdAt: string;
 }

--- a/scripts/migrate-db.mjs
+++ b/scripts/migrate-db.mjs
@@ -795,6 +795,14 @@ async function run() {
 
     await client.query(`ALTER TYPE "enum_pages_promoted_route" ADD VALUE IF NOT EXISTS 'contact'`)
     console.log('✓ enum_pages_promoted_route has contact')
+
+    // ------------------------------------------------------------------
+    // Migration 20260722_200000: blog promotable route (phase 6)
+    // Same enum-extend requirement as the routes above.
+    // ------------------------------------------------------------------
+
+    await client.query(`ALTER TYPE "enum_pages_promoted_route" ADD VALUE IF NOT EXISTS 'blog'`)
+    console.log('✓ enum_pages_promoted_route has blog')
   } finally {
     client.release()
     await pool.end()


### PR DESCRIPTION
## Summary
- Extends the block-editor promotion mechanism to `/blog`, matching About/Portfolio/Services/Testimonials/Contact.
- Adds a `LiveBlog` Puck block reusing `BlogClient.tsx` directly (already a self-contained client component taking `posts`/`categories` props, no server-only dependency - no extraction needed).
- Adds `/api/public-posts` (public, read-only - Payload's own `/api/posts` requires auth), returning the same shape `BlogClient` expects plus the present-categories list.
- Adds `blog` to `PROMOTABLE_ROUTES` + another `ALTER TYPE ... ADD VALUE` migration.

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] Production build succeeds
- [x] Ran migration, confirmed enum extended
- [x] Verified locally: real `/blog` still renders unchanged (regression check - filter bar + empty state)
- [ ] Will verify the promoted block's live post grid directly against production after this deploys (same local-network limitation documented for the other Live* blocks - server-side `resolveData` fetches the real domain, which this machine can't reach over HTTPS)