### PR TITLE
feat(design): add the Rising Roots four-role type system

### DIFF
--- a/app/(site)/layout.tsx
+++ b/app/(site)/layout.tsx
@@ -1,5 +1,13 @@
 import type { Metadata, Viewport } from 'next'
-import { Tangerine, Poppins, Abril_Fatface } from 'next/font/google'
+import {
+  Tangerine,
+  Poppins,
+  Abril_Fatface,
+  Cormorant_Garamond,
+  Barlow,
+  Jost,
+  Parisienne,
+} from 'next/font/google'
 import './globals.css'
 import './styles/tokens.css'
 import Navbar from '../components/Navbar/Navbar'
@@ -38,6 +46,42 @@ const abrialFatface = Abril_Fatface({
   weight: ['400'],
   subsets: ['latin'],
   variable: '--font-display-bold',
+  display: 'swap',
+})
+
+// Rising Roots type system. The reference template uses NyghtSerif Light (+
+// its italic) and Nostalgia for the script, both commercially licensed, so
+// they are deliberately NOT embedded here. Barlow and Jost are exactly what
+// the reference uses and are OFL-licensed; Cormorant Garamond stands in for
+// NyghtSerif (very close at light weight, and the face Tynnell already chose
+// in her own Showit draft), and Parisienne stands in for the script.
+// Italic is loaded explicitly because the accent role is an italic serif.
+const cormorant = Cormorant_Garamond({
+  weight: ['300', '400', '500', '600'],
+  style: ['normal', 'italic'],
+  subsets: ['latin'],
+  variable: '--font-serif',
+  display: 'swap',
+})
+
+const barlow = Barlow({
+  weight: ['300', '400', '500', '600'],
+  subsets: ['latin'],
+  variable: '--font-sans',
+  display: 'swap',
+})
+
+const jost = Jost({
+  weight: ['300', '400', '500'],
+  subsets: ['latin'],
+  variable: '--font-label',
+  display: 'swap',
+})
+
+const parisienne = Parisienne({
+  weight: ['400'],
+  subsets: ['latin'],
+  variable: '--font-script',
   display: 'swap',
 })
 
@@ -89,7 +133,7 @@ export default async function RootLayout({
   return (
     <html
       lang="en"
-      className={`${tangerine.variable} ${poppinsHeading.variable} ${poppinsBody.variable} ${abrialFatface.variable}`}
+      className={`${tangerine.variable} ${poppinsHeading.variable} ${poppinsBody.variable} ${abrialFatface.variable} ${cormorant.variable} ${barlow.variable} ${jost.variable} ${parisienne.variable}`}
       data-animations={theme.animationsEnabled ? undefined : 'off'}
     >
       {/* Site-wide theme (TYN-314), read fresh on every request from the

--- a/app/(site)/styles/tokens.css
+++ b/app/(site)/styles/tokens.css
@@ -40,6 +40,19 @@
   --font-body:            'Poppins', sans-serif;
   --font-mono:            var(--font-body);
 
+  /* Rising Roots faces. Set for real by next/font in app/(site)/layout.tsx;
+     these are the same fallback arrangement as the four above. */
+  --font-serif:           'Cormorant Garamond', serif;
+  --font-sans:            'Barlow', sans-serif;
+  --font-label:           'Jost', sans-serif;
+  --font-script:          'Parisienne', cursive;
+
+  /* Role vars, selectable per role in /design. --font-accent is the italic
+     serif used for emotional accent lines; consumers apply font-style: italic,
+     since italic is a style rather than a separate family. */
+  --font-accent:          var(--font-serif);
+  --font-script-role:     var(--font-script);
+
   /* ── Spacing ──────────────────────────────────────────────── */
   /* --space-scale (Design editor "Overall spacing": 0.75 compact / 1
      normal / 1.35 spacious) multiplies both spacing tokens below, so a

--- a/app/api/design/save/route.ts
+++ b/app/api/design/save/route.ts
@@ -15,6 +15,8 @@ const FIELDS = [
   'watermarkUrl',
   'headingFont',
   'bodyFont',
+  'accentFont',
+  'scriptFont',
   'colorBg',
   'colorBgAccent',
   'colorHeading',

--- a/app/builder/DesignPanelShared.tsx
+++ b/app/builder/DesignPanelShared.tsx
@@ -11,6 +11,17 @@ export const FONT_OPTIONS: { label: string; value: SiteTheme['headingFont'] }[] 
   { label: 'Poppins', value: 'poppins' },
   { label: 'Tangerine', value: 'tangerine' },
   { label: 'Abril Fatface', value: 'abril' },
+  { label: 'Cormorant Garamond', value: 'cormorant' },
+  { label: 'Barlow', value: 'barlow' },
+  { label: 'Jost', value: 'jost' },
+]
+
+// The script role is intentionally a short list: it is meant for single-word
+// moments (the Inquire CTA), not body copy, so offering every face invites
+// misuse.
+export const SCRIPT_FONT_OPTIONS: { label: string; value: SiteTheme['scriptFont'] }[] = [
+  { label: 'Parisienne', value: 'parisienne' },
+  { label: 'Tangerine', value: 'tangerine' },
 ]
 export const SPACING_OPTIONS: { label: string; value: SiteTheme['spacingScale'] }[] = [
   { label: 'Compact', value: 'compact' },
@@ -173,6 +184,10 @@ export function DesignSections({
         <Select value={theme.headingFont} onChange={(v) => set('headingFont', v as SiteTheme['headingFont'])} options={FONT_OPTIONS} />
         <FieldLabel style={{ marginTop: 12 }}>Body font</FieldLabel>
         <Select value={theme.bodyFont} onChange={(v) => set('bodyFont', v as SiteTheme['bodyFont'])} options={FONT_OPTIONS} />
+        <FieldLabel style={{ marginTop: 12 }}>Accent font (italic serif)</FieldLabel>
+        <Select value={theme.accentFont} onChange={(v) => set('accentFont', v as SiteTheme['accentFont'])} options={FONT_OPTIONS} />
+        <FieldLabel style={{ marginTop: 12 }}>Script font</FieldLabel>
+        <Select value={theme.scriptFont} onChange={(v) => set('scriptFont', v as SiteTheme['scriptFont'])} options={SCRIPT_FONT_OPTIONS} />
       </AccordionRow>
 
       <AccordionRow label="Colors" isOpen={open === 'colors'} onToggle={() => setOpen(open === 'colors' ? null : 'colors')}>

--- a/app/lib/siteDesign.ts
+++ b/app/lib/siteDesign.ts
@@ -29,6 +29,8 @@ export const getSiteDesign = cache(async (): Promise<SiteTheme> => {
       watermarkUrl: doc.watermarkUrl || DEFAULT_THEME.watermarkUrl,
       headingFont: doc.headingFont || DEFAULT_THEME.headingFont,
       bodyFont: doc.bodyFont || DEFAULT_THEME.bodyFont,
+      accentFont: doc.accentFont || DEFAULT_THEME.accentFont,
+      scriptFont: doc.scriptFont || DEFAULT_THEME.scriptFont,
       colorBg: doc.colorBg || DEFAULT_THEME.colorBg,
       colorBgAccent: doc.colorBgAccent || DEFAULT_THEME.colorBgAccent,
       colorHeading: doc.colorHeading || DEFAULT_THEME.colorHeading,

--- a/app/lib/siteTheme.ts
+++ b/app/lib/siteTheme.ts
@@ -5,13 +5,22 @@
 // payload.config.ts, which breaks the client bundle for /design's
 // 'use client' editor if it's imported from the same module as
 // getSiteDesign() (see app/lib/siteDesign.ts, the server-only counterpart).
+// Rising Roots adds a display serif, a body sans, a letterspaced label sans and
+// a script to the original Poppins/Tangerine/Abril set. NyghtSerif and Nostalgia
+// (what the reference template actually uses) are commercially licensed and are
+// deliberately not embedded - Cormorant Garamond and Parisienne stand in.
+export type FontChoice = 'poppins' | 'tangerine' | 'abril' | 'cormorant' | 'barlow' | 'jost'
+export type ScriptChoice = 'parisienne' | 'tangerine'
+
 export interface SiteTheme {
   logoUrl: string
   faviconUrl: string
   watermarkEnabled: boolean
   watermarkUrl: string
-  headingFont: 'poppins' | 'tangerine' | 'abril'
-  bodyFont: 'poppins' | 'tangerine' | 'abril'
+  headingFont: FontChoice
+  bodyFont: FontChoice
+  accentFont: FontChoice
+  scriptFont: ScriptChoice
   colorBg: string
   colorBgAccent: string
   colorHeading: string
@@ -41,6 +50,8 @@ export const DEFAULT_THEME: SiteTheme = {
   watermarkUrl: '',
   headingFont: 'poppins',
   bodyFont: 'poppins',
+  accentFont: 'cormorant',
+  scriptFont: 'parisienne',
   colorBg: '#0C0C0C',
   colorBgAccent: '#131313',
   colorHeading: '#D6D1CE',
@@ -63,9 +74,24 @@ export const DEFAULT_THEME: SiteTheme = {
   sharpeningLevel: 'none',
 }
 
-const FONT_ROLE_VAR: Record<'tangerine' | 'abril', string> = {
+// Every face except poppins maps to its own next/font variable. poppins is the
+// historic default for heading/body, so those two roles skip the override
+// entirely and fall through to tokens.css rather than emitting a redundant var.
+const FONT_ROLE_VAR: Record<Exclude<FontChoice, 'poppins'> | 'parisienne', string> = {
   tangerine: 'var(--font-display)',
   abril: 'var(--font-display-bold)',
+  cormorant: 'var(--font-serif)',
+  barlow: 'var(--font-sans)',
+  jost: 'var(--font-label)',
+  parisienne: 'var(--font-script)',
+}
+
+const POPPINS_VAR = "'Poppins', sans-serif"
+
+// Unlike heading/body, the accent and script roles have no historic default to
+// fall through to, so they always emit a concrete value.
+function fontVar(choice: FontChoice | ScriptChoice): string {
+  return choice === 'poppins' ? POPPINS_VAR : FONT_ROLE_VAR[choice]
 }
 
 const SPACE_SCALE: Record<SiteTheme['spacingScale'], number> = {
@@ -106,6 +132,8 @@ export function themeToCssVarMap(theme: SiteTheme): Record<string, string> {
   }
   if (theme.headingFont !== 'poppins') map['--font-heading'] = FONT_ROLE_VAR[theme.headingFont]
   if (theme.bodyFont !== 'poppins') map['--font-body'] = FONT_ROLE_VAR[theme.bodyFont]
+  map['--font-accent'] = fontVar(theme.accentFont)
+  map['--font-script-role'] = fontVar(theme.scriptFont)
   return map
 }
 

--- a/globals/SiteDesign.ts
+++ b/globals/SiteDesign.ts
@@ -47,6 +47,9 @@ export const SiteDesign: GlobalConfig = {
         { label: 'Poppins', value: 'poppins' },
         { label: 'Tangerine', value: 'tangerine' },
         { label: 'Abril Fatface', value: 'abril' },
+        { label: 'Cormorant Garamond', value: 'cormorant' },
+        { label: 'Barlow', value: 'barlow' },
+        { label: 'Jost', value: 'jost' },
       ],
     },
     {
@@ -58,6 +61,9 @@ export const SiteDesign: GlobalConfig = {
         { label: 'Poppins', value: 'poppins' },
         { label: 'Tangerine', value: 'tangerine' },
         { label: 'Abril Fatface', value: 'abril' },
+        { label: 'Cormorant Garamond', value: 'cormorant' },
+        { label: 'Barlow', value: 'barlow' },
+        { label: 'Jost', value: 'jost' },
       ],
     },
     {
@@ -95,6 +101,34 @@ export const SiteDesign: GlobalConfig = {
       type: 'text',
       label: 'Button color',
       defaultValue: '#9B9A9A',
+    },
+    // Rising Roots works in four type roles rather than two: a display serif,
+    // an italic serif for accent lines, a body sans, and a script reserved for
+    // single-word moments like the Inquire CTA. headingFont/bodyFont above
+    // cover the first and third; these two add the rest.
+    {
+      name: 'accentFont',
+      type: 'select',
+      label: 'Accent font (italic serif)',
+      defaultValue: 'cormorant',
+      options: [
+        { label: 'Cormorant Garamond', value: 'cormorant' },
+        { label: 'Poppins', value: 'poppins' },
+        { label: 'Tangerine', value: 'tangerine' },
+        { label: 'Abril Fatface', value: 'abril' },
+        { label: 'Barlow', value: 'barlow' },
+        { label: 'Jost', value: 'jost' },
+      ],
+    },
+    {
+      name: 'scriptFont',
+      type: 'select',
+      label: 'Script font (accents and CTAs)',
+      defaultValue: 'parisienne',
+      options: [
+        { label: 'Parisienne', value: 'parisienne' },
+        { label: 'Tangerine', value: 'tangerine' },
+      ],
     },
     // The six colors above cover text and the two page grounds, but a real
     // light/dark inversion also needs the card, hover, button-text, and border

--- a/payload-types.ts
+++ b/payload-types.ts
@@ -1062,8 +1062,10 @@ export interface SiteDesign {
   faviconUrl?: string | null;
   watermarkEnabled?: boolean | null;
   watermarkUrl?: string | null;
-  headingFont?: ('poppins' | 'tangerine' | 'abril') | null;
-  bodyFont?: ('poppins' | 'tangerine' | 'abril') | null;
+  headingFont?: ('poppins' | 'tangerine' | 'abril' | 'cormorant' | 'barlow' | 'jost') | null;
+  bodyFont?: ('poppins' | 'tangerine' | 'abril' | 'cormorant' | 'barlow' | 'jost') | null;
+  accentFont?: ('cormorant' | 'poppins' | 'tangerine' | 'abril' | 'barlow' | 'jost') | null;
+  scriptFont?: ('parisienne' | 'tangerine') | null;
   colorBg?: string | null;
   colorBgAccent?: string | null;
   colorHeading?: string | null;
@@ -1268,6 +1270,8 @@ export interface SiteDesignSelect<T extends boolean = true> {
   watermarkUrl?: T;
   headingFont?: T;
   bodyFont?: T;
+  accentFont?: T;
+  scriptFont?: T;
   colorBg?: T;
   colorBgAccent?: T;
   colorHeading?: T;

--- a/scripts/migrate-db.mjs
+++ b/scripts/migrate-db.mjs
@@ -862,6 +862,55 @@ async function run() {
       )
     }
     console.log('✓ site_design palette columns ready')
+
+    // ------------------------------------------------------------------
+    // Migration 20260806_110000: Rising Roots type system (four font roles)
+    // heading_font and body_font are REAL Postgres enums, so new faces need
+    // ALTER TYPE ... ADD VALUE rather than a plain column change - same trap
+    // as enum_pages_promoted_route above. The two new roles (accent, script)
+    // get their own enum types.
+    // ------------------------------------------------------------------
+
+    for (const face of ['cormorant', 'barlow', 'jost']) {
+      await client.query(
+        `ALTER TYPE "enum_site_design_heading_font" ADD VALUE IF NOT EXISTS '${face}'`
+      )
+      await client.query(
+        `ALTER TYPE "enum_site_design_body_font" ADD VALUE IF NOT EXISTS '${face}'`
+      )
+    }
+    console.log('✓ site_design font enums extended')
+
+    await client.query(`
+      DO $$ BEGIN
+        CREATE TYPE "enum_site_design_accent_font" AS ENUM
+          ('poppins', 'tangerine', 'abril', 'cormorant', 'barlow', 'jost');
+      EXCEPTION WHEN duplicate_object THEN NULL;
+      END $$
+    `)
+    await client.query(`
+      DO $$ BEGIN
+        CREATE TYPE "enum_site_design_script_font" AS ENUM ('parisienne', 'tangerine');
+      EXCEPTION WHEN duplicate_object THEN NULL;
+      END $$
+    `)
+    await client.query(`
+      ALTER TABLE "site_design"
+        ADD COLUMN IF NOT EXISTS "accent_font" "enum_site_design_accent_font"
+        DEFAULT 'cormorant'
+    `)
+    await client.query(`
+      ALTER TABLE "site_design"
+        ADD COLUMN IF NOT EXISTS "script_font" "enum_site_design_script_font"
+        DEFAULT 'parisienne'
+    `)
+    await client.query(
+      `UPDATE "site_design" SET "accent_font" = 'cormorant' WHERE "accent_font" IS NULL`
+    )
+    await client.query(
+      `UPDATE "site_design" SET "script_font" = 'parisienne' WHERE "script_font" IS NULL`
+    )
+    console.log('✓ site_design accent/script font columns ready')
   } finally {
     client.release()
     await pool.end()


### PR DESCRIPTION
> **Stacked on #99.** Base is `feature/0000210-rising-roots-palette-tokens`, not `main`, because both PRs touch the same five files. Merge #99 first, then this retargets to main cleanly.

## What Rising Roots actually uses

Sampled from the live demo rather than eyeballed:

| Role | Reference face | Licence |
|---|---|---|
| Display serif | NyghtSerif Light | commercial |
| Italic accent | NyghtSerif Light Italic | commercial |
| Body sans | Barlow | OFL |
| Label sans | Jost | OFL |
| Script (Inquire CTA) | Nostalgia | commercial |

Barlow and Jost ship exactly as the reference uses them.

**NyghtSerif and Nostalgia are deliberately not embedded.** Putting a commercially licensed webfont on a live business site without a licence is not something to do quietly. Cormorant Garamond stands in for the serif, and Parisienne for the script.

Cormorant is a good substitute on the merits (very close to NyghtSerif at light weight, with a genuinely good italic) and it is also the face Tynnell already chose in her own Showit draft, so it is not an arbitrary pick.

If the fonts get licensed later, swapping them is a one-line change per face in `app/(site)/layout.tsx` plus an enum value.

## Changes

- Four faces added via `next/font/google` (Cormorant loads italic explicitly, since the accent role is an italic serif)
- Two new role fields: `accentFont`, `scriptFont`
- New faces added as options on the existing `headingFont` / `bodyFont` roles
- Plumbed through the same chain as the palette: `SiteDesign`, `SiteTheme`, `DEFAULT_THEME`, `themeToCssVarMap`, `getSiteDesign`, the `/design` Fonts accordion, the save-route allowlist
- New CSS role vars `--font-accent` and `--font-script-role`

The script role's option list is deliberately short. It is meant for single-word moments, and offering every face invites misuse.

## The enum trap

`heading_font` and `body_font` are **real Postgres enums**, so new faces need `ALTER TYPE ... ADD VALUE`, not a column change. Same trap as `enum_pages_promoted_route`. The two new roles get their own enum types, created idempotently.

## Visually inert by default

`headingFont` and `bodyFont` still default to Poppins and skip the override entirely, falling through to `tokens.css` exactly as before. The accent and script roles have no historic default to fall through to, so they always emit a concrete value.

## Verification

- Migration ran clean; confirmed against the database that both enums now carry `cormorant`, `barlow`, `jost`, that the two new enum types exist with the right labels, and that the row backfilled to `cormorant` / `parisienne` with no NULLs
- `tsc --noEmit` exits 0
- ESLint clean on all six changed source files

## Note

`payload-types.ts` was hand-edited again. `generate:types` still fails on Node v24 with `TypeError: T.registerHooks is not a function` inside tsx.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
