### PR TITLE
feat(design): add paper grain and photo color treatment

### DIFF
--- a/app/(site)/globals.css
+++ b/app/(site)/globals.css
@@ -17,6 +17,50 @@ body {
   margin: 0;
 }
 
+/* ── Paper grain ──────────────────────────────────────────── */
+/* A fixed, non-interactive overlay over the whole viewport, driven by
+   --paper-grain-opacity from SiteDesign (/design > Texture). The noise is an
+   inline SVG feTurbulence data URI rather than a bitmap: no extra request, no
+   effect on LCP, and it tiles seamlessly at any viewport size.
+
+   z-index 1 deliberately: it sits above the page background but below the
+   navbar, mobile menu and any modal, all of which set their own higher
+   stacking. pointer-events: none so it never swallows a click.
+
+   Renders nothing at all when opacity is 0, which is the default. */
+
+body::before {
+  content: '';
+  position: fixed;
+  inset: 0;
+  z-index: 1;
+  pointer-events: none;
+  opacity: var(--paper-grain-opacity, 0);
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='180' height='180'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.82' numOctaves='3' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='180' height='180' filter='url(%23n)'/%3E%3C/svg%3E");
+  background-repeat: repeat;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  /* The grain is static, but honour the setting for anyone who has asked for
+     the plainest possible rendering. */
+  body::before {
+    opacity: calc(var(--paper-grain-opacity, 0) * 0.5);
+  }
+}
+
+/* ── Photo color treatment ────────────────────────────────── */
+/* Rising Roots runs its photography desaturated. Applied by the shell rather
+   than baked into the uploads, so it works on whatever gets uploaded later and
+   is reversible from /design.
+
+   Scoped to real photography: <img> inside content areas. Deliberately NOT
+   applied to inline SVG (social icons, the logo mark) which should keep their
+   own color, and skipped for anything opting out with .no-photo-treatment. */
+
+img:not(.no-photo-treatment) {
+  filter: saturate(var(--photo-saturation, 1));
+}
+
 a {
   color: inherit;
   text-decoration: none;

--- a/app/(site)/styles/tokens.css
+++ b/app/(site)/styles/tokens.css
@@ -27,6 +27,12 @@
      Overlay boxes (--color-bg-overlay) sit on top of photos, so they usually
      want to stay dark even on a light ground. It is adjustable regardless. */
 
+  /* ── Shell finishes (paper grain + photo treatment) ───────── */
+  /* Both driven by SiteDesign and editable in /design; the values here are
+     the "off" fallback for before SiteDesign has been read. */
+  --paper-grain-opacity:  0;
+  --photo-saturation:     1;
+
   /* ── Tape treatment ───────────────────────────────────────── */
   --tape-mat:             #f4efe8;
   --tape-color:           rgba(214, 209, 206, 0.42);

--- a/app/api/design/save/route.ts
+++ b/app/api/design/save/route.ts
@@ -33,6 +33,8 @@ const FIELDS = [
   'colorBorderSolid',
   'tapeMatColor',
   'tapeColor',
+  'paperGrain',
+  'photoTreatment',
   'spacingScale',
   'buttonStyle',
   'animationsEnabled',

--- a/app/builder/DesignPanelShared.tsx
+++ b/app/builder/DesignPanelShared.tsx
@@ -33,6 +33,18 @@ export const BUTTON_OPTIONS: { label: string; value: SiteTheme['buttonStyle'] }[
   { label: 'Rounded', value: 'rounded' },
   { label: 'Pill', value: 'pill' },
 ]
+export const GRAIN_OPTIONS: { label: string; value: SiteTheme['paperGrain'] }[] = [
+  { label: 'None', value: 'none' },
+  { label: 'Subtle', value: 'subtle' },
+  { label: 'Medium', value: 'medium' },
+  { label: 'Strong', value: 'strong' },
+]
+export const PHOTO_TREATMENT_OPTIONS: { label: string; value: SiteTheme['photoTreatment'] }[] = [
+  { label: 'Full color', value: 'color' },
+  { label: 'Muted', value: 'muted' },
+  { label: 'Nearly black & white', value: 'faded' },
+  { label: 'Black & white', value: 'bw' },
+]
 export const SHARPENING_OPTIONS: { label: string; value: SiteTheme['sharpeningLevel'] }[] = [
   { label: 'None', value: 'none' },
   { label: 'Subtle', value: 'subtle' },
@@ -225,6 +237,21 @@ export function DesignSections({
       <AccordionRow label="Buttons" isOpen={open === 'buttons'} onToggle={() => setOpen(open === 'buttons' ? null : 'buttons')}>
         <FieldLabel>Button shape</FieldLabel>
         <Select value={theme.buttonStyle} onChange={(v) => set('buttonStyle', v as SiteTheme['buttonStyle'])} options={BUTTON_OPTIONS} />
+      </AccordionRow>
+
+      <AccordionRow label="Texture" isOpen={open === 'texture'} onToggle={() => setOpen(open === 'texture' ? null : 'texture')}>
+        <FieldLabel>Paper grain</FieldLabel>
+        <Select value={theme.paperGrain} onChange={(v) => set('paperGrain', v as SiteTheme['paperGrain'])} options={GRAIN_OPTIONS} />
+        <p style={{ color: '#6b6a6a', fontSize: 11, marginTop: 8 }}>
+          A fine paper texture over the whole site. Keep it low: past &quot;Medium&quot; it starts competing with your photos
+          instead of sitting under them.
+        </p>
+        <FieldLabel style={{ marginTop: 12 }}>Photo color treatment</FieldLabel>
+        <Select value={theme.photoTreatment} onChange={(v) => set('photoTreatment', v as SiteTheme['photoTreatment'])} options={PHOTO_TREATMENT_OPTIONS} />
+        <p style={{ color: '#6b6a6a', fontSize: 11, marginTop: 8 }}>
+          Changes how photos are displayed sitewide. Your uploaded files are never altered, and a client&apos;s download is
+          always the untouched original.
+        </p>
       </AccordionRow>
 
       <AccordionRow label="Photo Sharpening" isOpen={open === 'sharpening'} onToggle={() => setOpen(open === 'sharpening' ? null : 'sharpening')}>

--- a/app/lib/siteDesign.ts
+++ b/app/lib/siteDesign.ts
@@ -47,6 +47,8 @@ export const getSiteDesign = cache(async (): Promise<SiteTheme> => {
       colorBorderSolid: doc.colorBorderSolid || DEFAULT_THEME.colorBorderSolid,
       tapeMatColor: doc.tapeMatColor || DEFAULT_THEME.tapeMatColor,
       tapeColor: doc.tapeColor || DEFAULT_THEME.tapeColor,
+      paperGrain: doc.paperGrain || DEFAULT_THEME.paperGrain,
+      photoTreatment: doc.photoTreatment || DEFAULT_THEME.photoTreatment,
       spacingScale: doc.spacingScale || DEFAULT_THEME.spacingScale,
       buttonStyle: doc.buttonStyle || DEFAULT_THEME.buttonStyle,
       animationsEnabled: doc.animationsEnabled ?? true,

--- a/app/lib/siteTheme.ts
+++ b/app/lib/siteTheme.ts
@@ -12,6 +12,11 @@
 export type FontChoice = 'poppins' | 'tangerine' | 'abril' | 'cormorant' | 'barlow' | 'jost'
 export type ScriptChoice = 'parisienne' | 'tangerine'
 
+// Shell-level finishes: applied by the shell over whatever photos exist,
+// rather than baked into the files themselves.
+export type PaperGrain = 'none' | 'subtle' | 'medium' | 'strong'
+export type PhotoTreatment = 'color' | 'muted' | 'faded' | 'bw'
+
 export interface SiteTheme {
   logoUrl: string
   faviconUrl: string
@@ -37,6 +42,8 @@ export interface SiteTheme {
   colorBorderSolid: string
   tapeMatColor: string
   tapeColor: string
+  paperGrain: PaperGrain
+  photoTreatment: PhotoTreatment
   spacingScale: 'compact' | 'normal' | 'spacious'
   buttonStyle: 'sharp' | 'rounded' | 'pill'
   animationsEnabled: boolean
@@ -68,6 +75,8 @@ export const DEFAULT_THEME: SiteTheme = {
   colorBorderSolid: '#1e1e1e',
   tapeMatColor: '#f4efe8',
   tapeColor: 'rgba(214, 209, 206, 0.42)',
+  paperGrain: 'none',
+  photoTreatment: 'color',
   spacingScale: 'normal',
   buttonStyle: 'sharp',
   animationsEnabled: true,
@@ -100,6 +109,24 @@ const SPACE_SCALE: Record<SiteTheme['spacingScale'], number> = {
   spacious: 1.35,
 }
 
+// Grain opacity is kept low on purpose. Above ~0.09 the texture starts
+// competing with the photography instead of sitting under it.
+const GRAIN_OPACITY: Record<PaperGrain, string> = {
+  none: '0',
+  subtle: '0.035',
+  medium: '0.06',
+  strong: '0.09',
+}
+
+// saturate() rather than grayscale() so "muted" and "faded" are real points on
+// the same axis; bw is the 0 end of it.
+const PHOTO_SATURATION: Record<PhotoTreatment, string> = {
+  color: '1',
+  muted: '0.65',
+  faded: '0.3',
+  bw: '0',
+}
+
 const BTN_RADIUS: Record<SiteTheme['buttonStyle'], string> = {
   sharp: '2px',
   rounded: '8px',
@@ -127,6 +154,8 @@ export function themeToCssVarMap(theme: SiteTheme): Record<string, string> {
     '--color-border-solid': theme.colorBorderSolid,
     '--tape-mat': theme.tapeMatColor,
     '--tape-color': theme.tapeColor,
+    '--paper-grain-opacity': GRAIN_OPACITY[theme.paperGrain],
+    '--photo-saturation': PHOTO_SATURATION[theme.photoTreatment],
     '--space-scale': String(SPACE_SCALE[theme.spacingScale]),
     '--btn-radius': BTN_RADIUS[theme.buttonStyle],
   }

--- a/globals/SiteDesign.ts
+++ b/globals/SiteDesign.ts
@@ -196,6 +196,33 @@ export const SiteDesign: GlobalConfig = {
       label: 'Tape strip color',
       defaultValue: 'rgba(214, 209, 206, 0.42)',
     },
+    // Two shell-level finishes (Rising Roots). Both are applied BY the shell
+    // rather than baked into any individual photo, so they work on whatever
+    // Tynnell uploads later. Both default to off, so this is inert until set.
+    {
+      name: 'paperGrain',
+      type: 'select',
+      label: 'Paper grain texture',
+      defaultValue: 'none',
+      options: [
+        { label: 'None', value: 'none' },
+        { label: 'Subtle', value: 'subtle' },
+        { label: 'Medium', value: 'medium' },
+        { label: 'Strong', value: 'strong' },
+      ],
+    },
+    {
+      name: 'photoTreatment',
+      type: 'select',
+      label: 'Photo color treatment',
+      defaultValue: 'color',
+      options: [
+        { label: 'Full color', value: 'color' },
+        { label: 'Muted', value: 'muted' },
+        { label: 'Nearly black & white', value: 'faded' },
+        { label: 'Black & white', value: 'bw' },
+      ],
+    },
     {
       name: 'spacingScale',
       type: 'select',

--- a/payload-types.ts
+++ b/payload-types.ts
@@ -1082,6 +1082,8 @@ export interface SiteDesign {
   colorBorderSolid?: string | null;
   tapeMatColor?: string | null;
   tapeColor?: string | null;
+  paperGrain?: ('none' | 'subtle' | 'medium' | 'strong') | null;
+  photoTreatment?: ('color' | 'muted' | 'faded' | 'bw') | null;
   spacingScale?: ('compact' | 'normal' | 'spacious') | null;
   buttonStyle?: ('sharp' | 'rounded' | 'pill') | null;
   animationsEnabled?: boolean | null;
@@ -1288,6 +1290,8 @@ export interface SiteDesignSelect<T extends boolean = true> {
   colorBorderSolid?: T;
   tapeMatColor?: T;
   tapeColor?: T;
+  paperGrain?: T;
+  photoTreatment?: T;
   spacingScale?: T;
   buttonStyle?: T;
   animationsEnabled?: T;

--- a/scripts/migrate-db.mjs
+++ b/scripts/migrate-db.mjs
@@ -911,6 +911,46 @@ async function run() {
       `UPDATE "site_design" SET "script_font" = 'parisienne' WHERE "script_font" IS NULL`
     )
     console.log('✓ site_design accent/script font columns ready')
+
+    // ------------------------------------------------------------------
+    // Migration 20260810_120000: shell finishes (paper grain + photo
+    // treatment). Both are Payload selects, which the postgres adapter backs
+    // with real enum types, so they need CREATE TYPE rather than plain
+    // varchar columns. Defaults are the "off" values, so this is inert until
+    // someone changes them in /design.
+    // ------------------------------------------------------------------
+
+    await client.query(`
+      DO $$ BEGIN
+        CREATE TYPE "enum_site_design_paper_grain" AS ENUM
+          ('none', 'subtle', 'medium', 'strong');
+      EXCEPTION WHEN duplicate_object THEN NULL;
+      END $$
+    `)
+    await client.query(`
+      DO $$ BEGIN
+        CREATE TYPE "enum_site_design_photo_treatment" AS ENUM
+          ('color', 'muted', 'faded', 'bw');
+      EXCEPTION WHEN duplicate_object THEN NULL;
+      END $$
+    `)
+    await client.query(`
+      ALTER TABLE "site_design"
+        ADD COLUMN IF NOT EXISTS "paper_grain" "enum_site_design_paper_grain"
+        DEFAULT 'none'
+    `)
+    await client.query(`
+      ALTER TABLE "site_design"
+        ADD COLUMN IF NOT EXISTS "photo_treatment" "enum_site_design_photo_treatment"
+        DEFAULT 'color'
+    `)
+    await client.query(
+      `UPDATE "site_design" SET "paper_grain" = 'none' WHERE "paper_grain" IS NULL`
+    )
+    await client.query(
+      `UPDATE "site_design" SET "photo_treatment" = 'color' WHERE "photo_treatment" IS NULL`
+    )
+    console.log('✓ site_design paper_grain/photo_treatment columns ready')
   } finally {
     client.release()
     await pool.end()


### PR DESCRIPTION
Issue 3 of the Rising Roots shell. Two finishes that are applied **by the shell** rather than baked into individual photos, so they work on whatever Tynnell uploads later and are reversible from `/design` without touching a file.

## Paper grain

A fixed, non-interactive overlay driven by `--paper-grain-opacity`.

- The noise is an **inline SVG `feTurbulence` data URI**, not a bitmap. No extra request, nothing for LCP to wait on, and it tiles seamlessly at any viewport size.
- `z-index: 1` puts it above the page background but below the navbar, mobile menu and modals, which all set their own higher stacking.
- `pointer-events: none`, so it can never swallow a click.
- Opacity tops out at **0.09**. Past that the texture starts competing with the photography instead of sitting under it, which is the opposite of what it is for.
- Renders nothing at all at the default of `none`.

## Photo color treatment

A `saturate()` filter rather than a `grayscale()` toggle, so *Muted* (0.65) and *Nearly black & white* (0.3) are real points on one axis with *Black & white* at the 0 end.

Scoped to `<img>` so inline SVG (social icons, the logo mark) keeps its own color, with a `.no-photo-treatment` opt-out for anything that should stay untouched.

**Neither finish alters an uploaded file.** A client's download is still the untouched original, the same guarantee the existing sharpening control makes.

## Inert by default

Both default to off (`none` / `color`). Nothing changes until they are set in **/design > Texture**.

## Migration note

Payload selects are backed by real postgres enums, so this creates two enum types rather than adding varchar columns. Same trap as `promotedRoute` and the font roles.

## Verification

- Real `next build`, **exit 0** (this covers typecheck)
- ESLint clean on all five changed source files
- Confirmed against the database that both enum types exist with the right labels and the row backfilled with no NULLs

## Note

`payload-types.ts` hand-edited again. `generate:types` still fails on Node v24 with `TypeError: T.registerHooks is not a function`.

## After merging

The grain and desaturation are what will make the site actually read as Rising Roots rather than a recoloured version of itself, but they need turning on in `/design` (a data change) once this is deployed. Worth doing at the same time as switching the heading/body font roles to Cormorant, since those are also still on their defaults.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
