### PR TITLE
feat(builder): scroll-triggered photo fade-in + testimonials sticky-scroll (TYN-353/354)

### DIFF
--- a/app/(site)/testimonials/_components/TestimonialsList.module.css
+++ b/app/(site)/testimonials/_components/TestimonialsList.module.css
@@ -92,6 +92,85 @@
   max-height: 600px;
 }
 
+/* ── Sticky-scroll photo pairing (TYN-354) ──────────────────────────── */
+
+.stickyLayout {
+  display: flex;
+  align-items: flex-start;
+  gap: clamp(2rem, 4vw, 4rem);
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 0 var(--padding-x) 6rem;
+}
+
+.stickyPhotoCol {
+  flex: 1 1 40%;
+  min-width: 0;
+  position: sticky;
+  top: 6rem;
+  align-self: flex-start;
+}
+
+.stickyPhotoWrap {
+  width: 100%;
+  aspect-ratio: 4 / 5;
+  overflow: hidden;
+  position: relative;
+}
+
+.stickyPhotoWrap .photo {
+  max-height: none;
+  height: 100%;
+  position: absolute;
+  inset: 0;
+  animation: stickyPhotoFade 0.6s ease;
+}
+
+@keyframes stickyPhotoFade {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+
+.stickyQuoteCol {
+  flex: 1 1 60%;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+}
+
+.stickyItem {
+  padding: 4rem 0;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.07);
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.stickyItem:first-child {
+  border-top: 1px solid rgba(255, 255, 255, 0.07);
+  padding-top: 0;
+}
+
+.stickyItem:last-child {
+  border-bottom: none;
+}
+
+@media (max-width: 768px) {
+  .stickyLayout {
+    flex-direction: column;
+  }
+
+  .stickyPhotoCol {
+    position: static;
+    flex-basis: auto;
+    width: 100%;
+  }
+
+  .stickyPhotoWrap {
+    aspect-ratio: 16 / 10;
+  }
+}
+
 .empty {
   font-family: var(--font-body);
   font-size: 0.8rem;

--- a/app/(site)/testimonials/_components/TestimonialsList.tsx
+++ b/app/(site)/testimonials/_components/TestimonialsList.tsx
@@ -1,3 +1,6 @@
+'use client'
+
+import { useEffect, useRef, useState } from 'react'
 import Image from 'next/image'
 import styles from './TestimonialsList.module.css'
 
@@ -11,13 +14,112 @@ export type TestimonialItem = {
   photoHeight?: number | null
 }
 
+function TestimonialPhoto({ photoUrl, photoWidth, photoHeight, clientName }: {
+  photoUrl: string
+  photoWidth?: number | null
+  photoHeight?: number | null
+  clientName: string
+}) {
+  return photoWidth && photoHeight ? (
+    <Image
+      src={photoUrl}
+      alt={`${clientName} session`}
+      width={photoWidth}
+      height={photoHeight}
+      sizes="(max-width: 768px) 100vw, 50vw"
+      quality={90}
+      className={styles.photo}
+    />
+  ) : (
+    // eslint-disable-next-line @next/next/no-img-element
+    <img src={photoUrl} alt={`${clientName} session`} className={styles.photo} loading="lazy" />
+  )
+}
+
+// TYN-354: the reference site shows one photo alongside the quotes, and the
+// photo changes to a different couple's photo as you scroll through the next
+// group of testimonials - reusing the existing per-testimonial `photo` field
+// (collections/Testimonials.ts) rather than adding a new grouping concept.
+// Testimonials without their own photo just keep whichever photo was last
+// seen, which is what naturally produces "groups" sharing one photo.
+function StickyScrollTestimonials({ testimonials }: { testimonials: TestimonialItem[] }) {
+  const [activeIndex, setActiveIndex] = useState(0)
+  const itemRefs = useRef<(HTMLElement | null)[]>([])
+
+  useEffect(() => {
+    const observer = new IntersectionObserver(
+      (entries) => {
+        const visible = entries.filter((e) => e.isIntersecting)
+        if (visible.length === 0) return
+        const topMost = visible.reduce((a, b) => (a.boundingClientRect.top < b.boundingClientRect.top ? a : b))
+        const idx = itemRefs.current.findIndex((el) => el === topMost.target)
+        if (idx !== -1) setActiveIndex(idx)
+      },
+      { rootMargin: '-40% 0px -40% 0px', threshold: 0 }
+    )
+    itemRefs.current.forEach((el) => { if (el) observer.observe(el) })
+    return () => observer.disconnect()
+  }, [testimonials.length])
+
+  // Carry the nearest-preceding photo forward so a testimonial without its
+  // own photo doesn't blank the panel out mid-group.
+  let lastPhoto: TestimonialItem | null = null
+  const activePhoto = (() => {
+    for (let i = 0; i <= activeIndex; i++) {
+      if (testimonials[i]?.photoUrl) lastPhoto = testimonials[i]
+    }
+    return lastPhoto
+  })()
+
+  return (
+    <div className={styles.stickyLayout}>
+      <div className={styles.stickyPhotoCol}>
+        <div className={styles.stickyPhotoWrap}>
+          {activePhoto?.photoUrl && (
+            <TestimonialPhoto
+              key={activePhoto.id}
+              photoUrl={activePhoto.photoUrl}
+              photoWidth={activePhoto.photoWidth}
+              photoHeight={activePhoto.photoHeight}
+              clientName={activePhoto.clientName}
+            />
+          )}
+        </div>
+      </div>
+      <div className={styles.stickyQuoteCol}>
+        {testimonials.map((t, i) => (
+          <article
+            key={t.id}
+            ref={(el) => { itemRefs.current[i] = el }}
+            className={styles.stickyItem}
+            aria-label={`Review from ${t.clientName}`}
+          >
+            {t.sessionType && <p className={styles.badge}>{t.sessionType} Testimonial</p>}
+            <cite className={styles.clientName}>{t.clientName}</cite>
+            <blockquote className={styles.quote}>
+              <span className={styles.quoteOpen} aria-hidden="true">&ldquo;</span>
+              {t.quote}
+              <span className={styles.quoteClose} aria-hidden="true">&rdquo;</span>
+            </blockquote>
+          </article>
+        ))}
+      </div>
+    </div>
+  )
+}
+
 // Extracted from the original testimonials/page.tsx inline markup (unchanged
 // behavior, including the empty state) so the same list can be reused by the
 // LiveTestimonials builder block (app/builder/puck.config.tsx) without
-// duplicating markup.
-export default function TestimonialsList({ testimonials }: { testimonials: TestimonialItem[] }) {
+// duplicating markup. `stickyPhotoScroll` is an opt-in layout (TYN-354/338
+// style-exposure convention) - default stays the original per-item layout.
+export default function TestimonialsList({ testimonials, stickyPhotoScroll = false }: { testimonials: TestimonialItem[]; stickyPhotoScroll?: boolean }) {
   if (testimonials.length === 0) {
     return <p className={styles.empty}>Kind words are on their way.</p>
+  }
+
+  if (stickyPhotoScroll) {
+    return <StickyScrollTestimonials testimonials={testimonials} />
   }
 
   return (
@@ -38,25 +140,7 @@ export default function TestimonialsList({ testimonials }: { testimonials: Testi
 
           {t.photoUrl && (
             <div className={styles.photoWrap}>
-              {t.photoWidth && t.photoHeight ? (
-                <Image
-                  src={t.photoUrl}
-                  alt={`${t.clientName} session`}
-                  width={t.photoWidth}
-                  height={t.photoHeight}
-                  sizes="(max-width: 768px) 100vw, 50vw"
-                  quality={90}
-                  className={styles.photo}
-                />
-              ) : (
-                // eslint-disable-next-line @next/next/no-img-element
-                <img
-                  src={t.photoUrl}
-                  alt={`${t.clientName} session`}
-                  className={styles.photo}
-                  loading="lazy"
-                />
-              )}
+              <TestimonialPhoto photoUrl={t.photoUrl} photoWidth={t.photoWidth} photoHeight={t.photoHeight} clientName={t.clientName} />
             </div>
           )}
         </article>

--- a/app/builder/ScrollFadeImage.tsx
+++ b/app/builder/ScrollFadeImage.tsx
@@ -1,0 +1,49 @@
+'use client'
+
+import { useEffect, useRef, useState } from 'react'
+
+// TYN-353: reusable scroll-into-view effect - a photo starts desaturated and
+// faded, then transitions to full color once it scrolls into the viewport.
+// A single shared component so every block's background photo (via Section)
+// gets this for free instead of each block reimplementing it. IntersectionObserver
+// instead of a CSS-only approach because Safari/Firefox don't yet support
+// scroll-driven animations (animation-timeline: view()) broadly enough to rely on.
+export function ScrollFadeImage({ src, alt, style }: { src: string; alt?: string; style?: React.CSSProperties }) {
+  const ref = useRef<HTMLImageElement>(null)
+  const [visible, setVisible] = useState(false)
+
+  useEffect(() => {
+    const el = ref.current
+    if (!el) return
+    if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
+      setVisible(true)
+      return
+    }
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry.isIntersecting) {
+          setVisible(true)
+          observer.disconnect()
+        }
+      },
+      { threshold: 0.15 }
+    )
+    observer.observe(el)
+    return () => observer.disconnect()
+  }, [])
+
+  return (
+    // eslint-disable-next-line @next/next/no-img-element
+    <img
+      ref={ref}
+      src={src}
+      alt={alt ?? ''}
+      style={{
+        ...style,
+        filter: visible ? 'grayscale(0)' : 'grayscale(1)',
+        opacity: visible ? 1 : 0.55,
+        transition: 'filter 1.2s ease, opacity 1.2s ease',
+      }}
+    />
+  )
+}

--- a/app/builder/puck.config.tsx
+++ b/app/builder/puck.config.tsx
@@ -15,6 +15,7 @@ import type { ReactNode } from 'react'
 import type { Config } from '@measured/puck'
 import { ImagePickerField } from './ImagePickerField'
 import { FreeformPhotoCanvasField } from './FreeformPhotoCanvasField'
+import { ScrollFadeImage } from './ScrollFadeImage'
 import { PhotoCarouselBlock } from './PhotoCarouselBlock'
 import CategoryPhotoGrid from '@/app/(site)/portfolio/_components/CategoryPhotoGrid'
 import AlbumGridComponent from '@/app/(site)/portfolio/_components/AlbumGrid'
@@ -134,16 +135,21 @@ const responsiveDefaults = { hideOnMobile: false, hideOnDesktop: false }
 // so every content block has consistent, Pixieset-style design options.
 // backgroundImage/backgroundFade (TYN-305) layer a user-picked, dimmed photo
 // behind the content instead of/under the flat background color.
-function Section({ background, backgroundImage, backgroundFade, spacing, className, children }: { background?: string; backgroundImage?: string; backgroundFade?: string; spacing?: string; className?: string; children?: ReactNode }) {
+function Section({ background, backgroundImage, backgroundFade, scrollFadeIn, spacing, className, children }: { background?: string; backgroundImage?: string; backgroundFade?: string; scrollFadeIn?: boolean; spacing?: string; className?: string; children?: ReactNode }) {
   const padY = SPACING[spacing ?? 'normal'] ?? SPACING.normal
   const bg = background && background !== 'transparent' ? background : undefined
   const fade = backgroundFade ? Number(backgroundFade) : 0.55
+  const bgImageStyle: React.CSSProperties = { position: 'absolute', inset: 0, width: '100%', height: '100%', objectFit: 'cover' }
   return (
     <section className={className} style={{ position: 'relative', background: bg, overflow: backgroundImage ? 'hidden' : undefined }}>
       {backgroundImage && (
         <>
-          {/* eslint-disable-next-line @next/next/no-img-element */}
-          <img src={backgroundImage} alt="" style={{ position: 'absolute', inset: 0, width: '100%', height: '100%', objectFit: 'cover' }} />
+          {scrollFadeIn ? (
+            <ScrollFadeImage src={backgroundImage} style={bgImageStyle} />
+          ) : (
+            // eslint-disable-next-line @next/next/no-img-element
+            <img src={backgroundImage} alt="" style={bgImageStyle} />
+          )}
           <div style={{ position: 'absolute', inset: 0, background: `rgba(12,12,12,${fade})` }} />
         </>
       )}
@@ -345,10 +351,23 @@ const backgroundFadeField = {
     { label: 'Heavy', value: '0.75' },
   ],
 }
+// TYN-353: reusable scroll-triggered fade-in (grayscale to color) for a
+// section's background photo - spread into every block via styleFields, so
+// it's available anywhere a background photo can be set, not tied to one
+// specific block.
+const scrollFadeInField = {
+  type: 'radio' as const,
+  label: 'Photo fade-in on scroll',
+  options: [
+    { label: 'Off', value: false },
+    { label: 'On', value: true },
+  ],
+}
 const styleFields = {
   background: bgField,
   backgroundImage: backgroundImageField,
   backgroundFade: backgroundFadeField,
+  scrollFadeIn: scrollFadeInField,
   spacing: {
     type: 'select' as const,
     label: 'Spacing',
@@ -360,7 +379,7 @@ const styleFields = {
     ],
   },
 }
-const styleDefaults = { background: 'transparent', backgroundImage: '', backgroundFade: '0.55', spacing: 'normal' }
+const styleDefaults = { background: 'transparent', backgroundImage: '', backgroundFade: '0.55', scrollFadeIn: false, spacing: 'normal' }
 
 export const config: Config = {
   root: {
@@ -492,8 +511,8 @@ export const config: Config = {
         ...responsiveFields,
       },
       defaultProps: { eyebrow: 'My Work', heading: 'A Section Heading', subtext: '', align: 'center', ...styleDefaults, ...responsiveDefaults },
-      render: ({ eyebrow, heading, subtext, align, background, backgroundImage, backgroundFade, spacing, hideOnMobile, hideOnDesktop }: any) => (
-        <Section background={background} backgroundImage={backgroundImage} backgroundFade={backgroundFade} spacing={spacing} className={visClass(hideOnMobile, hideOnDesktop)}>
+      render: ({ eyebrow, heading, subtext, align, background, backgroundImage, backgroundFade, scrollFadeIn, spacing, hideOnMobile, hideOnDesktop }: any) => (
+        <Section background={background} backgroundImage={backgroundImage} backgroundFade={backgroundFade} scrollFadeIn={scrollFadeIn} spacing={spacing} className={visClass(hideOnMobile, hideOnDesktop)}>
           <div style={{ textAlign: align, maxWidth: align === 'center' ? '70ch' : undefined, margin: align === 'center' ? '0 auto' : undefined }}>
             {eyebrow && <p style={eyebrowStyle}>{eyebrow}</p>}
             <h2 style={headingStyle()}>{heading}</h2>
@@ -513,8 +532,8 @@ export const config: Config = {
         ...responsiveFields,
       },
       defaultProps: { text: 'Tell your story here.', align: 'left', ...styleDefaults, ...responsiveDefaults },
-      render: ({ text, align, background, backgroundImage, backgroundFade, spacing, hideOnMobile, hideOnDesktop }: any) => (
-        <Section background={background} backgroundImage={backgroundImage} backgroundFade={backgroundFade} spacing={spacing} className={visClass(hideOnMobile, hideOnDesktop)}>
+      render: ({ text, align, background, backgroundImage, backgroundFade, scrollFadeIn, spacing, hideOnMobile, hideOnDesktop }: any) => (
+        <Section background={background} backgroundImage={backgroundImage} backgroundFade={backgroundFade} scrollFadeIn={scrollFadeIn} spacing={spacing} className={visClass(hideOnMobile, hideOnDesktop)}>
           <div style={{ maxWidth: '70ch', margin: align === 'center' ? '0 auto' : undefined, textAlign: align }}>
             <p style={{ color: C.body, fontSize: '1.05rem', lineHeight: 1.8, whiteSpace: 'pre-wrap', margin: 0 }}>{text}</p>
           </div>
@@ -559,8 +578,8 @@ export const config: Config = {
         ...styleDefaults,
         ...responsiveDefaults,
       },
-      render: ({ prefix, phrases, size, align, background, backgroundImage, backgroundFade, spacing, hideOnMobile, hideOnDesktop }: any) => (
-        <Section background={background} backgroundImage={backgroundImage} backgroundFade={backgroundFade} spacing={spacing} className={visClass(hideOnMobile, hideOnDesktop)}>
+      render: ({ prefix, phrases, size, align, background, backgroundImage, backgroundFade, scrollFadeIn, spacing, hideOnMobile, hideOnDesktop }: any) => (
+        <Section background={background} backgroundImage={backgroundImage} backgroundFade={backgroundFade} scrollFadeIn={scrollFadeIn} spacing={spacing} className={visClass(hideOnMobile, hideOnDesktop)}>
           <p style={{ ...headingStyle(size), textAlign: align, maxWidth: align === 'center' ? '70ch' : undefined, margin: align === 'center' ? '0 auto' : 0 }}>
             {prefix}
             <TypewriterText phrases={(phrases ?? []).map((p: any) => p.text).filter(Boolean)} />
@@ -593,6 +612,7 @@ export const config: Config = {
         buttonText: { type: 'text', label: 'Button text (optional)' },
         buttonHref: { type: 'text', label: 'Button link' },
         background: bgField,
+        scrollFadeIn: scrollFadeInField,
         ...responsiveFields,
       },
       defaultProps: {
@@ -605,9 +625,10 @@ export const config: Config = {
         buttonText: '',
         buttonHref: '',
         background: 'transparent',
+        scrollFadeIn: false,
         ...responsiveDefaults,
       },
-      render: ({ layout, imageUrl, imagePosition, eyebrow, heading, body, buttonText, buttonHref, background, hideOnMobile, hideOnDesktop }: any) => {
+      render: ({ layout, imageUrl, imagePosition, eyebrow, heading, body, buttonText, buttonHref, background, scrollFadeIn, hideOnMobile, hideOnDesktop }: any) => {
         const bg = background && background !== 'transparent' ? background : undefined
         const cls = visClass(hideOnMobile, hideOnDesktop)
 
@@ -615,8 +636,12 @@ export const config: Config = {
           return (
             <section className={cls} style={{ position: 'relative', minHeight: '50vh', display: 'flex', alignItems: 'flex-end', overflow: 'hidden' }}>
               {imageUrl ? (
-                // eslint-disable-next-line @next/next/no-img-element
-                <img src={imageUrl} alt="" style={{ position: 'absolute', inset: 0, width: '100%', height: '100%', objectFit: 'cover' }} />
+                scrollFadeIn ? (
+                  <ScrollFadeImage src={imageUrl} style={{ position: 'absolute', inset: 0, width: '100%', height: '100%', objectFit: 'cover' }} />
+                ) : (
+                  // eslint-disable-next-line @next/next/no-img-element
+                  <img src={imageUrl} alt="" style={{ position: 'absolute', inset: 0, width: '100%', height: '100%', objectFit: 'cover' }} />
+                )
               ) : (
                 <div style={{ position: 'absolute', inset: 0, background: C.accent }} />
               )}
@@ -636,8 +661,12 @@ export const config: Config = {
             <section className={cls} style={{ background: bg }}>
               <div style={{ minHeight: '280px', position: 'relative', background: C.accent }}>
                 {imageUrl && (
-                  // eslint-disable-next-line @next/next/no-img-element
-                  <img src={imageUrl} alt="" style={{ width: '100%', height: '100%', maxHeight: '55vh', objectFit: 'cover', display: 'block' }} />
+                  scrollFadeIn ? (
+                    <ScrollFadeImage src={imageUrl} style={{ width: '100%', height: '100%', maxHeight: '55vh', objectFit: 'cover', display: 'block' }} />
+                  ) : (
+                    // eslint-disable-next-line @next/next/no-img-element
+                    <img src={imageUrl} alt="" style={{ width: '100%', height: '100%', maxHeight: '55vh', objectFit: 'cover', display: 'block' }} />
+                  )
                 )}
               </div>
               <div style={{ padding: 'clamp(2rem,4vw,3.5rem)', textAlign: 'center', maxWidth: '65ch', margin: '0 auto' }}>
@@ -653,8 +682,12 @@ export const config: Config = {
         const img = (
           <div style={{ flex: '1 1 340px', minHeight: '320px', position: 'relative', background: C.accent }}>
             {imageUrl && (
-              // eslint-disable-next-line @next/next/no-img-element
-              <img src={imageUrl} alt="" style={{ position: 'absolute', inset: 0, width: '100%', height: '100%', objectFit: 'cover' }} />
+              scrollFadeIn ? (
+                <ScrollFadeImage src={imageUrl} style={{ position: 'absolute', inset: 0, width: '100%', height: '100%', objectFit: 'cover' }} />
+              ) : (
+                // eslint-disable-next-line @next/next/no-img-element
+                <img src={imageUrl} alt="" style={{ position: 'absolute', inset: 0, width: '100%', height: '100%', objectFit: 'cover' }} />
+              )
             )}
           </div>
         )
@@ -702,8 +735,8 @@ export const config: Config = {
         ...styleDefaults,
         ...responsiveDefaults,
       },
-      render: ({ heading, items, background, backgroundImage, backgroundFade, spacing, hideOnMobile, hideOnDesktop }: any) => (
-        <Section background={background} backgroundImage={backgroundImage} backgroundFade={backgroundFade} spacing={spacing} className={visClass(hideOnMobile, hideOnDesktop)}>
+      render: ({ heading, items, background, backgroundImage, backgroundFade, scrollFadeIn, spacing, hideOnMobile, hideOnDesktop }: any) => (
+        <Section background={background} backgroundImage={backgroundImage} backgroundFade={backgroundFade} scrollFadeIn={scrollFadeIn} spacing={spacing} className={visClass(hideOnMobile, hideOnDesktop)}>
           {heading && <h2 style={{ ...headingStyle(), textAlign: 'center', marginBottom: '2.5rem' }}>{heading}</h2>}
           <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(260px, 1fr))', gap: '1rem', maxWidth: '1100px', margin: '0 auto' }}>
             {(items ?? []).map((it: any, i: number) => (
@@ -747,8 +780,8 @@ export const config: Config = {
           return { props: { resolvedServices: [] } }
         }
       },
-      render: ({ resolvedServices, background, backgroundImage, backgroundFade, spacing, hideOnMobile, hideOnDesktop }: any) => (
-        <Section background={background} backgroundImage={backgroundImage} backgroundFade={backgroundFade} spacing={spacing} className={visClass(hideOnMobile, hideOnDesktop)}>
+      render: ({ resolvedServices, background, backgroundImage, backgroundFade, scrollFadeIn, spacing, hideOnMobile, hideOnDesktop }: any) => (
+        <Section background={background} backgroundImage={backgroundImage} backgroundFade={backgroundFade} scrollFadeIn={scrollFadeIn} spacing={spacing} className={visClass(hideOnMobile, hideOnDesktop)}>
           <ServicesGridComponent services={resolvedServices ?? []} />
         </Section>
       ),
@@ -781,8 +814,8 @@ export const config: Config = {
         spacing: 'normal',
         ...responsiveDefaults,
       },
-      render: ({ heading, items, background, backgroundImage, backgroundFade, spacing, hideOnMobile, hideOnDesktop }: any) => (
-        <Section background={background} backgroundImage={backgroundImage} backgroundFade={backgroundFade} spacing={spacing} className={visClass(hideOnMobile, hideOnDesktop)}>
+      render: ({ heading, items, background, backgroundImage, backgroundFade, scrollFadeIn, spacing, hideOnMobile, hideOnDesktop }: any) => (
+        <Section background={background} backgroundImage={backgroundImage} backgroundFade={backgroundFade} scrollFadeIn={scrollFadeIn} spacing={spacing} className={visClass(hideOnMobile, hideOnDesktop)}>
           {heading && <h2 style={{ ...headingStyle(), textAlign: 'center', marginBottom: '2.5rem' }}>{heading}</h2>}
           <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(280px, 1fr))', gap: '1.25rem', maxWidth: '1100px', margin: '0 auto' }}>
             {(items ?? []).map((it: any, i: number) => (
@@ -807,10 +840,22 @@ export const config: Config = {
     LiveTestimonials: {
       label: 'Testimonials (Live)',
       fields: {
+        // TYN-354: reference site pairs a sticky photo panel with the quote
+        // list, swapping photos as different testimonials scroll into view.
+        // Opt-in (TYN-338 style-exposure convention) - default keeps the
+        // original per-item layout already shipped on /testimonials.
+        stickyPhotoScroll: {
+          type: 'radio' as const,
+          label: 'Layout',
+          options: [
+            { label: 'Photo beside each quote', value: false },
+            { label: 'Sticky photo, changes on scroll', value: true },
+          ],
+        },
         ...styleFields,
         ...responsiveFields,
       },
-      defaultProps: { ...styleDefaults, ...responsiveDefaults },
+      defaultProps: { stickyPhotoScroll: false, ...styleDefaults, ...responsiveDefaults },
       resolveData: async () => {
         const base = typeof window === 'undefined' ? 'https://tynnellhollinsphotography.com' : ''
         try {
@@ -822,9 +867,9 @@ export const config: Config = {
           return { props: { resolvedTestimonials: [] } }
         }
       },
-      render: ({ resolvedTestimonials, background, backgroundImage, backgroundFade, spacing, hideOnMobile, hideOnDesktop }: any) => (
-        <Section background={background} backgroundImage={backgroundImage} backgroundFade={backgroundFade} spacing={spacing} className={visClass(hideOnMobile, hideOnDesktop)}>
-          <TestimonialsListComponent testimonials={resolvedTestimonials ?? []} />
+      render: ({ resolvedTestimonials, stickyPhotoScroll, background, backgroundImage, backgroundFade, scrollFadeIn, spacing, hideOnMobile, hideOnDesktop }: any) => (
+        <Section background={background} backgroundImage={backgroundImage} backgroundFade={backgroundFade} scrollFadeIn={scrollFadeIn} spacing={spacing} className={visClass(hideOnMobile, hideOnDesktop)}>
+          <TestimonialsListComponent testimonials={resolvedTestimonials ?? []} stickyPhotoScroll={stickyPhotoScroll} />
         </Section>
       ),
     },
@@ -855,8 +900,8 @@ export const config: Config = {
         ...styleDefaults,
         ...responsiveDefaults,
       },
-      render: ({ heading, items, background, backgroundImage, backgroundFade, spacing, hideOnMobile, hideOnDesktop }: any) => (
-        <Section background={background} backgroundImage={backgroundImage} backgroundFade={backgroundFade} spacing={spacing} className={visClass(hideOnMobile, hideOnDesktop)}>
+      render: ({ heading, items, background, backgroundImage, backgroundFade, scrollFadeIn, spacing, hideOnMobile, hideOnDesktop }: any) => (
+        <Section background={background} backgroundImage={backgroundImage} backgroundFade={backgroundFade} scrollFadeIn={scrollFadeIn} spacing={spacing} className={visClass(hideOnMobile, hideOnDesktop)}>
           {heading && <h2 style={{ ...headingStyle(), textAlign: 'center', marginBottom: '2rem' }}>{heading}</h2>}
           <AccordionBlock items={items ?? []} />
         </Section>
@@ -895,8 +940,8 @@ export const config: Config = {
           return { props: {} }
         }
       },
-      render: ({ eyebrow, heading, subtext, resolvedMinDate, resolvedMaxDate, background, backgroundImage, backgroundFade, spacing, hideOnMobile, hideOnDesktop }: any) => (
-        <Section background={background} backgroundImage={backgroundImage} backgroundFade={backgroundFade} spacing={spacing} className={visClass(hideOnMobile, hideOnDesktop)}>
+      render: ({ eyebrow, heading, subtext, resolvedMinDate, resolvedMaxDate, background, backgroundImage, backgroundFade, scrollFadeIn, spacing, hideOnMobile, hideOnDesktop }: any) => (
+        <Section background={background} backgroundImage={backgroundImage} backgroundFade={backgroundFade} scrollFadeIn={scrollFadeIn} spacing={spacing} className={visClass(hideOnMobile, hideOnDesktop)}>
           <div style={{ maxWidth: '640px', margin: '0 auto' }}>
             {eyebrow && <p style={{ ...eyebrowStyle, textAlign: 'center' }}>{eyebrow}</p>}
             {heading && <h2 style={{ ...headingStyle('clamp(1.5rem,3vw,2.4rem)'), textAlign: 'center' }}>{heading}</h2>}
@@ -926,8 +971,8 @@ export const config: Config = {
         spacing: 'spacious',
         ...responsiveDefaults,
       },
-      render: ({ heading, subtext, buttonText, buttonHref, background, backgroundImage, backgroundFade, spacing, hideOnMobile, hideOnDesktop }: any) => (
-        <Section background={background} backgroundImage={backgroundImage} backgroundFade={backgroundFade} spacing={spacing} className={visClass(hideOnMobile, hideOnDesktop)}>
+      render: ({ heading, subtext, buttonText, buttonHref, background, backgroundImage, backgroundFade, scrollFadeIn, spacing, hideOnMobile, hideOnDesktop }: any) => (
+        <Section background={background} backgroundImage={backgroundImage} backgroundFade={backgroundFade} scrollFadeIn={scrollFadeIn} spacing={spacing} className={visClass(hideOnMobile, hideOnDesktop)}>
           <div style={{ textAlign: 'center' }}>
             <h2 style={headingStyle('clamp(1.5rem,3vw,2.5rem)')}>{heading}</h2>
             {subtext && <p style={{ marginTop: '0.85rem', color: C.detail, maxWidth: '60ch', margin: '0.85rem auto 0' }}>{subtext}</p>}
@@ -1113,8 +1158,8 @@ export const config: Config = {
           return { props: { resolvedPhotos: [] } }
         }
       },
-      render: ({ resolvedPhotos, background, backgroundImage, backgroundFade, spacing, hideOnMobile, hideOnDesktop }: any) => (
-        <Section background={background} backgroundImage={backgroundImage} backgroundFade={backgroundFade} spacing={spacing} className={visClass(hideOnMobile, hideOnDesktop)}>
+      render: ({ resolvedPhotos, background, backgroundImage, backgroundFade, scrollFadeIn, spacing, hideOnMobile, hideOnDesktop }: any) => (
+        <Section background={background} backgroundImage={backgroundImage} backgroundFade={backgroundFade} scrollFadeIn={scrollFadeIn} spacing={spacing} className={visClass(hideOnMobile, hideOnDesktop)}>
           <CategoryPhotoGrid photos={resolvedPhotos ?? []} />
         </Section>
       ),
@@ -1160,8 +1205,8 @@ export const config: Config = {
           return { props: { resolvedAlbums: [] } }
         }
       },
-      render: ({ resolvedAlbums, background, backgroundImage, backgroundFade, spacing, hideOnMobile, hideOnDesktop }: any) => (
-        <Section background={background} backgroundImage={backgroundImage} backgroundFade={backgroundFade} spacing={spacing} className={visClass(hideOnMobile, hideOnDesktop)}>
+      render: ({ resolvedAlbums, background, backgroundImage, backgroundFade, scrollFadeIn, spacing, hideOnMobile, hideOnDesktop }: any) => (
+        <Section background={background} backgroundImage={backgroundImage} backgroundFade={backgroundFade} scrollFadeIn={scrollFadeIn} spacing={spacing} className={visClass(hideOnMobile, hideOnDesktop)}>
           <AlbumGridComponent albums={resolvedAlbums ?? []} />
         </Section>
       ),
@@ -1195,8 +1240,8 @@ export const config: Config = {
           return { props: { resolvedPosts: [], resolvedCategories: [] } }
         }
       },
-      render: ({ resolvedPosts, resolvedCategories, background, backgroundImage, backgroundFade, spacing, hideOnMobile, hideOnDesktop }: any) => (
-        <Section background={background} backgroundImage={backgroundImage} backgroundFade={backgroundFade} spacing={spacing} className={visClass(hideOnMobile, hideOnDesktop)}>
+      render: ({ resolvedPosts, resolvedCategories, background, backgroundImage, backgroundFade, scrollFadeIn, spacing, hideOnMobile, hideOnDesktop }: any) => (
+        <Section background={background} backgroundImage={backgroundImage} backgroundFade={backgroundFade} scrollFadeIn={scrollFadeIn} spacing={spacing} className={visClass(hideOnMobile, hideOnDesktop)}>
           <BlogClientComponent posts={resolvedPosts ?? []} categories={resolvedCategories ?? []} />
         </Section>
       ),
@@ -1218,10 +1263,10 @@ export const config: Config = {
         ...responsiveFields,
       },
       defaultProps: { heading: '', images: [], ...styleDefaults, ...responsiveDefaults },
-      render: ({ heading, images, background, backgroundImage, backgroundFade, spacing, hideOnMobile, hideOnDesktop }: any) => {
+      render: ({ heading, images, background, backgroundImage, backgroundFade, scrollFadeIn, spacing, hideOnMobile, hideOnDesktop }: any) => {
         const valid = (images ?? []).filter((i: any) => i?.url)
         return (
-          <Section background={background} backgroundImage={backgroundImage} backgroundFade={backgroundFade} spacing={spacing} className={visClass(hideOnMobile, hideOnDesktop)}>
+          <Section background={background} backgroundImage={backgroundImage} backgroundFade={backgroundFade} scrollFadeIn={scrollFadeIn} spacing={spacing} className={visClass(hideOnMobile, hideOnDesktop)}>
             {heading && <h2 style={{ ...headingStyle(), textAlign: 'center', marginBottom: '1.5rem' }}>{heading}</h2>}
             {valid.length === 0 ? (
               <p style={{ color: C.detail, textAlign: 'center' }}>Add photos to populate the carousel.</p>
@@ -1323,10 +1368,10 @@ export const config: Config = {
         ...responsiveFields,
       },
       defaultProps: { photos: [], canvasHeight: '65vh', ...styleDefaults, ...responsiveDefaults },
-      render: ({ photos, canvasHeight, background, backgroundImage, backgroundFade, spacing, hideOnMobile, hideOnDesktop }: any) => {
+      render: ({ photos, canvasHeight, background, backgroundImage, backgroundFade, scrollFadeIn, spacing, hideOnMobile, hideOnDesktop }: any) => {
         const valid = (photos ?? []).filter((p: any) => p?.url)
         return (
-          <Section background={background} backgroundImage={backgroundImage} backgroundFade={backgroundFade} spacing={spacing} className={visClass(hideOnMobile, hideOnDesktop)}>
+          <Section background={background} backgroundImage={backgroundImage} backgroundFade={backgroundFade} scrollFadeIn={scrollFadeIn} spacing={spacing} className={visClass(hideOnMobile, hideOnDesktop)}>
             <div style={{ position: 'relative', width: '100%', height: canvasHeight }}>
               {valid.length === 0 ? (
                 <p style={{ color: C.detail, textAlign: 'center' }}>Add photos in the Fields panel, then drag them into place.</p>
@@ -1711,8 +1756,8 @@ export const config: Config = {
         ...styleDefaults,
         ...responsiveDefaults,
       },
-      render: ({ heading, address, height, background, backgroundImage, backgroundFade, spacing, hideOnMobile, hideOnDesktop }: any) => (
-        <Section background={background} backgroundImage={backgroundImage} backgroundFade={backgroundFade} spacing={spacing} className={visClass(hideOnMobile, hideOnDesktop)}>
+      render: ({ heading, address, height, background, backgroundImage, backgroundFade, scrollFadeIn, spacing, hideOnMobile, hideOnDesktop }: any) => (
+        <Section background={background} backgroundImage={backgroundImage} backgroundFade={backgroundFade} scrollFadeIn={scrollFadeIn} spacing={spacing} className={visClass(hideOnMobile, hideOnDesktop)}>
           {heading && <h2 style={{ ...headingStyle(), textAlign: 'center', marginBottom: '1.5rem' }}>{heading}</h2>}
           <div style={{ position: 'relative', width: '100%', height }}>
             {address ? (
@@ -1764,8 +1809,8 @@ export const config: Config = {
         ...styleDefaults,
         ...responsiveDefaults,
       },
-      render: ({ heading, embedUrl, height, background, backgroundImage, backgroundFade, spacing, hideOnMobile, hideOnDesktop }: any) => (
-        <Section background={background} backgroundImage={backgroundImage} backgroundFade={backgroundFade} spacing={spacing} className={visClass(hideOnMobile, hideOnDesktop)}>
+      render: ({ heading, embedUrl, height, background, backgroundImage, backgroundFade, scrollFadeIn, spacing, hideOnMobile, hideOnDesktop }: any) => (
+        <Section background={background} backgroundImage={backgroundImage} backgroundFade={backgroundFade} scrollFadeIn={scrollFadeIn} spacing={spacing} className={visClass(hideOnMobile, hideOnDesktop)}>
           {heading && <h2 style={{ ...headingStyle(), textAlign: 'center', marginBottom: '1.5rem' }}>{heading}</h2>}
           <div style={{ position: 'relative', width: '100%', height }}>
             {embedUrl ? (
@@ -1822,8 +1867,8 @@ export const config: Config = {
         ...styleDefaults,
         ...responsiveDefaults,
       },
-      render: ({ heading, embedUrl, height, background, backgroundImage, backgroundFade, spacing, hideOnMobile, hideOnDesktop }: any) => (
-        <Section background={background} backgroundImage={backgroundImage} backgroundFade={backgroundFade} spacing={spacing} className={visClass(hideOnMobile, hideOnDesktop)}>
+      render: ({ heading, embedUrl, height, background, backgroundImage, backgroundFade, scrollFadeIn, spacing, hideOnMobile, hideOnDesktop }: any) => (
+        <Section background={background} backgroundImage={backgroundImage} backgroundFade={backgroundFade} scrollFadeIn={scrollFadeIn} spacing={spacing} className={visClass(hideOnMobile, hideOnDesktop)}>
           {heading && <h2 style={{ ...headingStyle(), textAlign: 'center', marginBottom: '1.5rem' }}>{heading}</h2>}
           <div style={{ position: 'relative', width: '100%', height }}>
             {embedUrl ? (


### PR DESCRIPTION
## Summary
- **TYN-353**: new `ScrollFadeImage` component (IntersectionObserver, respects `prefers-reduced-motion`) - a photo starts grayscale/faded, transitions to full color on scroll into view. Wired as a "Photo fade-in on scroll" toggle into the shared `Section` wrapper's background photo (available on every block that has one) and into `SplitImageText`'s own photo across all 3 layout variants.
- **TYN-354**: `TestimonialsList` gets an opt-in `stickyPhotoScroll` layout - a sticky photo panel that swaps to match whichever testimonial is centered in the viewport, using the existing per-testimonial `photo` field. Carries the last-seen photo forward so quotes without their own photo don't blank the panel, producing the reference site's "groups share one photo" behavior. Exposed as a Layout radio on the Testimonials (Live) block; original per-item layout stays the default.

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] Verified against a local production build: toggled scroll fade-in on a Split Image + Text photo, confirmed initial `grayscale(1)`/`opacity(0.55)` + transition
- [x] Confirmed the sticky-scroll CSS classes compiled into the bundle
- [ ] Sticky-scroll layout with real testimonial data - blocked locally by the documented resolveData/local-network limitation (same as every other Live* block this session); verify against production once deployed