### PR TITLE
feat(builder): add Session Types click-to-reveal Puck block (TYN-345)

### DIFF
--- a/app/builder/SpecialtiesRevealBlock.tsx
+++ b/app/builder/SpecialtiesRevealBlock.tsx
@@ -1,0 +1,72 @@
+'use client'
+
+import { useState } from 'react'
+
+export type SpecialtyRevealItem = {
+  heading?: string
+  body?: string
+  photo?: string
+}
+
+// TYN-345: click (or hover, for mouse users) a list item to crossfade a photo
+// panel to match it. Puck-block version of app/(site)/about/SpecialtyReveal.tsx -
+// that one is styled via the About page's own CSS module, which isn't usable
+// here since this block also has to render identically in the Puck editor
+// canvas; this uses the same inline-style convention as every other block in
+// puck.config.tsx instead.
+export function SpecialtiesRevealBlock({
+  items, bodyColor, detailColor, bodyFont,
+}: {
+  items: SpecialtyRevealItem[]
+  bodyColor: string
+  detailColor: string
+  bodyFont: string
+}) {
+  const valid = (items ?? []).filter((i) => i?.heading)
+  const firstWithPhoto = valid.findIndex((i) => i.photo)
+  const [activeIndex, setActiveIndex] = useState(firstWithPhoto === -1 ? 0 : firstWithPhoto)
+  const active = valid[activeIndex]
+
+  if (valid.length === 0) return null
+
+  return (
+    <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: '3rem', alignItems: 'start' }}>
+      <div style={{ position: 'relative', aspectRatio: '4 / 5', overflow: 'hidden', background: 'rgba(255,255,255,0.04)' }}>
+        {active?.photo && (
+          // eslint-disable-next-line @next/next/no-img-element
+          <img
+            key={active.photo}
+            src={active.photo}
+            alt=""
+            style={{ position: 'absolute', inset: 0, width: '100%', height: '100%', objectFit: 'cover', animation: 'puckSpecialtyFade 0.5s ease' }}
+          />
+        )}
+      </div>
+      <ul style={{ listStyle: 'none', margin: 0, padding: 0, display: 'flex', flexDirection: 'column', gap: '1rem', alignSelf: 'center' }}>
+        {valid.map((item, i) => (
+          <li key={item.heading}>
+            <button
+              type="button"
+              onClick={() => item.photo && setActiveIndex(i)}
+              onMouseEnter={() => item.photo && setActiveIndex(i)}
+              aria-pressed={activeIndex === i}
+              style={{
+                display: 'flex', alignItems: 'flex-start', gap: '0.75rem', width: '100%',
+                background: 'none', border: 'none', padding: 0, margin: 0, textAlign: 'left', cursor: 'pointer',
+              }}
+            >
+              <span style={{ width: 4, height: 4, borderRadius: '50%', background: detailColor, flexShrink: 0, marginTop: '0.5em' }} aria-hidden="true" />
+              <span style={{ display: 'flex', flexDirection: 'column', gap: '0.25rem' }}>
+                <span style={{ fontFamily: bodyFont, fontSize: '0.8rem', fontWeight: 300, color: bodyColor }}>{item.heading}</span>
+                {item.body && (
+                  <span style={{ fontFamily: bodyFont, fontSize: '0.7rem', fontWeight: 300, lineHeight: 1.6, color: detailColor }}>{item.body}</span>
+                )}
+              </span>
+            </button>
+          </li>
+        ))}
+      </ul>
+      <style>{`@keyframes puckSpecialtyFade { from { opacity: 0 } to { opacity: 1 } }`}</style>
+    </div>
+  )
+}

--- a/app/builder/puck.config.tsx
+++ b/app/builder/puck.config.tsx
@@ -16,6 +16,7 @@ import type { Config } from '@measured/puck'
 import { ImagePickerField } from './ImagePickerField'
 import { FreeformPhotoCanvasField } from './FreeformPhotoCanvasField'
 import { ScrollFadeImage } from './ScrollFadeImage'
+import { SpecialtiesRevealBlock } from './SpecialtiesRevealBlock'
 import { PhotoCarouselBlock } from './PhotoCarouselBlock'
 import CategoryPhotoGrid from '@/app/(site)/portfolio/_components/CategoryPhotoGrid'
 import AlbumGridComponent from '@/app/(site)/portfolio/_components/AlbumGrid'
@@ -393,7 +394,7 @@ export const config: Config = {
 
   categories: {
     layout: { title: 'Layout', components: ['SectionHeading', 'Spacer', 'Shape', 'Line', 'SocialLinks'] },
-    content: { title: 'Content', components: ['RichText', 'TypewriterHeading', 'SplitImageText', 'Services', 'LiveServices', 'Testimonials', 'LiveTestimonials', 'Accordion', 'ContactFormBlock', 'CTA'] },
+    content: { title: 'Content', components: ['RichText', 'TypewriterHeading', 'SplitImageText', 'Services', 'LiveServices', 'SpecialtiesReveal', 'Testimonials', 'LiveTestimonials', 'Accordion', 'ContactFormBlock', 'CTA'] },
     media: { title: 'Media', components: ['Hero', 'PhotoGallery', 'PortfolioGrid', 'AlbumGrid', 'LiveBlog', 'PhotoCarousel', 'ImageGrid', 'FreeformPhotoCanvas', 'FullWidthImage', 'Video', 'Map', 'InstagramFeed', 'TikTokFeed'] },
   },
 
@@ -747,6 +748,48 @@ export const config: Config = {
               </div>
             ))}
           </div>
+        </Section>
+      ),
+    },
+
+    // ------------------------------------------------------- SpecialtiesReveal
+    // TYN-345: click (or hover) a session-type item to crossfade a photo panel
+    // to match it. Puck-block equivalent of the same interaction shipped on
+    // the hardcoded About page (app/(site)/about/SpecialtyReveal.tsx) - needed
+    // separately since About is currently promoted to a Puck page, so the
+    // hardcoded branch's version never renders on the live site.
+    SpecialtiesReveal: {
+      label: 'Session Types (click to reveal photo)',
+      fields: {
+        items: {
+          type: 'array',
+          label: 'Session Types',
+          arrayFields: {
+            heading: { type: 'text', label: 'Name' },
+            body: { type: 'textarea', label: 'Description (optional)' },
+            photo: imageField('Photo (optional)'),
+          },
+          defaultItemProps: { heading: 'Weddings', body: '', photo: '' },
+          getItemSummary: (item: any) => item?.heading || 'Session type',
+        },
+        ...styleFields,
+        ...responsiveFields,
+      },
+      defaultProps: {
+        items: [
+          { heading: 'Weddings', body: '', photo: '' },
+          { heading: 'Engagements', body: '', photo: '' },
+          { heading: 'Portraits', body: '', photo: '' },
+          { heading: 'Family Sessions', body: '', photo: '' },
+          { heading: 'Maternity', body: '', photo: '' },
+          { heading: 'Events', body: '', photo: '' },
+        ],
+        ...styleDefaults,
+        ...responsiveDefaults,
+      },
+      render: ({ items, background, backgroundImage, backgroundFade, scrollFadeIn, spacing, hideOnMobile, hideOnDesktop }: any) => (
+        <Section background={background} backgroundImage={backgroundImage} backgroundFade={backgroundFade} scrollFadeIn={scrollFadeIn} spacing={spacing} className={visClass(hideOnMobile, hideOnDesktop)}>
+          <SpecialtiesRevealBlock items={items ?? []} bodyColor={C.body} detailColor={C.detail} bodyFont={BODY_FONT} />
         </Section>
       ),
     },


### PR DESCRIPTION
## Summary
About is currently promoted to a Puck page on production, so the click-to-reveal fix shipped for the hardcoded About page branch (merged in #88) never actually renders live - that branch is dead code for the real `/about` route right now. This adds the same interaction as a real Puck block (`SpecialtiesReveal`) so it's usable on the actual promoted page.

- New `SpecialtiesRevealBlock.tsx`: click/hover a session-type item, photo panel crossfades to match. Styled inline (puck.config.tsx's convention) rather than via CSS module, since it must render identically in the Puck editor canvas.
- Array field per item: Name, Description (optional), Photo (optional). Items without a photo just don't change the panel.
- Registered under Content category, defaults pre-filled with the same 6 categories already on the live page.

## Test plan
- [x] `npx tsc --noEmit` clean
- [ ] Add the block to the live About page and set real photos - follow-up step after merge, since About's actual promoted content needs updating separately to actually use it