### PR TITLE
perf(images): extend next/image cache TTL to 1 year (TYN-187)

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -52,6 +52,13 @@ const nextConfig = {
     // since photography work reads visibly compressed at the default 75,
     // stacked on top of the resize sharp already does at upload time.
     qualities: [75, 90],
+    // Default minimumCacheTTL is 60s (TYN-187) - far too short for photos that
+    // never change once uploaded. Re-optimizing the same photo against R2
+    // every minute on a busy portfolio page is pure waste. A photo's URL only
+    // ever changes if the underlying file is replaced (new upload = new id),
+    // so a long TTL is safe: one year, matching the immutable-asset convention
+    // Vercel already applies to _next/static.
+    minimumCacheTTL: 31536000,
     // Photos are served from Cloudflare R2. next/image rejects any remote host
     // not listed here. This block was lost when Sanity (cdn.sanity.io) was
     // removed and must cover the R2 host that now serves every image.


### PR DESCRIPTION
## Summary
- Sets `images.minimumCacheTTL` to 1 year in `next.config.mjs`, up from Next.js's stock 60-second default.
- Photos never change once uploaded (replacing one creates a new id/URL), so the short default was causing needless re-optimization against R2 on every request past a minute old.
- Matches the immutable-asset TTL Vercel already applies to `_next/static`.

Part of the TYN-187 performance investigation - this is the one concrete, low-risk fix identified; fonts, image `sizes`/`next/image` usage, bundle size, and query depth were all audited and found already correct (see ticket for details). The full Lighthouse baseline is still pending (blocked on temporarily lifting `COMING_SOON` in Vercel so unauthenticated Lighthouse can measure real pages instead of the coming-soon placeholder).

## Test plan
- [x] `npx tsc --noEmit`
- [x] `next build` succeeds
- [ ] Confirm on a preview deploy that photo-heavy pages (`/portfolio`, gallery albums) still load correctly with the new cache header

🤖 Generated with [Claude Code](https://claude.com/claude-code)