### PR TITLE
fix(builder): stop hover toolbars flashing on every canvas tick

### DIFF
--- a/app/builder/AddElementPanel.tsx
+++ b/app/builder/AddElementPanel.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useState } from 'react'
-import { usePuck } from '@measured/puck'
+import { useGetPuck } from '@measured/puck'
 
 // TYN-355: "+ Add Element" trigger + icon-grid panel, shown alongside
 // SectionHoverToolbar (unmodified) only for FreeformSection - see
@@ -40,13 +40,14 @@ export function AddElementTrigger({
   hover: boolean
   isSelected: boolean
 }) {
-  const { dispatch, getItemById } = usePuck()
+  const getPuck = useGetPuck()
   const [open, setOpen] = useState(false)
   const visible = hover || isSelected
 
   if (!visible && !open) return null
 
   const addElement = (type: string) => {
+    const { dispatch, getItemById } = getPuck()
     const section = getItemById(componentId)
     const elements = (section?.props as { elements?: unknown[] } | undefined)?.elements ?? []
     dispatch({

--- a/app/builder/ConvertToFreeformTrigger.tsx
+++ b/app/builder/ConvertToFreeformTrigger.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { usePuck } from '@measured/puck'
+import { useGetPuck } from '@measured/puck'
 import { FREEFORM_CONVERSIONS, canConvertToFreeform } from './freeformConversions'
 
 // TYN-355 Phase 4 follow-up: one-way "Convert to Freeform" button, composed
@@ -20,12 +20,13 @@ export function ConvertToFreeformTrigger({
   hover: boolean
   isSelected: boolean
 }) {
-  const { dispatch, getItemById, getSelectorForId } = usePuck()
+  const getPuck = useGetPuck()
   const visible = (hover || isSelected) && canConvertToFreeform(componentType)
 
   if (!visible) return null
 
   const convert = () => {
+    const { dispatch, getItemById, getSelectorForId } = getPuck()
     const item = getItemById(componentId)
     const selector = getSelectorForId(componentId)
     if (!item || !selector) return

--- a/app/builder/DrawerItemClickToAdd.tsx
+++ b/app/builder/DrawerItemClickToAdd.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { usePuck } from '@measured/puck'
+import { useGetPuck } from '@measured/puck'
 import { DRAWER_ICONS, DefaultDrawerIcon } from './DrawerIcons'
 
 // TYN-340: the builder's own Help panel claims a block can be added by
@@ -28,11 +28,15 @@ import { DRAWER_ICONS, DefaultDrawerIcon } from './DrawerIcons'
 // classnames) get the grid/tile layout in puck-theme.css; this component only
 // needs to supply the tile's actual content.
 export function DrawerItemClickToAdd({ name }: { children: React.ReactNode; name: string }) {
-  const { dispatch, config } = usePuck()
+  const getPuck = useGetPuck()
   const Icon = DRAWER_ICONS[name] ?? DefaultDrawerIcon
+  // config is a static prop passed once to <Puck> - never changes at runtime,
+  // so reading it once here (not subscribing) is always correct.
+  const config = getPuck().config
   const label = (config.components as Record<string, { label?: string }>)[name]?.label ?? name
 
   const handleClick = () => {
+    const { dispatch, config } = getPuck()
     const componentConfig = (config.components as Record<string, { defaultProps?: Record<string, unknown> }>)[name]
     if (!componentConfig) return
     const id = `${name}-${crypto.randomUUID()}`

--- a/app/builder/FreeformElementToolbar.tsx
+++ b/app/builder/FreeformElementToolbar.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { usePuck } from '@measured/puck'
+import { useGetPuck } from '@measured/puck'
 
 // TYN-355: componentOverlay for freeform child elements (TextElement/
 // ImageElement/ButtonElement/ShapeElement), routed here by BuilderOverlay.tsx.
@@ -38,9 +38,11 @@ export function FreeformElementToolbar({
   hover: boolean
   isSelected: boolean
 }) {
-  const { dispatch, config, getItemById, getSelectorForId } = usePuck()
+  const getPuck = useGetPuck()
   const visible = hover || isSelected
-  const label = (config.components as Record<string, { label?: string }>)[componentType]?.label ?? componentType
+  // config is a static prop passed once to <Puck> - never changes at runtime,
+  // so reading it once here (not subscribing) is always correct.
+  const label = (getPuck().config.components as Record<string, { label?: string }>)[componentType]?.label ?? componentType
 
   const getCanvasRect = (): DOMRect | null => {
     const el = document.querySelector(`[data-puck-component="${CSS.escape(componentId)}"]`)
@@ -52,6 +54,7 @@ export function FreeformElementToolbar({
   const startDrag = (e: React.MouseEvent, mode: 'move' | 'resize') => {
     e.preventDefault()
     e.stopPropagation()
+    const { dispatch, getItemById, getSelectorForId } = getPuck()
     const rect = getCanvasRect()
     const item = getItemById(componentId)
     const selector = getSelectorForId(componentId)
@@ -84,24 +87,28 @@ export function FreeformElementToolbar({
   }
 
   const select = () => {
+    const { dispatch, getSelectorForId } = getPuck()
     const selector = getSelectorForId(componentId)
     if (!selector) return
     dispatch({ type: 'setUi', ui: { itemSelector: selector } })
   }
 
   const duplicate = () => {
+    const { dispatch, getSelectorForId } = getPuck()
     const selector = getSelectorForId(componentId)
     if (!selector) return
     dispatch({ type: 'duplicate', sourceIndex: selector.index, sourceZone: selector.zone })
   }
 
   const remove = () => {
+    const { dispatch, getSelectorForId } = getPuck()
     const selector = getSelectorForId(componentId)
     if (!selector) return
     dispatch({ type: 'remove', index: selector.index, zone: selector.zone })
   }
 
   const reorder = (direction: -1 | 1) => {
+    const { dispatch, getSelectorForId } = getPuck()
     const selector = getSelectorForId(componentId)
     if (!selector) return
     const destinationIndex = selector.index + direction

--- a/app/builder/SectionHoverToolbar.tsx
+++ b/app/builder/SectionHoverToolbar.tsx
@@ -1,6 +1,17 @@
 'use client'
 
-import { usePuck } from '@measured/puck'
+import { createUsePuck, useGetPuck } from '@measured/puck'
+
+// Scoped hook (per Puck's own guidance - the bare `usePuck()` hook subscribes
+// to the ENTIRE app state and re-renders on every store tick, including every
+// pointer-move while dragging/hovering anywhere on the canvas, not just this
+// block. That was the real cause of the toolbar visibly flashing on hover -
+// confirmed via Puck's own dev-mode console warning firing 100+ times per
+// hover). `content` is the only piece this component needs reactively (to
+// keep `index`/reorder-button-disabled state correct after edits elsewhere);
+// dispatch/getSelectorForId are only ever used inside click handlers, so they
+// go through useGetPuck() below instead (a stable getter, zero subscriptions).
+const usePuck = createUsePuck()
 
 // TYN-328 (rebuilt to match the real Pixieset reference exactly, per screenshots
 // of website.pixieset.com/pages/... - not just loose inspiration): floating
@@ -42,8 +53,9 @@ export function SectionHoverToolbar({
   hover: boolean
   isSelected: boolean
 }) {
-  const { appState, dispatch, config, getSelectorForId } = usePuck()
-  const content = appState.data.content
+  const content = usePuck((s) => s.appState.data.content)
+  const config = usePuck((s) => s.config)
+  const getPuck = useGetPuck()
   const index = content.findIndex((item) => item.props.id === componentId)
   const visible = (hover || isSelected) && index !== -1
   const hasLayout = Boolean(
@@ -51,6 +63,7 @@ export function SectionHoverToolbar({
   )
 
   const select = () => {
+    const { dispatch, getSelectorForId } = getPuck()
     const selector = getSelectorForId(componentId)
     if (!selector) return
     dispatch({ type: 'setUi', ui: { itemSelector: selector } })
@@ -60,7 +73,7 @@ export function SectionHoverToolbar({
     if (index === -1) return
     const clone = structuredClone(content[index]) as (typeof content)[number]
     clone.props.id = `${componentType}-${crypto.randomUUID()}`
-    dispatch({
+    getPuck().dispatch({
       type: 'setData',
       data: (prev) => {
         const next = [...prev.content]
@@ -72,7 +85,7 @@ export function SectionHoverToolbar({
 
   const remove = () => {
     if (index === -1) return
-    dispatch({
+    getPuck().dispatch({
       type: 'setData',
       data: (prev) => ({ ...prev, content: prev.content.filter((item) => item.props.id !== componentId) }),
     })
@@ -81,7 +94,7 @@ export function SectionHoverToolbar({
   const move = (direction: -1 | 1) => {
     const target = index + direction
     if (index === -1 || target < 0 || target >= content.length) return
-    dispatch({
+    getPuck().dispatch({
       type: 'setData',
       data: (prev) => {
         const next = [...prev.content]

--- a/app/builder/[slug]/EditorClient.tsx
+++ b/app/builder/[slug]/EditorClient.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { Puck, usePuck, type Data } from '@measured/puck'
+import { Puck, useGetPuck, type Data } from '@measured/puck'
 import '@measured/puck/puck.css'
 import '../puck-theme.css'
 import { useCallback, useEffect, useRef, useState } from 'react'
@@ -286,20 +286,26 @@ export function EditorClient({
 // live Puck state via usePuck so it always previews exactly what's on the
 // canvas, same as SaveDraftButton below.
 function PreviewButton({ onPreview, style, busy }: { onPreview: (data: Data) => void; style: React.CSSProperties; busy: boolean }) {
-  const { appState } = usePuck()
+  // useGetPuck() (a stable getter, not a subscription) instead of usePuck() -
+  // this button only needs the current data at click time, not a live prop,
+  // so subscribing to the full app state would re-render it on every canvas
+  // pointer move for no benefit (see SectionHoverToolbar.tsx for the full
+  // writeup of this bug class).
+  const getPuck = useGetPuck()
   return (
-    <button type="button" style={{ ...style, opacity: busy ? 0.6 : 1, cursor: busy ? 'default' : 'pointer' }} disabled={busy} aria-busy={busy} onClick={() => onPreview(appState.data)} title="Preview your unpublished edits in a new tab">
+    <button type="button" style={{ ...style, opacity: busy ? 0.6 : 1, cursor: busy ? 'default' : 'pointer' }} disabled={busy} aria-busy={busy} onClick={() => onPreview(getPuck().appState.data)} title="Preview your unpublished edits in a new tab">
       {busy ? 'Opening preview...' : 'Preview'}
     </button>
   )
 }
 
-// Save draft: persists the current document without publishing. Reads the live
-// Puck state via usePuck so it always saves exactly what is on the canvas.
+// Save draft: persists the current document without publishing. Reads the
+// live Puck state via useGetPuck so it always saves exactly what is on the
+// canvas, without subscribing to every app-state tick (see PreviewButton).
 function SaveDraftButton({ onSave, style, saving }: { onSave: (data: Data) => void; style: React.CSSProperties; saving: boolean }) {
-  const { appState } = usePuck()
+  const getPuck = useGetPuck()
   return (
-    <button type="button" style={{ ...style, opacity: saving ? 0.6 : 1, cursor: saving ? 'default' : 'pointer' }} disabled={saving} aria-busy={saving} onClick={() => onSave(appState.data)} title="Save your work without making it live">
+    <button type="button" style={{ ...style, opacity: saving ? 0.6 : 1, cursor: saving ? 'default' : 'pointer' }} disabled={saving} aria-busy={saving} onClick={() => onSave(getPuck().appState.data)} title="Save your work without making it live">
       {saving ? 'Saving...' : 'Save draft'}
     </button>
   )


### PR DESCRIPTION
## Summary
- Root cause of the flashing reported on the Freeform Section "Edit Text" toolbar: all 6 componentOverlay/handler components called Puck's bare `usePuck()`, which subscribes to the *entire* app state and re-renders on every canvas pointer move, not just when that component's own hover/select state changes. Confirmed via Puck's own dev-mode console warning firing 100+ times per hover.
- Fixed by switching handler-only usages to `useGetPuck()` (a stable getter, zero subscriptions) and `SectionHoverToolbar` (which genuinely needs live content data) to `createUsePuck()` with a scoped selector.
- No behavior change - same actions, same UI - purely eliminates the unnecessary re-render storm.

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `next build` clean
- [x] Verified live: hovering a freeform text element no longer triggers the Puck console warning (previously fired continuously); "Edit Text" toolbar still renders and functions (duplicate/delete/reorder/drag)