### PR TITLE
fix(portfolio): support the `all` category so /portfolio renders photos

### DIFF
--- a/app/api/portfolio-photos/route.ts
+++ b/app/api/portfolio-photos/route.ts
@@ -14,16 +14,27 @@ import type { Photo } from '@/payload-types'
 // a new exposure.
 const VALID_CATEGORIES = ['weddings', 'portraits', 'families', 'couples', 'brands'] as const
 
+// `all` is a real, selectable value on the PortfolioGrid block (see
+// app/builder/puck.config.tsx) and is what the promoted /portfolio page
+// stores. It means "every category", NOT "every photo": a photo with no
+// category set is library staging (untagged uploads, texture assets) and has
+// never been reachable from any public page, so `all` deliberately keeps
+// excluding it rather than newly publishing it.
+const ALL = 'all'
+
 export async function GET(req: NextRequest) {
   const category = req.nextUrl.searchParams.get('category')
-  if (!category || !(VALID_CATEGORIES as readonly string[]).includes(category)) {
+  const wantsAll = category === ALL
+  if (!category || (!wantsAll && !(VALID_CATEGORIES as readonly string[]).includes(category))) {
     return NextResponse.json({ photos: [] })
   }
 
   const payload = await getPayload({ config })
   const { docs } = await payload.find({
     collection: 'photos',
-    where: { category: { equals: category } },
+    where: wantsAll
+      ? { category: { in: [...VALID_CATEGORIES] } }
+      : { category: { equals: category } },
     sort: 'displayOrder',
     depth: 0,
     limit: 500,

--- a/app/builder/puck.config.tsx
+++ b/app/builder/puck.config.tsx
@@ -1224,6 +1224,7 @@ export const config: Config = {
           type: 'select',
           label: 'Category',
           options: [
+            { label: 'All', value: 'all' },
             { label: 'Portraits', value: 'portraits' },
             { label: 'Family', value: 'families' },
             { label: 'Weddings', value: 'weddings' },


### PR DESCRIPTION
## Problem

The promoted `/portfolio` builder page stores `category: "all"` on its PortfolioGrid block, but `/api/portfolio-photos` only accepted the five concrete categories and silently returned `{"photos":[]}` for anything else.

Confirmed against production:

- `?category=portraits` returns 5 photos
- `?category=all` returned 0

So one of the main navigation routes was rendering a completely blank photo grid.

`all` was also missing from the block's own Category dropdown in `puck.config.tsx`, so the stored value was unreachable from the builder UI and could not have been set or corrected by hand.

## Fix

Adds `all` to both sides: the API route and the block's select options.

It maps to an `in` query across the five real categories rather than dropping the category filter entirely. A photo with no category set is library staging (untagged uploads, texture assets) and has never been reachable from any public page, so `all` deliberately keeps excluding it instead of newly publishing it to the portfolio.

## Verification

- `tsc --noEmit` exits 0
- ESLint clean on both changed files
- Ran the new filter query against the live database: returns the 7 categorized photos, excludes the 14 untagged ones

Not exercised over live HTTP locally, so the preview deployment on this PR is the real end-to-end check.

## Note

This makes `/portfolio` render 7 photos instead of 0. It is no longer blank, but the portfolio is still thin and there are currently 0 featured photos sitewide. That part is a content gap, not a code one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
