### PR TITLE
feat(about): click-to-reveal photo per session-type item (TYN-345)

### DIFF
--- a/app/(site)/about/SpecialtyReveal.tsx
+++ b/app/(site)/about/SpecialtyReveal.tsx
@@ -1,0 +1,51 @@
+'use client'
+
+import { useState } from 'react'
+import styles from './page.module.css'
+
+export type SpecialtyItem = {
+  heading: string
+  body?: string
+  photoUrl?: string | null
+}
+
+// TYN-345: clicking (or hovering, for mouse users) a session-type item
+// transitions the panel to a matching photo. Keyboard/touch users get the
+// same result via click, since hover isn't reliably available to them.
+export default function SpecialtyReveal({ items }: { items: SpecialtyItem[] }) {
+  const firstWithPhoto = items.findIndex((i) => i.photoUrl)
+  const [activeIndex, setActiveIndex] = useState(firstWithPhoto === -1 ? 0 : firstWithPhoto)
+  const active = items[activeIndex]
+
+  return (
+    <>
+      <div className={styles.specialtyPhotoPanel} aria-hidden={!active?.photoUrl}>
+        {active?.photoUrl && (
+          // eslint-disable-next-line @next/next/no-img-element
+          <img key={active.photoUrl} src={active.photoUrl} alt="" className={styles.specialtyPhoto} />
+        )}
+      </div>
+      <ul className={styles.specialtyList}>
+        {items.map((item, i) => (
+          <li key={item.heading} className={styles.specialtyItem}>
+            <button
+              type="button"
+              className={styles.specialtyButton}
+              onClick={() => item.photoUrl && setActiveIndex(i)}
+              onMouseEnter={() => item.photoUrl && setActiveIndex(i)}
+              aria-pressed={activeIndex === i}
+            >
+              <span className={styles.specialtyDot} aria-hidden="true" />
+              <span className={styles.specialtyContent}>
+                <span className={styles.specialtyHeading}>{item.heading}</span>
+                {item.body && (
+                  <span className={styles.specialtyBody}>{item.body}</span>
+                )}
+              </span>
+            </button>
+          </li>
+        ))}
+      </ul>
+    </>
+  )
+}

--- a/app/(site)/about/page.module.css
+++ b/app/(site)/about/page.module.css
@@ -268,7 +268,49 @@
 .specialtyItem {
   display: flex;
   align-items: flex-start;
+}
+
+/* TYN-345: click/hover to reveal a matching photo in .specialtyPhotoPanel */
+.specialtyButton {
+  display: flex;
+  align-items: flex-start;
   gap: 0.75rem;
+  width: 100%;
+  background: none;
+  border: none;
+  padding: 0;
+  margin: 0;
+  text-align: left;
+  cursor: pointer;
+  font: inherit;
+  color: inherit;
+}
+
+.specialtyPhotoPanel {
+  /* grid-row deliberately unset - auto-placement puts this in the first free
+     row of column 1 (below sectionHeading), and the list in column 2 keeps
+     sharing sectionHeading's row, since DOM order here is heading, this
+     panel, then the list. */
+  grid-column: 1;
+  margin-top: 1.5rem;
+  aspect-ratio: 4 / 5;
+  position: relative;
+  overflow: hidden;
+  background: var(--color-bg-accent);
+}
+
+.specialtyPhoto {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  animation: specialtyPhotoFade 0.5s ease;
+}
+
+@keyframes specialtyPhotoFade {
+  from { opacity: 0; }
+  to { opacity: 1; }
 }
 
 .specialtyDot {

--- a/app/(site)/about/page.tsx
+++ b/app/(site)/about/page.tsx
@@ -12,6 +12,7 @@ import { config as puckConfig } from '@/app/builder/puck.config'
 import type { Photo } from '@/payload-types'
 import JsonLd from '@/app/components/JsonLd/JsonLd'
 import { isPreviewMode } from '@/app/lib/builderPreview'
+import SpecialtyReveal from './SpecialtyReveal'
 import styles from './page.module.css'
 
 // About content rarely changes - revalidate every 2 minutes
@@ -20,6 +21,32 @@ export const revalidate = 120
 const getAboutData = cache(async () => {
   const payload = await getPayload({ config })
   return payload.findGlobal({ slug: 'about-page', depth: 1 })
+})
+
+// The DEFAULT_VALUES fallback has no photo of its own - fetch one representative
+// photo per matching category (same "featured, else most recent" pattern
+// portfolio/page.tsx already uses for its category tiles) so the click-to-reveal
+// interaction (TYN-345) isn't empty before Tynnell has entered her own values.
+const resolveFallbackSpecialtyPhotos = cache(async (): Promise<AboutValue[]> => {
+  const payload = await getPayload({ config })
+  return Promise.all(
+    DEFAULT_VALUES.map(async (value) => {
+      const category = FALLBACK_CATEGORY_BY_HEADING[value.heading]
+      if (!category) return value
+      const { docs: featured } = await payload.find({
+        collection: 'photos',
+        where: { and: [{ category: { equals: category } }, { featured: { equals: true } }] },
+        sort: '-updatedAt',
+        limit: 1,
+        depth: 0,
+      })
+      const photo = featured[0] ?? (
+        await payload.find({ collection: 'photos', where: { category: { equals: category } }, sort: 'displayOrder', limit: 1, depth: 0 })
+      ).docs[0]
+      const p = photo as Photo | undefined
+      return { ...value, photoUrl: p?.sizes?.card?.url ?? p?.url ?? null }
+    })
+  )
 })
 
 // A builder page can be promoted to replace this real route (same idea as
@@ -64,6 +91,7 @@ export async function generateMetadata(): Promise<Metadata> {
 type AboutValue = {
   heading: string
   body?: string
+  photoUrl?: string | null
 }
 
 const DEFAULT_VALUES: AboutValue[] = [
@@ -74,6 +102,17 @@ const DEFAULT_VALUES: AboutValue[] = [
   { heading: 'Maternity' },
   { heading: 'Events' },
 ]
+
+// TYN-345: the fallback list above has no photo field of its own (unlike
+// about.values, which now carries an optional `photo` per item) - these
+// headings happen to line up with real Photos categories, so the fallback
+// state still gets a representative photo per item instead of shipping
+// with the click-to-reveal interaction visibly doing nothing.
+const FALLBACK_CATEGORY_BY_HEADING: Record<string, string> = {
+  Weddings: 'weddings',
+  Portraits: 'portraits',
+  'Family Sessions': 'families',
+}
 
 // Static Person schema used for the promoted (Puck) branch - deliberately not
 // derived from the about-page global or any Puck block props (no "schema-
@@ -121,10 +160,16 @@ export default async function AboutPage() {
   const headshotHeroUrl = headshotPhoto?.sizes?.hero?.url ?? headshotPhoto?.url ?? null
   const headshotUrl = headshotPhoto?.sizes?.card?.url ?? headshotPhoto?.url ?? null
 
-  type RawValue = { heading?: string | null; body?: string | null }
+  type RawValue = { heading?: string | null; body?: string | null; photo?: Photo | number | null }
   const specialties: AboutValue[] = about?.values?.length
-    ? about.values.map((v: RawValue) => ({ heading: v.heading ?? '', body: v.body ?? undefined }))
-    : DEFAULT_VALUES
+    ? about.values.map((v: RawValue) => ({
+        heading: v.heading ?? '',
+        body: v.body ?? undefined,
+        photoUrl: typeof v.photo === 'object' && v.photo !== null
+          ? (v.photo.sizes?.card?.url ?? v.photo.url ?? null)
+          : null,
+      }))
+    : await resolveFallbackSpecialtyPhotos()
 
   const personSchema = {
     '@context': 'https://schema.org',
@@ -237,19 +282,7 @@ export default async function AboutPage() {
         <h2 className={styles.sectionHeading}>
           {"Capturing Life’s Most"}<br />Meaningful Moments
         </h2>
-        <ul className={styles.specialtyList}>
-          {specialties.map((item) => (
-            <li key={item.heading} className={styles.specialtyItem}>
-              <span className={styles.specialtyDot} aria-hidden="true" />
-              <span className={styles.specialtyContent}>
-                <span className={styles.specialtyHeading}>{item.heading}</span>
-                {item.body && (
-                  <span className={styles.specialtyBody}>{item.body}</span>
-                )}
-              </span>
-            </li>
-          ))}
-        </ul>
+        <SpecialtyReveal items={specialties} />
       </section>
 
       {/* CTA */}

--- a/globals/AboutPage.ts
+++ b/globals/AboutPage.ts
@@ -117,6 +117,18 @@ export const AboutPage: GlobalConfig = {
             rows: 2,
           },
         },
+        {
+          // TYN-345: clicking/hovering this item on the About page transitions
+          // a photo panel to show this photo, if set. Optional - items without
+          // one simply don't change the panel when clicked.
+          name: 'photo',
+          type: 'upload',
+          relationTo: 'photos',
+          label: 'Photo (optional)',
+          admin: {
+            description: 'Shown when a visitor clicks or hovers this item on your About page.',
+          },
+        },
       ],
     },
   ],

--- a/payload-types.ts
+++ b/payload-types.ts
@@ -999,6 +999,10 @@ export interface AboutPage {
          * A sentence or two describing what this value means to you.
          */
         body?: string | null;
+        /**
+         * Shown when a visitor clicks or hovers this item on your About page.
+         */
+        photo?: (number | null) | Photo;
         id?: string | null;
       }[]
     | null;
@@ -1221,6 +1225,7 @@ export interface AboutPageSelect<T extends boolean = true> {
     | {
         heading?: T;
         body?: T;
+        photo?: T;
         id?: T;
       };
   updatedAt?: T;

--- a/scripts/migrate-db.mjs
+++ b/scripts/migrate-db.mjs
@@ -803,6 +803,33 @@ async function run() {
 
     await client.query(`ALTER TYPE "enum_pages_promoted_route" ADD VALUE IF NOT EXISTS 'blog'`)
     console.log('✓ enum_pages_promoted_route has blog')
+
+    // ------------------------------------------------------------------
+    // Migration 20260723_100000: about_page_values.photo_id column (TYN-345)
+    // Lets each About page "value"/specialty item carry an optional photo,
+    // shown when a visitor clicks or hovers that item. FK set null on
+    // delete so removing a photo from the library doesn't break the row.
+    // ------------------------------------------------------------------
+
+    await client.query(`
+      ALTER TABLE "about_page_values" ADD COLUMN IF NOT EXISTS "photo_id" integer
+    `)
+    await client.query(`
+      DO $$ BEGIN
+        ALTER TABLE "about_page_values"
+          ADD CONSTRAINT "about_page_values_photo_id_fk"
+          FOREIGN KEY ("photo_id")
+          REFERENCES "photos"("id")
+          ON DELETE SET NULL;
+      EXCEPTION
+        WHEN duplicate_object THEN NULL;
+      END $$;
+    `)
+    await client.query(`
+      CREATE INDEX IF NOT EXISTS "about_page_values_photo_idx"
+        ON "about_page_values" USING btree ("photo_id")
+    `)
+    console.log('✓ about_page_values.photo_id column ready')
   } finally {
     client.release()
     await pool.end()


### PR DESCRIPTION
## Summary
- The "What I Shoot" list on the About page (Weddings/Engagements/Portraits/Family Sessions/Maternity/Events) was plain static text - no click/hover interaction.
- Adds an optional `photo` field to each item in `AboutPage.values` (Tynnell can pick a photo per item). New `SpecialtyReveal` client component renders the list + a photo panel in the section's existing left column; clicking/hovering an item with a photo crossfades the panel to it.
- The live site currently falls back to a hardcoded `DEFAULT_VALUES` list (Tynnell hasn't entered her own values yet) - those get a representative photo auto-matched by category (Weddings/Portraits/Family Sessions match real Photos categories; Engagements/Maternity/Events don't and stay photo-less) using the same "featured, else most recent" pattern `portfolio/page.tsx` already uses.
- DB migration adds `about_page_values.photo_id` (nullable FK) - runs automatically via `vercel.json`'s buildCommand pre-build step on deploy, not run manually (blocked by the auto-mode safety classifier, correctly, since it's a schema change against the shared production DB).
- `payload-types.ts` hand-patched since `generate:types` is currently broken on this machine (`T.registerHooks is not a function`, an unrelated tsx/Node compatibility issue).

## Test plan
- [x] `npx tsc --noEmit` clean
- [ ] Local production build - blocked by the same missing-column error until the migration runs (only happens automatically on deploy); verify the live interaction on production after merge