### PR TITLE
feat(chrome): rebuild header and footer for Rising Roots

### DIFF
--- a/app/components/Footer/Footer.module.css
+++ b/app/components/Footer/Footer.module.css
@@ -114,6 +114,109 @@
   transform: scale(1.04);
 }
 
+/* ── Main footer (wordmark / contact / nav) ──────────────── */
+
+.main {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  gap: 2.5rem;
+  align-items: start;
+  padding: 3.5rem var(--padding-x) 2.5rem;
+  border-top: 1px solid var(--color-border);
+}
+
+.footerBrand {
+  display: flex;
+  flex-direction: column;
+  text-decoration: none;
+  line-height: 1.05;
+}
+
+.footerMark {
+  font-family: var(--font-heading);
+  font-size: 1.6rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--color-heading);
+  white-space: nowrap;
+}
+
+.footerSub {
+  font-family: var(--font-label, var(--font-body));
+  font-size: 0.5rem;
+  letter-spacing: 0.42em;
+  text-indent: 0.42em;
+  text-transform: uppercase;
+  color: var(--color-detail);
+  margin-top: 0.3rem;
+}
+
+.contactBlock {
+  display: flex;
+  flex-direction: column;
+  gap: 0.55rem;
+  justify-self: center;
+}
+
+.location,
+.contactEmail {
+  font-family: var(--font-body);
+  font-size: 0.68rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--color-detail);
+  text-decoration: none;
+}
+
+.contactEmail {
+  transition: color 0.2s ease;
+}
+
+.contactEmail:hover {
+  color: var(--color-heading);
+}
+
+.footerNav {
+  display: flex;
+  gap: 3rem;
+}
+
+.footerNavColumn {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.55rem;
+}
+
+.footerNavLink {
+  font-family: var(--font-body);
+  font-size: 0.68rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--color-detail);
+  text-decoration: none;
+  transition: color 0.2s ease;
+}
+
+.footerNavLink:hover {
+  color: var(--color-heading);
+}
+
+@media (max-width: 900px) {
+  .main {
+    grid-template-columns: 1fr;
+    gap: 2rem;
+    text-align: center;
+    justify-items: center;
+  }
+  .footerBrand { align-items: center; }
+  .contactBlock { justify-self: center; align-items: center; }
+  .footerNav { gap: 2.5rem; }
+  .footerNavColumn { align-items: center; }
+}
+
 /* ── Bottom bar ──────────────────────────────────────────── */
 
 .bottom {

--- a/app/components/Footer/Footer.tsx
+++ b/app/components/Footer/Footer.tsx
@@ -3,10 +3,25 @@ import Image from 'next/image'
 import { getPayload } from 'payload'
 import config from '@payload-config'
 import { CONTACT_EMAIL } from '@/app/lib/constants'
+import { navLinks, type NavLink } from '@/app/constants/nav'
 import styles from './Footer.module.css'
 
 const INSTAGRAM_URL = 'https://instagram.com/tynnellhollinsphotography'
 const TIKTOK_URL = 'https://tiktok.com/@tynnellhollinsphotography'
+
+// Sourced from Tynnell's own Showit footer. Lives here beside CONTACT_EMAIL
+// for now (app/lib/constants.ts is the existing single-source-of-truth
+// pattern); SiteConfig has no location field yet, and adding one would collide
+// with the open TYN-326 PR that wires SiteConfig into the site.
+const STUDIO_LOCATION = 'Based in New Mexico | Travel Worldwide'
+
+// Two columns, matching the reference and her Showit draft. Built from the
+// shared nav constant so a route rename cannot leave the footer pointing at a
+// dead link.
+const FOOTER_NAV_COLUMNS: NavLink[][] = [
+  navLinks.filter(l => ['Home', 'About', 'Portfolio'].includes(l.label)),
+  navLinks.filter(l => ['Services', 'Contact', 'Blog'].includes(l.label)),
+]
 
 export default async function Footer() {
   const year = new Date().getFullYear()
@@ -67,7 +82,38 @@ export default async function Footer() {
         )}
       </div>
 
-      {/* Bottom bar */}
+      {/* Main footer: wordmark, contact block, two-column nav. Mirrors the
+          Rising Roots footer and Tynnell's own Showit draft, which read
+          wordmark / location + email / two nav columns. */}
+      <div className={styles.main}>
+        <Link href="/" className={styles.footerBrand} aria-label="Tynnell Hollins Photography, home">
+          <span className={styles.footerMark}>Tynnell Hollins</span>
+          <span className={styles.footerSub}>Photography</span>
+        </Link>
+
+        <div className={styles.contactBlock}>
+          <p className={styles.location}>{STUDIO_LOCATION}</p>
+          <a href={`mailto:${CONTACT_EMAIL}`} className={styles.contactEmail}>
+            {CONTACT_EMAIL}
+          </a>
+        </div>
+
+        <nav className={styles.footerNav} aria-label="Footer navigation">
+          {FOOTER_NAV_COLUMNS.map((column, i) => (
+            <ul key={i} className={styles.footerNavColumn}>
+              {column.map(link => (
+                <li key={link.href}>
+                  <Link href={link.href} className={styles.footerNavLink}>
+                    {link.label}
+                  </Link>
+                </li>
+              ))}
+            </ul>
+          ))}
+        </nav>
+      </div>
+
+      {/* Legal row */}
       <div className={styles.bottom}>
         <div className={styles.socials}>
           <a

--- a/app/components/Navbar/Navbar.module.css
+++ b/app/components/Navbar/Navbar.module.css
@@ -1,24 +1,31 @@
+/* Three columns so the brand mark stays optically centred no matter how wide
+   the link groups are. space-between would drift it off-centre the moment one
+   side gains a link (a builder page flagged show-in-nav, for instance). */
+
 .navbar {
   position: fixed;
   top: 0;
   left: 0;
   right: 0;
   z-index: 100;
-  display: flex;
-  align-items: flex-start;
-  justify-content: space-between;
-  padding: 1.5rem var(--padding-x);
+  display: grid;
+  grid-template-columns: 1fr auto 1fr;
+  align-items: center;
+  gap: 1.5rem;
+  padding: 1.25rem var(--padding-x);
   background: transparent;
   transition: background 0.35s ease, padding 0.3s ease;
 }
 
-.scrolled {
-  background: var(--color-bg);
-  padding: 1rem var(--padding-x);
-}
-
+/* Solid brand-olive bar on scroll, matching the reference. This reuses the
+   button tokens rather than inventing a hardcoded olive, so it stays
+   adjustable from /design (Colors > Button color / Button text color). If the
+   nav ever needs a colour independent of the buttons, that wants its own
+   SiteDesign field rather than a literal here. */
+.scrolled,
 .menuOpen {
-  background: var(--color-bg);
+  background: var(--color-btn-bg);
+  padding: 0.85rem var(--padding-x);
 }
 
 /* ── Brand ───────────────────────────────────────────────── */
@@ -26,8 +33,9 @@
 .brand {
   display: flex;
   flex-direction: column;
+  align-items: center;
   text-decoration: none;
-  line-height: 1.08;
+  line-height: 1.05;
   flex-shrink: 0;
 }
 
@@ -38,30 +46,44 @@
   object-fit: contain;
 }
 
-.brandLine {
+.brandMark {
   display: block;
   font-family: var(--font-heading);
-  font-size: 1rem;
-  font-weight: 800;
-  letter-spacing: 0.08em;
+  font-size: 1.35rem;
+  font-weight: 400;
+  letter-spacing: 0.16em;
   text-transform: uppercase;
-  color: rgba(255, 255, 255, 0.95);
+  white-space: nowrap;
+  color: rgba(255, 255, 255, 0.96);
   transition: color 0.3s ease;
 }
 
-.scrolled .brandLine,
-.menuOpen .brandLine {
-  color: var(--color-heading);
+.brandSub {
+  display: block;
+  font-family: var(--font-label, var(--font-body));
+  font-size: 0.52rem;
+  font-weight: 400;
+  letter-spacing: 0.42em;
+  text-transform: uppercase;
+  /* The tracking adds a trailing gap on the last letter; pull it back so the
+     subline stays optically centred under the mark. */
+  text-indent: 0.42em;
+  color: rgba(255, 255, 255, 0.62);
+  margin-top: 0.28rem;
+  transition: color 0.3s ease;
+}
+
+.scrolled .brandMark,
+.menuOpen .brandMark {
+  color: var(--color-btn-text);
+}
+
+.scrolled .brandSub,
+.menuOpen .brandSub {
+  color: color-mix(in srgb, var(--color-btn-text) 70%, transparent);
 }
 
 /* ── Desktop link rows ───────────────────────────────────── */
-
-.linksWrapper {
-  display: flex;
-  flex-direction: column;
-  align-items: flex-end;
-  gap: 0.35rem;
-}
 
 .row {
   list-style: none;
@@ -72,8 +94,37 @@
   gap: 1.75rem;
 }
 
-.row2 {
-  align-self: flex-end;
+.rowLeft {
+  justify-content: flex-start;
+}
+
+.rowRight {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 1.75rem;
+}
+
+/* ── Inquire CTA ─────────────────────────────────────────── */
+/* The one script moment in the chrome, exactly as the reference uses it. */
+
+.cta {
+  font-family: var(--font-script-role, var(--font-display));
+  font-size: 1.5rem;
+  line-height: 1;
+  color: rgba(255, 255, 255, 0.95);
+  text-decoration: none;
+  white-space: nowrap;
+  transition: color 0.2s ease, opacity 0.2s ease;
+}
+
+.cta:hover {
+  opacity: 0.75;
+}
+
+.scrolled .cta,
+.menuOpen .cta {
+  color: var(--color-btn-text);
 }
 
 /* ── Nav links ───────────────────────────────────────────── */
@@ -103,12 +154,12 @@
 
 .scrolled .link,
 .menuOpen .link {
-  color: var(--color-detail);
+  color: color-mix(in srgb, var(--color-btn-text) 82%, transparent);
 }
 
 .scrolled .link:hover,
 .menuOpen .link:hover {
-  color: var(--color-heading);
+  color: var(--color-btn-text);
 }
 
 /* ── Portfolio dropdown ──────────────────────────────────── */
@@ -200,7 +251,7 @@
 
 .scrolled .bar,
 .menuOpen .bar {
-  background: var(--color-heading);
+  background: var(--color-btn-text);
 }
 
 .hamburgerOpen .bar:nth-child(1) {
@@ -216,15 +267,34 @@
 
 /* ── Responsive ──────────────────────────────────────────── */
 
-@media (min-width: 769px) and (max-width: 1080px) {
-  .row { gap: 1.1rem; }
+/* The three-column grid needs more room than the old stacked rows, so the
+   collapse point moves up: below 1024px the link groups go and the hamburger
+   takes over, leaving brand + CTA + burger. */
+
+@media (min-width: 1025px) and (max-width: 1240px) {
+  .row,
+  .rowRight { gap: 1.05rem; }
   .link { font-size: 0.6rem; letter-spacing: 0.12em; }
-  .brandLine { font-size: 0.85rem; }
+  .brandMark { font-size: 1.1rem; letter-spacing: 0.12em; }
+  .brandSub { font-size: 0.46rem; letter-spacing: 0.3em; text-indent: 0.3em; }
+  .cta { font-size: 1.25rem; }
 }
 
-@media (max-width: 768px) {
-  .linksWrapper { display: none; }
+@media (max-width: 1024px) {
+  .row { display: none; }
   .hamburger { display: flex; }
-  .brandLine { font-size: 0.9rem; }
-  .navbar { align-items: center; }
+  /* Collapse to two columns: brand hard left, CTA + burger hard right. The
+     empty 1fr on the left would otherwise push the brand off-centre with
+     nothing to balance it. */
+  .navbar { grid-template-columns: auto 1fr; }
+  .brand { align-items: flex-start; }
+  .brandMark { font-size: 1.1rem; }
+}
+
+@media (max-width: 560px) {
+  /* The script CTA and the burger start fighting for the same space; the
+     burger wins since the menu contains Contact anyway. */
+  .cta { display: none; }
+  .brandMark { font-size: 1rem; letter-spacing: 0.12em; }
+  .brandSub { font-size: 0.46rem; letter-spacing: 0.3em; text-indent: 0.3em; }
 }

--- a/app/components/Navbar/Navbar.tsx
+++ b/app/components/Navbar/Navbar.tsx
@@ -7,7 +7,14 @@ import { useScrollLock } from '@/app/hooks/useScrollLock'
 import MobileMenu from '@/app/components/MobileMenu/MobileMenu'
 import styles from './Navbar.module.css'
 
-const ROW1 = ['Home', 'About', 'Portfolio', 'Services', 'Testimonials']
+// Rising Roots splits the primary links either side of a centred brand mark,
+// with the contact link promoted out of the row into a script CTA. LEFT_LINKS
+// fixes which labels sit on which side; everything else (including builder
+// pages flagged show-in-nav) lands on the right, and CTA_LABEL is pulled out
+// of the rows entirely.
+const LEFT_LINKS = ['Home', 'About', 'Portfolio']
+const CTA_LABEL = 'Contact'
+const CTA_TEXT = 'Inquire now'
 
 export default function Navbar({ builderLinks = [], logoUrl }: { builderLinks?: NavLink[]; logoUrl?: string }) {
   const [scrolled, setScrolled] = useState(false)
@@ -68,8 +75,57 @@ export default function Navbar({ builderLinks = [], logoUrl }: { builderLinks?: 
   useEffect(() => { setPortfolioOpen(false) }, [pathname])
 
   const allLinks = [...navLinks, ...builderLinks]
-  const row1Links = allLinks.filter(l => ROW1.includes(l.label))
-  const row2Links = allLinks.filter(l => !ROW1.includes(l.label))
+  const ctaLink = allLinks.find(l => l.label === CTA_LABEL)
+  const rowLinks = allLinks.filter(l => l.label !== CTA_LABEL)
+  const leftLinks = rowLinks.filter(l => LEFT_LINKS.includes(l.label))
+  const rightLinks = rowLinks.filter(l => !LEFT_LINKS.includes(l.label))
+
+  // Both sides render the same way, dropdown included, so this stays one
+  // implementation rather than two that can drift.
+  const renderLink = (link: NavLink) =>
+    link.children ? (
+      <li
+        key={link.href}
+        className={styles.hasDropdown}
+        ref={dropdownRef}
+        onMouseEnter={openDropdown}
+        onMouseLeave={scheduleCloseDropdown}
+      >
+        <button
+          className={styles.link}
+          onClick={() => setPortfolioOpen(p => !p)}
+          aria-expanded={portfolioOpen}
+          aria-haspopup="true"
+        >
+          {link.label}
+          <span className={`${styles.arrow} ${portfolioOpen ? styles.arrowOpen : ''}`} aria-hidden="true" />
+        </button>
+        <ul className={`${styles.dropdown} ${portfolioOpen ? styles.dropdownOpen : ''}`} role="menu">
+          {link.children.map(child => (
+            <li key={child.href} role="none">
+              <Link
+                href={child.href}
+                className={styles.dropdownItem}
+                role="menuitem"
+                onClick={() => setPortfolioOpen(false)}
+              >
+                {child.label}
+              </Link>
+            </li>
+          ))}
+        </ul>
+      </li>
+    ) : (
+      <li key={link.href}>
+        <Link
+          href={link.href}
+          className={styles.link}
+          aria-current={pathname === link.href ? 'page' : undefined}
+        >
+          {link.label}
+        </Link>
+      </li>
+    )
 
   const navClass = [
     styles.navbar,
@@ -80,96 +136,47 @@ export default function Navbar({ builderLinks = [], logoUrl }: { builderLinks?: 
   return (
     <>
       <nav className={navClass} aria-label="Main navigation">
+        <ul className={`${styles.row} ${styles.rowLeft}`} aria-label="Site navigation">
+          {leftLinks.map(renderLink)}
+        </ul>
+
         <Link href="/" className={styles.brand} aria-label="Tynnell Hollins Photography, home">
           {logoUrl ? (
             // eslint-disable-next-line @next/next/no-img-element
             <img src={logoUrl} alt="Tynnell Hollins Photography" className={styles.brandLogo} />
           ) : (
             <>
-              <span className={styles.brandLine}>Tynnell</span>
-              <span className={styles.brandLine}>Hollins</span>
-              <span className={styles.brandLine}>Photography</span>
+              {/* Two lines, not three. The old stacked
+                  Tynnell/Hollins/Photography wordmark is the design problem
+                  CLAUDE.md flags: it reads as a column of shouting rather than
+                  a mark, and it cannot centre. */}
+              <span className={styles.brandMark}>Tynnell Hollins</span>
+              <span className={styles.brandSub}>Photography</span>
             </>
           )}
         </Link>
 
-        <div className={styles.linksWrapper}>
-          <ul className={styles.row} aria-label="Site navigation">
-            {row1Links.map(link =>
-              link.children ? (
-                <li
-                  key={link.href}
-                  className={styles.hasDropdown}
-                  ref={dropdownRef}
-                  onMouseEnter={openDropdown}
-                  onMouseLeave={scheduleCloseDropdown}
-                >
-                  <button
-                    className={styles.link}
-                    onClick={() => setPortfolioOpen(p => !p)}
-                    aria-expanded={portfolioOpen}
-                    aria-haspopup="true"
-                  >
-                    {link.label}
-                    <span className={`${styles.arrow} ${portfolioOpen ? styles.arrowOpen : ''}`} aria-hidden="true" />
-                  </button>
-                  <ul className={`${styles.dropdown} ${portfolioOpen ? styles.dropdownOpen : ''}`} role="menu">
-                    {link.children.map(child => (
-                      <li key={child.href} role="none">
-                        <Link
-                          href={child.href}
-                          className={styles.dropdownItem}
-                          role="menuitem"
-                          onClick={() => setPortfolioOpen(false)}
-                        >
-                          {child.label}
-                        </Link>
-                      </li>
-                    ))}
-                  </ul>
-                </li>
-              ) : (
-                <li key={link.href}>
-                  <Link
-                    href={link.href}
-                    className={styles.link}
-                    aria-current={pathname === link.href ? 'page' : undefined}
-                  >
-                    {link.label}
-                  </Link>
-                </li>
-              )
-            )}
-          </ul>
+        <div className={styles.rowRight}>
+          <ul className={styles.row}>{rightLinks.map(renderLink)}</ul>
 
-          {row2Links.length > 0 && (
-            <ul className={`${styles.row} ${styles.row2}`}>
-              {row2Links.map(link => (
-                <li key={link.href}>
-                  <Link
-                    href={link.href}
-                    className={styles.link}
-                    aria-current={pathname === link.href ? 'page' : undefined}
-                  >
-                    {link.label}
-                  </Link>
-                </li>
-              ))}
-            </ul>
+          {ctaLink && (
+            <Link href={ctaLink.href} className={styles.cta}>
+              {CTA_TEXT}
+            </Link>
           )}
-        </div>
 
-        <button
+          <button
           className={`${styles.hamburger} ${menuOpen ? styles.hamburgerOpen : ''}`}
           onClick={() => setMenuOpen(p => !p)}
           aria-label={menuOpen ? 'Close navigation menu' : 'Open navigation menu'}
           aria-expanded={menuOpen}
           aria-controls="mobile-menu"
         >
-          <span className={styles.bar} aria-hidden="true" />
-          <span className={styles.bar} aria-hidden="true" />
-          <span className={styles.bar} aria-hidden="true" />
-        </button>
+            <span className={styles.bar} aria-hidden="true" />
+            <span className={styles.bar} aria-hidden="true" />
+            <span className={styles.bar} aria-hidden="true" />
+          </button>
+        </div>
       </nav>
 
       <MobileMenu isOpen={menuOpen} onClose={() => setMenuOpen(false)} links={allLinks} />


### PR DESCRIPTION
Issue 4 of the Rising Roots shell: the persistent furniture.

## Header

Restructured from "brand left, two stacked link rows right" to the reference layout: primary links split either side of a **centred brand mark**, the contact link promoted out of the rows into a **script CTA**, plus the hamburger.

Uses a **3-column grid (`1fr auto 1fr`)** rather than `space-between`. With `space-between` the brand drifts off-centre the moment one side gains a link, which happens whenever a builder page is flagged show-in-nav. The grid keeps it optically centred regardless.

On scroll the bar goes **solid brand-olive with cream text**, matching the reference.

## The 3-line wordmark

CLAUDE.md flags the stacked `Tynnell / Hollins / Photography` wordmark as a known design problem, deliberately skipped during TYN-326. This fixes it: a single letterspaced mark with a small tracked subline underneath. Two lines, not three, and it can actually centre.

## Footer

Gains the reference's main row above the existing socials/copyright (now a legal row):

- Wordmark, matching the header treatment
- Contact block: location + email
- Two nav columns

Nav columns are built from the shared `navLinks` constant, so a route rename can't leave the footer pointing at a dead link.

## Responsive

The collapse point moves **768px to 1024px**, since three columns need more room than the old stacked rows. Below 560px the script CTA gives way to the hamburger, which contains Contact anyway.

## Colour tokens, not literals

The olive scroll bar reuses the existing **button** tokens rather than introducing a hardcoded olive, so it stays adjustable from `/design` and respects the TYN-338 convention. The coupling is slightly odd semantically. If the nav ever needs a colour independent of the buttons, that wants its own `SiteDesign` field rather than a literal.

## Verification

- Real `next build`, **exit 0** (covers typecheck)
- ESLint clean on both components
- **Served the build locally and asserted the rendered markup**: 2 brand spans not 3, no `brandLine` remaining, the script CTA present, all 6 footer nav links, location and email

## Not included, deliberately

**The hero corner labels.** They're hero furniture rather than chrome. On a promoted builder page the hero is a Puck block, so anchoring labels to it belongs with the editorial framework work (issue 5), not here. Bolting them onto the layout would have meant guessing where the hero ends.

## Two content notes

The location string is a module constant beside `CONTACT_EMAIL`. `SiteConfig` has no location field, and adding one now would collide with the open TYN-326 PR that wires SiteConfig into the site.

The email still comes from `constants.ts`. The `tynnellhollinsphoto.com` vs `tynnellhollinsphotography.com` conflict found in Tynnell's Showit footer is **still unconfirmed**, so it is not guessed at here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
