### PR TITLE
feat(contact): add honeypot + Cloudflare Turnstile spam filtering

### DIFF
--- a/app/(site)/contact/ContactForm.module.css
+++ b/app/(site)/contact/ContactForm.module.css
@@ -4,6 +4,18 @@
   gap: 1.5rem;
 }
 
+/* Honeypot (TYN-357): off-screen rather than display:none/visibility:hidden -
+ * some bots specifically skip fields hidden that way, but still fill in
+ * anything positioned off-screen since it reads as "visible" to a naive
+ * parser. Real users never see or tab into it (tabIndex=-1 in the markup). */
+.honeypot {
+  position: absolute;
+  left: -9999px;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+}
+
 /* ── Layout helpers ──────────────────────────────────────── */
 
 .row {

--- a/app/(site)/contact/ContactForm.tsx
+++ b/app/(site)/contact/ContactForm.tsx
@@ -3,6 +3,15 @@ import { useState, useEffect, useRef, FormEvent, ReactNode } from 'react'
 import styles from './ContactForm.module.css'
 import { CONTACT_EMAIL } from '@/app/lib/constants'
 import dynamic from 'next/dynamic'
+import Turnstile from '@/app/components/Turnstile/Turnstile'
+
+// TYN-357: public site key is safe to expose client-side (that's how Turnstile
+// works - verification happens server-side against the secret key in
+// /api/contact). Left unset, the widget simply doesn't render and the server
+// skips verification too - see that route for the matching fail-open logic.
+// Set via Vercel env vars / .env.local once a Turnstile widget exists for
+// this domain in the Cloudflare dashboard.
+const TURNSTILE_SITE_KEY = process.env.NEXT_PUBLIC_TURNSTILE_SITE_KEY
 
 // ssr: false prevents @googlemaps/js-api-loader from being evaluated on the
 // server - it references `window` at module load time and throws during SSR.
@@ -29,6 +38,11 @@ interface FormFields {
   location: string
   message: string
   howHeard: string
+  // Honeypot (TYN-357): real users never see or fill this in - a bot filling
+  // every field blindly will. Kept in the same fields object/state so it
+  // rides along with the normal update()/reset flow rather than needing its
+  // own special-cased plumbing.
+  website: string
 }
 
 const SESSION_TYPES = [
@@ -59,6 +73,7 @@ const EMPTY_FORM: FormFields = {
   location: '',
   message: '',
   howHeard: '',
+  website: '',
 }
 
 // minDate/maxDate are optional (TYN-332) so this component can be embedded
@@ -71,6 +86,7 @@ export default function ContactForm({ minDate, maxDate }: { minDate?: string; ma
   const [status, setStatus] = useState<FormStatus>('idle')
   const [errorMessage, setErrorMessage] = useState<ReactNode>('')
   const [phoneError, setPhoneError] = useState('')
+  const [turnstileToken, setTurnstileToken] = useState('')
   const successRef = useRef<HTMLDivElement>(null)
 
   useEffect(() => {
@@ -98,6 +114,15 @@ export default function ContactForm({ minDate, maxDate }: { minDate?: string; ma
       return
     }
 
+    // If a Turnstile widget is configured, its token is required before
+    // submitting - the server enforces the same check (see /api/contact),
+    // this just avoids a round-trip for the obvious case.
+    if (TURNSTILE_SITE_KEY && !turnstileToken) {
+      setStatus('error')
+      setErrorMessage('Please complete the verification above.')
+      return
+    }
+
     setStatus('loading')
     setErrorMessage('')
     setPhoneError('')
@@ -106,7 +131,7 @@ export default function ContactForm({ minDate, maxDate }: { minDate?: string; ma
       const res = await fetch('/api/contact', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(fields),
+        body: JSON.stringify({ ...fields, turnstileToken }),
       })
 
       const data = await res.json()
@@ -161,6 +186,22 @@ export default function ContactForm({ minDate, maxDate }: { minDate?: string; ma
 
   return (
     <form className={styles.form} onSubmit={handleSubmit} noValidate>
+
+      {/* Honeypot (TYN-357): visually hidden, not display:none (some bots
+          skip those), kept out of tab order and screen readers. Any real
+          visitor never sees or reaches this field. */}
+      <div className={styles.honeypot} aria-hidden="true">
+        <label htmlFor="website">Website</label>
+        <input
+          id="website"
+          name="website"
+          type="text"
+          tabIndex={-1}
+          autoComplete="off"
+          value={fields.website}
+          onChange={update('website')}
+        />
+      </div>
 
       {/* Row: Name + Email */}
       <div className={styles.row}>
@@ -316,6 +357,12 @@ export default function ContactForm({ minDate, maxDate }: { minDate?: string; ma
           ))}
         </select>
       </div>
+
+      {TURNSTILE_SITE_KEY && (
+        <div className={styles.field}>
+          <Turnstile siteKey={TURNSTILE_SITE_KEY} onVerify={setTurnstileToken} />
+        </div>
+      )}
 
       {status === 'error' && (
         <p className={styles.errorMsg} role="alert">{errorMessage}</p>

--- a/app/api/contact/route.test.ts
+++ b/app/api/contact/route.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 
 const sendMock = vi.fn()
 const findGlobalMock = vi.fn()
@@ -185,5 +185,70 @@ describe('POST /api/contact - sad paths', () => {
     sendMock.mockRejectedValueOnce(new Error('network failure'))
     const res = await POST(makeRequest(validBody()))
     expect(res.status).toBe(500)
+  })
+})
+
+describe('POST /api/contact - honeypot (TYN-357)', () => {
+  it('silently accepts and drops a submission with the honeypot field filled in', async () => {
+    const res = await POST(makeRequest(validBody({ website: 'http://spam.example.com' })))
+    const json = await res.json()
+
+    expect(res.status).toBe(200)
+    expect(json).toEqual({ success: true })
+    expect(sendMock).not.toHaveBeenCalled()
+    expect(safeLimitMock).not.toHaveBeenCalled()
+  })
+
+  it('proceeds normally when the honeypot field is empty', async () => {
+    const res = await POST(makeRequest(validBody({ website: '' })))
+    expect(res.status).toBe(200)
+    expect(sendMock).toHaveBeenCalledTimes(2)
+  })
+})
+
+describe('POST /api/contact - Turnstile (TYN-357)', () => {
+  const originalSecret = process.env.TURNSTILE_SECRET_KEY
+
+  afterEach(() => {
+    if (originalSecret === undefined) delete process.env.TURNSTILE_SECRET_KEY
+    else process.env.TURNSTILE_SECRET_KEY = originalSecret
+    vi.unstubAllGlobals()
+  })
+
+  it('skips verification entirely when no secret key is configured', async () => {
+    delete process.env.TURNSTILE_SECRET_KEY
+    const res = await POST(makeRequest(validBody()))
+    expect(res.status).toBe(200)
+  })
+
+  it('rejects a submission missing a token when a secret key is configured', async () => {
+    process.env.TURNSTILE_SECRET_KEY = 'test-secret'
+    const res = await POST(makeRequest(validBody({ turnstileToken: '' })))
+    expect(res.status).toBe(400)
+    expect(sendMock).not.toHaveBeenCalled()
+  })
+
+  it('rejects a submission when Cloudflare reports the token as invalid', async () => {
+    process.env.TURNSTILE_SECRET_KEY = 'test-secret'
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ json: () => Promise.resolve({ success: false }) }))
+    const res = await POST(makeRequest(validBody({ turnstileToken: 'bad-token' })))
+    expect(res.status).toBe(400)
+    expect(sendMock).not.toHaveBeenCalled()
+  })
+
+  it('proceeds when Cloudflare confirms the token is valid', async () => {
+    process.env.TURNSTILE_SECRET_KEY = 'test-secret'
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ json: () => Promise.resolve({ success: true }) }))
+    const res = await POST(makeRequest(validBody({ turnstileToken: 'good-token' })))
+    expect(res.status).toBe(200)
+    expect(sendMock).toHaveBeenCalledTimes(2)
+  })
+
+  it('returns 400 when the Cloudflare verification request itself fails', async () => {
+    process.env.TURNSTILE_SECRET_KEY = 'test-secret'
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('network down')))
+    const res = await POST(makeRequest(validBody({ turnstileToken: 'some-token' })))
+    expect(res.status).toBe(400)
+    expect(sendMock).not.toHaveBeenCalled()
   })
 })

--- a/app/api/contact/route.ts
+++ b/app/api/contact/route.ts
@@ -24,7 +24,17 @@ export async function POST(request: Request) {
   } catch {
     return NextResponse.json({ error: 'Invalid request body' }, { status: 400 })
   }
-  const { name, email, phone, contactPreference, sessionType, date, location, message, howHeard } = body
+  const { name, email, phone, contactPreference, sessionType, date, location, message, howHeard, website, turnstileToken } = body
+
+  // Honeypot (TYN-357): a real visitor never sees or fills in `website` (see
+  // ContactForm.tsx). A bot that fills every field blindly trips this. Return
+  // a fake success rather than a 400/403 - telling the bot it was caught
+  // just teaches it to route around this specific check next time. Checked
+  // before rate limiting/validation so obvious bot traffic costs nothing.
+  if (typeof website === 'string' && website.trim().length > 0) {
+    console.log('[contact] honeypot triggered, silently dropping submission')
+    return NextResponse.json({ success: true })
+  }
 
   const { success } = await safeLimit(contactRatelimit, getClientIp(request))
   if (!success) {
@@ -45,6 +55,36 @@ export async function POST(request: Request) {
 
   if (!isValidPhone(phone)) {
     return NextResponse.json({ error: 'Please enter a valid phone number (at least 7 digits).' }, { status: 400 })
+  }
+
+  // Cloudflare Turnstile (TYN-357): fails open (skips verification) when no
+  // secret key is configured, so the form keeps working exactly as before
+  // until a real Turnstile widget is set up for this domain and the site/
+  // secret keys are added to env vars - see ContactForm.tsx for the matching
+  // client-side skip.
+  const turnstileSecret = process.env.TURNSTILE_SECRET_KEY
+  if (turnstileSecret) {
+    if (typeof turnstileToken !== 'string' || !turnstileToken) {
+      return NextResponse.json({ error: 'Verification failed. Please try again.' }, { status: 400 })
+    }
+    try {
+      const verifyRes = await fetch('https://challenges.cloudflare.com/turnstile/v0/siteverify', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+        body: new URLSearchParams({
+          secret: turnstileSecret,
+          response: turnstileToken,
+          remoteip: getClientIp(request),
+        }),
+      })
+      const verifyJson = (await verifyRes.json()) as { success: boolean }
+      if (!verifyJson.success) {
+        return NextResponse.json({ error: 'Verification failed. Please try again.' }, { status: 400 })
+      }
+    } catch (e) {
+      console.error('[contact] Turnstile verification request failed:', e)
+      return NextResponse.json({ error: 'Verification failed. Please try again.' }, { status: 400 })
+    }
   }
 
   // Fetch booking settings and availability from the admin - fall back to

--- a/app/components/Turnstile/Turnstile.tsx
+++ b/app/components/Turnstile/Turnstile.tsx
@@ -1,0 +1,71 @@
+'use client'
+import { useEffect, useRef, useId } from 'react'
+
+// TYN-357: minimal Cloudflare Turnstile wrapper - loads the widget script
+// once (shared across every mount) and renders a widget bound to `siteKey`,
+// reporting the verification token back via `onVerify`. Only ever rendered
+// by callers when a site key is actually configured (see ContactForm.tsx),
+// so this component doesn't need its own "not configured" fallback.
+declare global {
+  interface Window {
+    turnstile?: {
+      render: (container: string | HTMLElement, options: Record<string, unknown>) => string
+      remove: (widgetId: string) => void
+    }
+  }
+}
+
+let scriptLoadPromise: Promise<void> | null = null
+function loadTurnstileScript(): Promise<void> {
+  if (scriptLoadPromise) return scriptLoadPromise
+  scriptLoadPromise = new Promise((resolve, reject) => {
+    if (window.turnstile) {
+      resolve()
+      return
+    }
+    const script = document.createElement('script')
+    script.src = 'https://challenges.cloudflare.com/turnstile/v0/api.js'
+    script.async = true
+    script.defer = true
+    script.onload = () => resolve()
+    script.onerror = () => reject(new Error('Failed to load Turnstile script'))
+    document.head.appendChild(script)
+  })
+  return scriptLoadPromise
+}
+
+export default function Turnstile({
+  siteKey,
+  onVerify,
+}: {
+  siteKey: string
+  onVerify: (token: string) => void
+}) {
+  const containerRef = useRef<HTMLDivElement>(null)
+  const widgetIdRef = useRef<string | null>(null)
+  const id = useId()
+
+  useEffect(() => {
+    let cancelled = false
+    loadTurnstileScript()
+      .then(() => {
+        if (cancelled || !containerRef.current || !window.turnstile) return
+        widgetIdRef.current = window.turnstile.render(containerRef.current, {
+          sitekey: siteKey,
+          callback: (token: string) => onVerify(token),
+          'expired-callback': () => onVerify(''),
+          'error-callback': () => onVerify(''),
+        })
+      })
+      .catch((e) => console.error('[turnstile]', e))
+    return () => {
+      cancelled = true
+      if (widgetIdRef.current && window.turnstile) {
+        window.turnstile.remove(widgetIdRef.current)
+      }
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [siteKey])
+
+  return <div ref={containerRef} id={`turnstile-${id}`} />
+}


### PR DESCRIPTION
Closes TYN-357.

## Summary
- Added a honeypot field (`website`) to the contact form - visually hidden, out of tab order, never seen by real visitors. If filled in, the server silently returns a fake success without sending any email, so a bot never learns it was caught.
- Added Cloudflare Turnstile verification via a small reusable `Turnstile` widget component and server-side verification against Cloudflare's `siteverify` endpoint in `/api/contact`.
- Both the client widget and server check **fail open** when no site/secret key is configured (`NEXT_PUBLIC_TURNSTILE_SITE_KEY` / `TURNSTILE_SECRET_KEY`), so this ships safely now and the form keeps working exactly as before until real Turnstile keys are added.
- Existing rate limiting is unchanged - this adds two new layers on top of it.
- Both `ContactFormBlock` and `ContactFormElement` in the Puck builder reuse the same `ContactForm` component, so every render path (the dedicated `/contact` page and any builder-embedded instance) is covered by this one change.

## Still needed before Turnstile actually enforces anything
1. In the Cloudflare dashboard: Turnstile -> Add a widget for tynnellhollinsphotography.com, get the **Site Key** and **Secret Key**.
2. Add `NEXT_PUBLIC_TURNSTILE_SITE_KEY` (the site key, plain value) and `TURNSTILE_SECRET_KEY` (the secret, ideally via 1Password like the other secrets) to Vercel's env vars for all environments.
3. Until then, the honeypot alone is active in production - a real, meaningful improvement on its own.

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `next build` clean
- [x] New vitest coverage: honeypot trip/pass-through, Turnstile skip-when-unconfigured, missing token, invalid token, valid token, verification-request failure (52/52 tests passing)
- [x] Verified live (local prod build): honeypot field renders hidden/out-of-tab-order/aria-hidden as expected; Turnstile widget correctly does not render when no site key is configured