### PR TITLE
fix(blog-editor): stop toolbar/fields panel re-rendering on every edit

### DIFF
--- a/app/blog-editor/BlogBodyFieldsPanel.tsx
+++ b/app/blog-editor/BlogBodyFieldsPanel.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { Puck, usePuck } from '@measured/puck'
+import { Puck, createUsePuck, useGetPuck } from '@measured/puck'
 
 // Puck's default layout puts Puck.Fields in a permanent right sidebar as part
 // of its own header/sidebar/preview grid. BlogPostCanvas replaces that whole
@@ -8,13 +8,26 @@ import { Puck, usePuck } from '@measured/puck'
 // panel an inserted block would have no way to edit its props. Only shows
 // once a block is selected (clicking a block in the preview sets this
 // automatically), and closing it deselects rather than deleting anything.
+//
+// Scoped selector (createUsePuck) instead of the bare usePuck() this file
+// previously called - the panel is always mounted (just conditionally
+// returns null), so the bare hook re-rendered it, and everything inside
+// <Puck.Fields />, on every keystroke/edit anywhere in the blog body, not
+// just when selection actually changed. Same re-render-storm bug found and
+// fixed in the page builder (see app/builder/SectionHoverToolbar.tsx).
+// itemSelector/selectedItem genuinely need to be reactive (they drive
+// whether this panel shows and its title); dispatch is only used in the
+// close handler, so it goes through useGetPuck() instead.
+const usePuck = createUsePuck()
+
 export function BlogBodyFieldsPanel() {
-  const { appState, dispatch, selectedItem } = usePuck()
-  const selector = appState.ui.itemSelector
+  const selector = usePuck((s) => s.appState.ui.itemSelector)
+  const selectedItem = usePuck((s) => s.selectedItem)
+  const getPuck = useGetPuck()
 
   if (!selector || !selectedItem) return null
 
-  const close = () => dispatch({ type: 'setUi', ui: { itemSelector: null } })
+  const close = () => getPuck().dispatch({ type: 'setUi', ui: { itemSelector: null } })
 
   return (
     <div

--- a/app/blog-editor/BlogBodyToolbar.tsx
+++ b/app/blog-editor/BlogBodyToolbar.tsx
@@ -1,11 +1,21 @@
 'use client'
 
-import { usePuck } from '@measured/puck'
+import { useGetPuck } from '@measured/puck'
 
 // Bottom insert-block toolbar, replacing Puck's default left-side drag
 // palette (hidden via overrides.drawer in BlogPostCanvas). Must render inside
-// <Puck> so usePuck() has a live dispatch. Inserting a block auto-selects it,
-// so the (still-visible) fields panel immediately shows its editable props.
+// <Puck> so useGetPuck() has a live dispatch. Inserting a block auto-selects
+// it, so the (still-visible) fields panel immediately shows its editable
+// props.
+//
+// Uses useGetPuck() (a stable getter, not a subscription) rather than the
+// bare usePuck() this file previously called - this toolbar is ALWAYS
+// mounted (not hover-gated like the page builder's overlays), so subscribing
+// to the full app state re-rendered it on every keystroke/edit anywhere in
+// the blog body, the same re-render-storm bug found and fixed in the page
+// builder's SectionHoverToolbar/FreeformElementToolbar (see app/builder/).
+// dispatch/appState are only ever read inside the click handler, never for
+// render output, so there's nothing here that needs to be reactive.
 const BLOCKS: { type: string; label: string; icon: string }[] = [
   { type: 'Text', label: 'Text', icon: 'T' },
   { type: 'Image', label: 'Image', icon: '\u{1F5BC}' },
@@ -14,9 +24,10 @@ const BLOCKS: { type: string; label: string; icon: string }[] = [
 ]
 
 export function BlogBodyToolbar() {
-  const { appState, dispatch } = usePuck()
+  const getPuck = useGetPuck()
 
   const insert = (componentType: string) => {
+    const { appState, dispatch } = getPuck()
     dispatch({
       type: 'insert',
       componentType,


### PR DESCRIPTION
## Summary
- Same bare `usePuck()` anti-pattern found and fixed in the page builder (Puck's own console warns: subscribing to the entire app state instead of a scoped selector) also existed in the blog editor's separate Puck instance: `BlogBodyToolbar` and `BlogBodyFieldsPanel`.
- Both are always mounted (not hover-gated), so this re-rendered them - and everything inside `<Puck.Fields />` - on every keystroke/edit anywhere in the blog body.
- Fixed the same way: `useGetPuck()` for handler-only usages, `createUsePuck()` with a scoped selector for `BlogBodyFieldsPanel`'s genuinely-reactive selection state.

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `next build` clean
- [x] Verified live: inserted a Text block, clicked it, confirmed the Fields panel opens ("Edit Text") and closes correctly, zero console warnings throughout