### PR TITLE
fix(builder): move Puck editor back button to the upper-left corner (TYN-342)

### DIFF
--- a/app/builder/[slug]/EditorClient.tsx
+++ b/app/builder/[slug]/EditorClient.tsx
@@ -18,6 +18,12 @@ import { DrawerItemClickToAdd } from '../DrawerItemClickToAdd'
 // in-editor help panel for a non-technical user.
 type SaveState = 'idle' | 'saving' | 'error' | 'saved'
 
+// Puck's own sidebar-toggle icons occupy roughly the first 90px of the
+// header row (2 icon buttons + header padding) - measured directly against
+// the rendered header rather than guessed, so the back button sits right
+// after them without overlapping.
+const BACK_BUTTON_LEFT_OFFSET = 90
+
 export function EditorClient({
   slug,
   title,
@@ -144,8 +150,42 @@ export function EditorClient({
           actionBar: () => <></>,
           componentOverlay: SectionHoverToolbar,
           drawerItem: DrawerItemClickToAdd,
+          // headerActions only injects into Puck's right-side action row - that's
+          // why the back button used to land sandwiched between Help and View
+          // Page instead of reading as a true "back" control. Puck's own header
+          // is a CSS Grid item sized by its own stylesheet; wrapping it in a
+          // `header` override to reposition things breaks that sizing (tried and
+          // reverted - the header collapsed to a ~225px column). `position: fixed`
+          // on just this one button sidesteps Puck's layout entirely and lands it
+          // in the true upper-left, just past Puck's own sidebar-toggle icons -
+          // BACK_BUTTON_LEFT_OFFSET below was measured against their real
+          // rendered position.
           headerActions: ({ children }) => (
             <>
+              <Link
+                href="/builder"
+                onClick={guardLeave}
+                aria-label="Back to Pages"
+                title="Back to Pages"
+                style={{
+                  position: 'fixed',
+                  top: '19px',
+                  left: `${BACK_BUTTON_LEFT_OFFSET}px`,
+                  zIndex: 10,
+                  display: 'inline-flex',
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                  width: '34px',
+                  height: '34px',
+                  borderRadius: '4px',
+                  border: 'none',
+                  background: 'transparent',
+                  color: 'inherit',
+                  cursor: 'pointer',
+                }}
+              >
+                <BackArrowIcon />
+              </Link>
               <span
                 style={{
                   display: 'inline-flex',
@@ -170,26 +210,6 @@ export function EditorClient({
               <button type="button" style={headerBtn} aria-pressed={showHelp} onClick={() => setShowHelp((v) => !v)} title="How the builder works">
                 <span aria-hidden="true">?</span> Help
               </button>
-              <Link
-                href="/builder"
-                onClick={guardLeave}
-                aria-label="Back to Pages"
-                title="Back to Pages"
-                style={{
-                  display: 'inline-flex',
-                  alignItems: 'center',
-                  justifyContent: 'center',
-                  width: '34px',
-                  height: '34px',
-                  borderRadius: '4px',
-                  border: 'none',
-                  background: 'transparent',
-                  color: 'inherit',
-                  cursor: 'pointer',
-                }}
-              >
-                <BackArrowIcon />
-              </Link>
               {isPublished && (
                 <Link
                   href={publicPath}


### PR DESCRIPTION
## Summary
- The back button (shipped in PR #77) was rendered via `headerActions`, which only injects into Puck's right-side action row - it looked out of place sandwiched between Help and View Page instead of reading as a "back" control.
- Moved it to `position: fixed`, placed just past Puck's own sidebar-toggle icons in the true upper-left corner of the editor header.
- Tried using Puck's `header` override first to move it structurally - reverted that after it broke the header's CSS Grid sizing (collapsed to a ~225px column, since Puck's stylesheet expects `<header>` to remain a direct grid item). `position: fixed` sidesteps that layout entirely.

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] Production build succeeds
- [x] Verified in a local production build: header layout is fully intact (full width, normal height), back button sits immediately after Puck's own sidebar-toggle icons with matching vertical alignment (both centered at the same y), and clicking it still navigates back to `/builder` correctly