### PR TITLE
fix(photos): raise resolution/quality for new uploads (TYN-344)

### DIFF
--- a/app/(site)/about/page.tsx
+++ b/app/(site)/about/page.tsx
@@ -157,6 +157,7 @@ export default async function AboutPage() {
             fill
             priority
             sizes="100vw"
+            quality={90}
             className={styles.heroImg}
           />
         )}
@@ -179,6 +180,7 @@ export default async function AboutPage() {
                 fill
                 priority
                 sizes="(max-width: 768px) 100vw, 50vw"
+                quality={90}
                 className={styles.headshotImg}
               />
             ) : (

--- a/app/(site)/blog/BlogClient.tsx
+++ b/app/(site)/blog/BlogClient.tsx
@@ -100,6 +100,7 @@ export default function BlogClient({
                         alt={post.coverImage?.alt ?? post.title}
                         fill
                         sizes="(max-width: 640px) 100vw, (max-width: 1024px) 50vw, 33vw"
+                        quality={90}
                         className={styles.cardPhoto}
                       />
                     ) : (

--- a/app/(site)/blog/[slug]/page.tsx
+++ b/app/(site)/blog/[slug]/page.tsx
@@ -140,6 +140,7 @@ export default async function BlogPostPage({ params }: Props) {
               fill
               priority
               sizes="100vw"
+              quality={90}
               className={styles.coverPhoto}
             />
             <div className={styles.coverOverlay} />
@@ -210,6 +211,7 @@ export default async function BlogPostPage({ params }: Props) {
                             alt={rpCover?.alt ?? rp.title}
                             fill
                             sizes="(max-width: 768px) 100vw, 33vw"
+                            quality={90}
                             className={styles.relatedPhoto}
                           />
                         </div>

--- a/app/(site)/blog/page.tsx
+++ b/app/(site)/blog/page.tsx
@@ -106,6 +106,7 @@ export default async function BlogPage() {
             fill
             priority
             sizes="100vw"
+            quality={90}
             className={styles.heroPhoto}
           />
         )}

--- a/app/(site)/portfolio/family/page.tsx
+++ b/app/(site)/portfolio/family/page.tsx
@@ -92,6 +92,7 @@ export default async function FamilyPage() {
             priority
             className={styles.heroImg}
             sizes="100vw"
+            quality={90}
           />
         )}
         <div className={styles.heroOverlay} />

--- a/app/(site)/portfolio/page.tsx
+++ b/app/(site)/portfolio/page.tsx
@@ -135,6 +135,7 @@ export default async function PortfolioPage() {
                   alt={cat.label}
                   fill
                   sizes="(max-width: 768px) 100vw, 33vw"
+                  quality={90}
                   className={styles.tileImg}
                   priority={i === 0}
                 />

--- a/app/(site)/portfolio/portraits/page.tsx
+++ b/app/(site)/portfolio/portraits/page.tsx
@@ -92,6 +92,7 @@ export default async function PortraitsPage() {
             priority
             className={styles.heroImg}
             sizes="100vw"
+            quality={90}
           />
         )}
         <div className={styles.heroOverlay} />

--- a/app/(site)/portfolio/weddings/page.tsx
+++ b/app/(site)/portfolio/weddings/page.tsx
@@ -136,6 +136,7 @@ export default async function WeddingsPage() {
             priority
             className={styles.heroImg}
             sizes="100vw"
+            quality={90}
           />
         )}
         <div className={styles.heroOverlay} />

--- a/app/(site)/testimonials/_components/TestimonialsList.tsx
+++ b/app/(site)/testimonials/_components/TestimonialsList.tsx
@@ -45,6 +45,7 @@ export default function TestimonialsList({ testimonials }: { testimonials: Testi
                   width={t.photoWidth}
                   height={t.photoHeight}
                   sizes="(max-width: 768px) 100vw, 50vw"
+                  quality={90}
                   className={styles.photo}
                 />
               ) : (

--- a/app/api/admin/regenerate-photo-sizes/route.ts
+++ b/app/api/admin/regenerate-photo-sizes/route.ts
@@ -1,0 +1,100 @@
+import { NextResponse } from 'next/server'
+import { getPayload } from 'payload'
+import { headers } from 'next/headers'
+import config from '@payload-config'
+import { S3Client } from '@aws-sdk/client-s3'
+import { applyWatermarkIfEnabled } from '@/app/lib/watermark'
+import { applySharpeningIfEnabled } from '@/app/lib/sharpening'
+import type { Photo } from '@/payload-types'
+
+export const dynamic = 'force-dynamic'
+export const maxDuration = 60
+
+// Maintenance route for TYN-344 (site-wide blurry photos): the hero/card
+// imageSizes in collections/Photos.ts were bumped to higher resolutions with
+// an explicit JPEG quality, but that only affects NEW uploads. This
+// regenerates ONE existing photo's preview sizes from its original file,
+// re-running the same sharp resize + sharpening/watermark pipeline the real
+// ingest route runs, so it ends up equivalent to a fresh upload. One photo
+// per request (not a bulk loop) so it stays well inside Vercel's function
+// time limit regardless of library size - call it once per photo ID from an
+// authenticated admin session.
+function buildS3Client(): S3Client {
+  return new S3Client({
+    endpoint: `https://${process.env.R2_ACCOUNT_ID}.r2.cloudflarestorage.com`,
+    credentials: {
+      accessKeyId: process.env.R2_ACCESS_KEY_ID ?? '',
+      secretAccessKey: process.env.R2_SECRET_ACCESS_KEY ?? '',
+    },
+    region: 'auto',
+    forcePathStyle: true,
+  })
+}
+
+async function fetchBuffer(url: string): Promise<Buffer> {
+  const res = await fetch(url)
+  if (!res.ok) throw new Error(`HTTP ${res.status} fetching ${url}`)
+  return Buffer.from(await res.arrayBuffer())
+}
+
+export async function POST(request: Request) {
+  try {
+    const payload = await getPayload({ config })
+    const headersList = await headers()
+    const { user } = await payload.auth({ headers: headersList })
+    if (!user) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+    }
+
+    let id: number | string
+    try {
+      const body = await request.json()
+      id = body?.id
+    } catch {
+      return NextResponse.json({ error: 'Invalid request body' }, { status: 400 })
+    }
+    if (!id) {
+      return NextResponse.json({ error: 'id is required' }, { status: 400 })
+    }
+
+    const photo = (await payload.findByID({ collection: 'photos', id, depth: 0 })) as Photo
+    if (!photo?.url) {
+      return NextResponse.json({ error: 'Photo not found or has no url' }, { status: 404 })
+    }
+
+    const buffer = await fetchBuffer(photo.url)
+    const updated = (await payload.update({
+      collection: 'photos',
+      id,
+      data: {},
+      file: {
+        data: buffer,
+        mimetype: photo.mimeType ?? 'image/jpeg',
+        name: photo.filename ?? `photo-${id}.jpg`,
+        size: buffer.length,
+      },
+      overrideAccess: false,
+      user,
+    })) as Photo
+
+    const s3 = buildS3Client()
+    const bucket = process.env.R2_BUCKET ?? 'tynnell-hollins-photos'
+
+    try {
+      await applySharpeningIfEnabled({ s3, bucket, sizes: updated.sizes })
+    } catch (err) {
+      console.warn(`[regenerate-photo-sizes] sharpening failed for ${id} (non-fatal):`, err)
+    }
+    try {
+      await applyWatermarkIfEnabled({ s3, bucket, sizes: updated.sizes })
+    } catch (err) {
+      console.warn(`[regenerate-photo-sizes] watermark failed for ${id} (non-fatal):`, err)
+    }
+
+    return NextResponse.json({ ok: true, id })
+  } catch (err) {
+    console.error('[regenerate-photo-sizes] failed:', err)
+    const message = err instanceof Error ? err.message : String(err)
+    return NextResponse.json({ error: message }, { status: 500 })
+  }
+}

--- a/app/blog-editor/BlogPostCanvas.tsx
+++ b/app/blog-editor/BlogPostCanvas.tsx
@@ -79,7 +79,7 @@ export function BlogPostCanvas({
         <HeroCoverPicker onSelect={(id) => { void handleCoverSelect(id) }}>
           {coverUrl && (
             <div className={styles.coverImage}>
-              <Image src={coverUrl} alt={cover?.alt ?? title} fill priority sizes="100vw" className={styles.coverPhoto} />
+              <Image src={coverUrl} alt={cover?.alt ?? title} fill priority sizes="100vw" quality={90} className={styles.coverPhoto} />
               <div className={styles.coverOverlay} />
             </div>
           )}

--- a/app/components/ProtectedImage/ProtectedImage.tsx
+++ b/app/components/ProtectedImage/ProtectedImage.tsx
@@ -6,11 +6,16 @@ import styles from './ProtectedImage.module.css'
 
 const prevent = (e: React.SyntheticEvent) => e.preventDefault()
 
-export function ProtectedImage({ className, ...props }: ImageProps) {
+export function ProtectedImage({ className, quality, ...props }: ImageProps) {
   return (
     // eslint-disable-next-line jsx-a11y/alt-text
     <Image
       {...props}
+      // Default quality bumped from next/image's own default (75) - a
+      // photography portfolio gets scrutinized more closely than most sites,
+      // and 75 was visibly compressing photos on top of the resize Payload's
+      // sharp step already does (TYN-344). Callers can still override.
+      quality={quality ?? 90}
       draggable={false}
       onContextMenu={prevent}
       onDragStart={prevent}

--- a/collections/Photos.ts
+++ b/collections/Photos.ts
@@ -43,24 +43,35 @@ export const Photos: CollectionConfig = {
     staticDir: 'media',
     adminThumbnail: 'thumbnail',
     bulkUpload: true,
+    // Widths bumped and an explicit JPEG quality set (TYN-344) - card/hero
+    // were sized for a 1x display. A photography portfolio is disproportionately
+    // viewed on high-DPI screens (2x/3x), where a 1920px "hero" gets upscaled by
+    // the browser for any full-bleed section wider than that in physical
+    // pixels - the actual complaint (About page hero "looks noticeably
+    // blurry"). Sharp's own default quality (~80) was also being re-compressed
+    // a second time by next/image's default (75); setting quality explicitly
+    // here avoids stacking two lossy passes at a low setting.
     imageSizes: [
       {
         name: 'thumbnail',
         width: 400,
         height: 300,
         position: 'centre',
+        formatOptions: { format: 'jpeg', options: { quality: 80 } },
       },
       {
         name: 'card',
-        width: 800,
-        height: 600,
+        width: 1200,
+        height: 900,
         position: 'centre',
+        formatOptions: { format: 'jpeg', options: { quality: 85 } },
       },
       {
         name: 'hero',
-        width: 1920,
-        height: 1080,
+        width: 2560,
+        height: 1440,
         position: 'centre',
+        formatOptions: { format: 'jpeg', options: { quality: 88 } },
       },
     ],
     mimeTypes: ['image/*'],

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -47,6 +47,11 @@ const nextConfig = {
     optimizePackageImports: ['swiper'],
   },
   images: {
+    // next/image only allows quality values listed here (default: [75]).
+    // 90 is used site-wide for photos (ProtectedImage, hero banners - TYN-344)
+    // since photography work reads visibly compressed at the default 75,
+    // stacked on top of the resize sharp already does at upload time.
+    qualities: [75, 90],
     // Photos are served from Cloudflare R2. next/image rejects any remote host
     // not listed here. This block was lost when Sanity (cdn.sanity.io) was
     // removed and must cover the R2 host that now serves every image.


### PR DESCRIPTION
## Summary
- Photos.ts's `hero`/`card` imageSizes bumped from 1x-display sizing (1920x1080/800x600) to 2560x1440/1200x900 with explicit JPEG quality (88/85) - a 1920px hero was getting upscaled by the browser on any high-DPI/large screen, the concrete complaint (About hero "looks noticeably blurry").
- Every next/image usage sitewide omitted `quality`, silently falling back to Next's own default of 75 - a second lossy pass stacked on the resize above. Set `quality={90}` explicitly across About, Portfolio (+3 category pages), Blog (+post +related), Testimonials, and the blog editor canvas.
- `ProtectedImage` (shared by AlbumGrid, CategoryPhotoGrid, GalleryViewer, AboutPreview, PortfolioTeaser) now defaults to `quality=90` itself, so every caller benefits without individual edits.
- `next.config.mjs`'s `images.qualities` allow-list extended to include 90 (required by Next 15 to permit a non-default quality value).
- New `POST /api/admin/regenerate-photo-sizes` (admin-auth-gated, one photo per request) re-runs the upload pipeline against an existing photo's original file - **not yet invoked against any real photos**, since that's a live-data bulk operation held for explicit confirmation separate from this PR.

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] Verified against a local production build connected to the real DB
- [ ] Regeneration route tested against a real photo - blocked by the auto-mode safety classifier (expected, live-data mutation); needs to be run with explicit authorization, see follow-up discussion