### PR TITLE
feat(builder): add real draft preview (TYN-343)

### DIFF
--- a/app/(site)/[...slug]/page.tsx
+++ b/app/(site)/[...slug]/page.tsx
@@ -6,6 +6,7 @@ import { Render, resolveAllData } from '@measured/puck/rsc'
 import type { Data } from '@measured/puck'
 import payloadConfig from '@payload-config'
 import { config as puckConfig } from '@/app/builder/puck.config'
+import { isPreviewMode } from '@/app/lib/builderPreview'
 
 // Public render of a builder page (TYN-216). This catch-all only handles slugs
 // NOT already owned by an explicit route (/, /about, /portfolio, ...): Next.js
@@ -23,9 +24,12 @@ export const revalidate = 120
 // single request render, so a published-page view hits the DB once, not twice.
 const findPublishedPage = cache(async (path: string) => {
   const payload = await getPayload({ config: payloadConfig })
+  const preview = await isPreviewMode()
   const { docs } = await payload.find({
     collection: 'pages',
-    where: { and: [{ slug: { equals: path } }, { published: { equals: true } }] },
+    where: preview
+      ? { slug: { equals: path } }
+      : { and: [{ slug: { equals: path } }, { published: { equals: true } }] },
     limit: 1,
     depth: 0,
   })

--- a/app/(site)/about/page.tsx
+++ b/app/(site)/about/page.tsx
@@ -11,6 +11,7 @@ import config from '@payload-config'
 import { config as puckConfig } from '@/app/builder/puck.config'
 import type { Photo } from '@/payload-types'
 import JsonLd from '@/app/components/JsonLd/JsonLd'
+import { isPreviewMode } from '@/app/lib/builderPreview'
 import styles from './page.module.css'
 
 // About content rarely changes - revalidate every 2 minutes
@@ -26,9 +27,12 @@ const getAboutData = cache(async () => {
 // Shared via cache() so generateMetadata and the page body see one DB read.
 const getPromotedAboutPage = cache(async () => {
   const payload = await getPayload({ config })
+  const preview = await isPreviewMode()
   const { docs } = await payload.find({
     collection: 'pages',
-    where: { and: [{ promotedRoute: { equals: 'about' } }, { published: { equals: true } }] },
+    where: preview
+      ? { promotedRoute: { equals: 'about' } }
+      : { and: [{ promotedRoute: { equals: 'about' } }, { published: { equals: true } }] },
     limit: 1,
     depth: 0,
   })

--- a/app/(site)/blog/page.tsx
+++ b/app/(site)/blog/page.tsx
@@ -9,6 +9,7 @@ import { config as puckConfig } from '@/app/builder/puck.config'
 import type { Photo } from '@/payload-types'
 import JsonLd from '@/app/components/JsonLd/JsonLd'
 import BlogClient from './BlogClient'
+import { isPreviewMode } from '@/app/lib/builderPreview'
 import styles from './page.module.css'
 
 export const revalidate = 3600
@@ -18,9 +19,12 @@ export const revalidate = 3600
 // app/(site)/about/page.tsx).
 const getPromotedPage = cache(async () => {
   const payload = await getPayload({ config })
+  const preview = await isPreviewMode()
   const { docs } = await payload.find({
     collection: 'pages',
-    where: { and: [{ promotedRoute: { equals: 'blog' } }, { published: { equals: true } }] },
+    where: preview
+      ? { promotedRoute: { equals: 'blog' } }
+      : { and: [{ promotedRoute: { equals: 'blog' } }, { published: { equals: true } }] },
     limit: 1,
     depth: 0,
   })

--- a/app/(site)/contact/page.tsx
+++ b/app/(site)/contact/page.tsx
@@ -11,6 +11,7 @@ import styles from './page.module.css'
 import { CONTACT_EMAIL } from '@/app/lib/constants'
 import { getActiveOoo, type BlockedRange } from '@/app/lib/availability'
 import { computeBookingDateBounds } from '@/app/lib/validation'
+import { isPreviewMode } from '@/app/lib/builderPreview'
 
 // OOO banner is time-sensitive - shorter revalidate so it appears within 1 minute of being set
 export const revalidate = 60
@@ -24,9 +25,12 @@ export const revalidate = 60
 // branch.
 const getPromotedPage = cache(async () => {
   const payload = await getPayload({ config })
+  const preview = await isPreviewMode()
   const { docs } = await payload.find({
     collection: 'pages',
-    where: { and: [{ promotedRoute: { equals: 'contact' } }, { published: { equals: true } }] },
+    where: preview
+      ? { promotedRoute: { equals: 'contact' } }
+      : { and: [{ promotedRoute: { equals: 'contact' } }, { published: { equals: true } }] },
     limit: 1,
     depth: 0,
   })

--- a/app/(site)/page.tsx
+++ b/app/(site)/page.tsx
@@ -6,6 +6,7 @@ import config from '@payload-config'
 import { config as puckConfig } from '@/app/builder/puck.config'
 import JsonLd from '@/app/components/JsonLd/JsonLd'
 import { CONTACT_EMAIL } from '@/app/lib/constants'
+import { isPreviewMode } from '@/app/lib/builderPreview'
 import Hero from '@/app/components/Hero/Hero'
 import PortfolioTeaser from '@/app/components/PortfolioTeaser/PortfolioTeaser'
 import AboutPreview from '@/app/components/AboutPreview/AboutPreview'
@@ -25,9 +26,12 @@ export default async function Home() {
 
   // A builder page can be promoted to the site homepage (TYN-227). When one is
   // flagged + published it renders at "/" in place of the built-in home below.
+  const preview = await isPreviewMode()
   const { docs: homepageDocs } = await payload.find({
     collection: 'pages',
-    where: { and: [{ isHomepage: { equals: true } }, { published: { equals: true } }] },
+    where: preview
+      ? { isHomepage: { equals: true } }
+      : { and: [{ isHomepage: { equals: true } }, { published: { equals: true } }] },
     limit: 1,
     depth: 0,
   })

--- a/app/(site)/portfolio/family/page.tsx
+++ b/app/(site)/portfolio/family/page.tsx
@@ -10,6 +10,7 @@ import { config as puckConfig } from '@/app/builder/puck.config'
 import type { Photo } from '@/payload-types'
 import JsonLd from '@/app/components/JsonLd/JsonLd'
 import CategoryPhotoGrid, { type CategoryPhoto } from '../_components/CategoryPhotoGrid'
+import { isPreviewMode } from '@/app/lib/builderPreview'
 import styles from '../_components/CategoryPage.module.css'
 
 export const revalidate = 120
@@ -18,9 +19,12 @@ export const revalidate = 120
 // as About (see collections/Pages.ts, app/(site)/about/page.tsx).
 const getPromotedPage = cache(async () => {
   const payload = await getPayload({ config })
+  const preview = await isPreviewMode()
   const { docs } = await payload.find({
     collection: 'pages',
-    where: { and: [{ promotedRoute: { equals: 'portfolio/family' } }, { published: { equals: true } }] },
+    where: preview
+      ? { promotedRoute: { equals: 'portfolio/family' } }
+      : { and: [{ promotedRoute: { equals: 'portfolio/family' } }, { published: { equals: true } }] },
     limit: 1,
     depth: 0,
   })

--- a/app/(site)/portfolio/page.tsx
+++ b/app/(site)/portfolio/page.tsx
@@ -9,6 +9,7 @@ import config from '@payload-config'
 import { config as puckConfig } from '@/app/builder/puck.config'
 import type { Photo } from '@/payload-types'
 import JsonLd from '@/app/components/JsonLd/JsonLd'
+import { isPreviewMode } from '@/app/lib/builderPreview'
 import styles from './portfolio-landing.module.css'
 
 export const revalidate = 120
@@ -17,9 +18,12 @@ export const revalidate = 120
 // as About (see collections/Pages.ts, app/(site)/about/page.tsx).
 const getPromotedPage = cache(async () => {
   const payload = await getPayload({ config })
+  const preview = await isPreviewMode()
   const { docs } = await payload.find({
     collection: 'pages',
-    where: { and: [{ promotedRoute: { equals: 'portfolio' } }, { published: { equals: true } }] },
+    where: preview
+      ? { promotedRoute: { equals: 'portfolio' } }
+      : { and: [{ promotedRoute: { equals: 'portfolio' } }, { published: { equals: true } }] },
     limit: 1,
     depth: 0,
   })

--- a/app/(site)/portfolio/portraits/page.tsx
+++ b/app/(site)/portfolio/portraits/page.tsx
@@ -10,6 +10,7 @@ import { config as puckConfig } from '@/app/builder/puck.config'
 import type { Photo } from '@/payload-types'
 import JsonLd from '@/app/components/JsonLd/JsonLd'
 import CategoryPhotoGrid, { type CategoryPhoto } from '../_components/CategoryPhotoGrid'
+import { isPreviewMode } from '@/app/lib/builderPreview'
 import styles from '../_components/CategoryPage.module.css'
 
 export const revalidate = 120
@@ -18,9 +19,12 @@ export const revalidate = 120
 // as About (see collections/Pages.ts, app/(site)/about/page.tsx).
 const getPromotedPage = cache(async () => {
   const payload = await getPayload({ config })
+  const preview = await isPreviewMode()
   const { docs } = await payload.find({
     collection: 'pages',
-    where: { and: [{ promotedRoute: { equals: 'portfolio/portraits' } }, { published: { equals: true } }] },
+    where: preview
+      ? { promotedRoute: { equals: 'portfolio/portraits' } }
+      : { and: [{ promotedRoute: { equals: 'portfolio/portraits' } }, { published: { equals: true } }] },
     limit: 1,
     depth: 0,
   })

--- a/app/(site)/portfolio/weddings/page.tsx
+++ b/app/(site)/portfolio/weddings/page.tsx
@@ -11,6 +11,7 @@ import type { Photo } from '@/payload-types'
 import JsonLd from '@/app/components/JsonLd/JsonLd'
 import CategoryPhotoGrid, { type CategoryPhoto } from '../_components/CategoryPhotoGrid'
 import AlbumGrid, { type AlbumItem } from '../_components/AlbumGrid'
+import { isPreviewMode } from '@/app/lib/builderPreview'
 import styles from '../_components/CategoryPage.module.css'
 
 export const revalidate = 120
@@ -23,9 +24,12 @@ export const revalidate = 120
 // silently dropped that feature.
 const getPromotedPage = cache(async () => {
   const payload = await getPayload({ config })
+  const preview = await isPreviewMode()
   const { docs } = await payload.find({
     collection: 'pages',
-    where: { and: [{ promotedRoute: { equals: 'portfolio/weddings' } }, { published: { equals: true } }] },
+    where: preview
+      ? { promotedRoute: { equals: 'portfolio/weddings' } }
+      : { and: [{ promotedRoute: { equals: 'portfolio/weddings' } }, { published: { equals: true } }] },
     limit: 1,
     depth: 0,
   })

--- a/app/(site)/services/page.tsx
+++ b/app/(site)/services/page.tsx
@@ -8,6 +8,7 @@ import config from '@payload-config'
 import { config as puckConfig } from '@/app/builder/puck.config'
 import JsonLd from '@/app/components/JsonLd/JsonLd'
 import ServicesGrid from './_components/ServicesGrid'
+import { isPreviewMode } from '@/app/lib/builderPreview'
 import styles from './page.module.css'
 
 // Service packages/pricing rarely change - revalidate every 2 minutes
@@ -17,9 +18,12 @@ export const revalidate = 120
 // as About/Portfolio (see collections/Pages.ts, app/(site)/about/page.tsx).
 const getPromotedPage = cache(async () => {
   const payload = await getPayload({ config })
+  const preview = await isPreviewMode()
   const { docs } = await payload.find({
     collection: 'pages',
-    where: { and: [{ promotedRoute: { equals: 'services' } }, { published: { equals: true } }] },
+    where: preview
+      ? { promotedRoute: { equals: 'services' } }
+      : { and: [{ promotedRoute: { equals: 'services' } }, { published: { equals: true } }] },
     limit: 1,
     depth: 0,
   })

--- a/app/(site)/testimonials/page.tsx
+++ b/app/(site)/testimonials/page.tsx
@@ -8,6 +8,7 @@ import config from '@payload-config'
 import { config as puckConfig } from '@/app/builder/puck.config'
 import JsonLd from '@/app/components/JsonLd/JsonLd'
 import TestimonialsList from './_components/TestimonialsList'
+import { isPreviewMode } from '@/app/lib/builderPreview'
 import styles from './page.module.css'
 import type { Photo } from '@/payload-types'
 
@@ -17,9 +18,12 @@ export const revalidate = 120
 // as About/Portfolio/Services (see collections/Pages.ts, app/(site)/about/page.tsx).
 const getPromotedPage = cache(async () => {
   const payload = await getPayload({ config })
+  const preview = await isPreviewMode()
   const { docs } = await payload.find({
     collection: 'pages',
-    where: { and: [{ promotedRoute: { equals: 'testimonials' } }, { published: { equals: true } }] },
+    where: preview
+      ? { promotedRoute: { equals: 'testimonials' } }
+      : { and: [{ promotedRoute: { equals: 'testimonials' } }, { published: { equals: true } }] },
     limit: 1,
     depth: 0,
   })

--- a/app/api/builder-preview/route.ts
+++ b/app/api/builder-preview/route.ts
@@ -1,0 +1,44 @@
+import { NextResponse } from 'next/server'
+import { draftMode, headers } from 'next/headers'
+import { getPayload } from 'payload'
+import config from '@payload-config'
+
+// TYN-343: "View Page" in the Page Builder only ever showed the live,
+// published version. This enables Next.js Draft Mode for an authenticated
+// admin session, then redirects to wherever this page actually renders
+// (its own slug, or the real route it's promoted to / isHomepage) - every
+// promoted-page lookup (see app/lib/builderPreview.ts) drops its
+// `published: true` filter while draft mode is active, so the page's
+// current saved content renders there regardless of publish state.
+export async function GET(request: Request) {
+  const payload = await getPayload({ config })
+  const headersList = await headers()
+  const { user } = await payload.auth({ headers: headersList })
+  if (!user) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const { searchParams } = new URL(request.url)
+  const slug = searchParams.get('slug')
+  if (!slug) {
+    return NextResponse.json({ error: 'slug is required' }, { status: 400 })
+  }
+
+  const { docs } = await payload.find({
+    collection: 'pages',
+    where: { slug: { equals: slug } },
+    limit: 1,
+    depth: 0,
+  })
+  const page = docs[0]
+  if (!page) {
+    return NextResponse.json({ error: 'Page not found' }, { status: 404 })
+  }
+
+  const targetPath = page.isHomepage ? '/' : page.promotedRoute ? `/${page.promotedRoute}` : `/${page.slug}`
+
+  const dm = await draftMode()
+  dm.enable()
+
+  return NextResponse.redirect(new URL(targetPath, request.url))
+}

--- a/app/api/exit-preview/route.ts
+++ b/app/api/exit-preview/route.ts
@@ -1,0 +1,9 @@
+import { NextResponse } from 'next/server'
+import { draftMode } from 'next/headers'
+
+// Disables the Draft Mode enabled by /api/builder-preview (TYN-343).
+export async function GET(request: Request) {
+  const dm = await draftMode()
+  dm.disable()
+  return NextResponse.redirect(new URL('/', request.url))
+}

--- a/app/builder/[slug]/EditorClient.tsx
+++ b/app/builder/[slug]/EditorClient.tsx
@@ -95,6 +95,23 @@ export function EditorClient({
   const onPublish = (data: Data) => persist(data, true)
   const onSaveDraft = (data: Data) => persist(data, false)
 
+  // Preview (TYN-343): "View Page" only ever showed the live published
+  // version, with no way to see draft edits in context before hitting
+  // Publish. Saves the current canvas as a draft first (so what opens
+  // matches exactly what's on screen), then opens /api/builder-preview in a
+  // new tab, which turns on Next.js Draft Mode and redirects to wherever
+  // this page actually renders.
+  const [previewing, setPreviewing] = useState(false)
+  const onPreview = async (data: Data) => {
+    setPreviewing(true)
+    try {
+      await persist(data, false)
+      window.open(`/api/builder-preview?slug=${encodeURIComponent(slug)}`, '_blank', 'noopener,noreferrer')
+    } finally {
+      setPreviewing(false)
+    }
+  }
+
   // Plain-English status shown in the header.
   const pill =
     saveState === 'saving'
@@ -221,6 +238,7 @@ export function EditorClient({
                   View Page <span aria-hidden="true">&#8599;</span>
                 </Link>
               )}
+              <PreviewButton onPreview={onPreview} style={headerBtn} busy={previewing || saveState === 'saving'} />
               <SaveDraftButton onSave={onSaveDraft} style={headerBtn} saving={saveState === 'saving'} />
               {children}
             </>
@@ -230,6 +248,20 @@ export function EditorClient({
 
       {showHelp && <HelpPanel onClose={() => setShowHelp(false)} isPublished={isPublished} />}
     </div>
+  )
+}
+
+// Preview: saves the current draft, then opens it in a new tab with Draft
+// Mode on - shows the actual unpublished edits in context, unlike "View
+// Page" which only ever reflects what's currently live (TYN-343). Reads the
+// live Puck state via usePuck so it always previews exactly what's on the
+// canvas, same as SaveDraftButton below.
+function PreviewButton({ onPreview, style, busy }: { onPreview: (data: Data) => void; style: React.CSSProperties; busy: boolean }) {
+  const { appState } = usePuck()
+  return (
+    <button type="button" style={{ ...style, opacity: busy ? 0.6 : 1, cursor: busy ? 'default' : 'pointer' }} disabled={busy} aria-busy={busy} onClick={() => onPreview(appState.data)} title="Preview your unpublished edits in a new tab">
+      {busy ? 'Opening preview...' : 'Preview'}
+    </button>
   )
 }
 

--- a/app/lib/builderPreview.ts
+++ b/app/lib/builderPreview.ts
@@ -1,0 +1,19 @@
+import { draftMode } from 'next/headers'
+
+// TYN-343: "View Page" in the Page Builder only ever showed the live,
+// published version - there was no way to see draft/unpublished edits in
+// context before hitting Publish. This checks Next.js Draft Mode, which
+// /api/builder-preview turns on for an authenticated admin session. Every
+// promoted-route page.tsx (and the custom-page catch-all) drops its
+// `published: true` filter when preview mode is active, so the one page
+// currently claiming that route/slug renders regardless of publish state -
+// preventDuplicatePromotion (collections/Pages.ts) already guarantees at
+// most one page can claim a given route, so this can't leak a different
+// page's draft.
+export async function isPreviewMode(): Promise<boolean> {
+  try {
+    return (await draftMode()).isEnabled
+  } catch {
+    return false
+  }
+}


### PR DESCRIPTION
## Summary
- "View Page" in the Page Builder only ever showed the currently-published version - no way to see unpublished draft edits before hitting Publish.
- New `GET /api/builder-preview?slug=` (admin-auth-gated) enables Next.js Draft Mode and redirects to wherever the page actually renders.
- Every promoted-route lookup (About, Portfolio +3 category pages, Services, Testimonials, Contact, Blog, Home, the custom-page catch-all) drops its `published: true` filter while Draft Mode is active, via a shared `isPreviewMode()` helper (`app/lib/builderPreview.ts`).
- `EditorClient.tsx` gets a new always-visible "Preview" button: saves the current canvas as a draft, then opens the preview link in a new tab.
- `GET /api/exit-preview` disables Draft Mode.

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] Verified against a local production build: clicked Preview on a draft (unpublished) page, confirmed its content rendered at its target route (`/`) instead of the still-live hardcoded page