### PR TITLE
feat(design): make the taped photo frame work on the light ground

### DIFF
--- a/app/(site)/styles/tokens.css
+++ b/app/(site)/styles/tokens.css
@@ -36,7 +36,11 @@
   /* ── Tape treatment ───────────────────────────────────────── */
   --tape-mat:             #f4efe8;
   --tape-color:           rgba(214, 209, 206, 0.42);
-  --tape-shadow:          0 10px 26px rgba(0, 0, 0, 0.45);
+  /* Warm and low-alpha, not near-black: the old 0.45 black drop was tuned for
+     the charcoal ground and reads as grime under the print on bone paper.
+     Driven by SiteDesign (/design > Photo Frame > shadow); this is the
+     pre-SiteDesign fallback. */
+  --tape-shadow:          0 4px 14px rgba(60, 55, 40, 0.10);
 
   /* ── Typography ───────────────────────────────────────────── */
   --font-display:         'Tangerine', cursive;

--- a/app/api/design/save/route.ts
+++ b/app/api/design/save/route.ts
@@ -33,6 +33,7 @@ const FIELDS = [
   'colorBorderSolid',
   'tapeMatColor',
   'tapeColor',
+  'tapeShadow',
   'paperGrain',
   'photoTreatment',
   'spacingScale',

--- a/app/builder/DesignPanelShared.tsx
+++ b/app/builder/DesignPanelShared.tsx
@@ -100,6 +100,12 @@ export const TAPE_FIELDS: { key: keyof Pick<SiteTheme, 'tapeMatColor' | 'tapeCol
   { key: 'tapeMatColor', label: 'Photo mat color' },
   { key: 'tapeColor', label: 'Tape strip color' },
 ]
+export const TAPE_SHADOW_OPTIONS: { label: string; value: SiteTheme['tapeShadow'] }[] = [
+  { label: 'None', value: 'none' },
+  { label: 'Soft', value: 'soft' },
+  { label: 'Medium', value: 'medium' },
+  { label: 'Strong', value: 'strong' },
+]
 
 export function AccordionRow({ label, isOpen, onToggle, children }: { label: string; isOpen: boolean; onToggle: () => void; children: React.ReactNode }) {
   return (
@@ -218,6 +224,12 @@ export function DesignSections({
             <ColorInput value={theme[f.key]} onChange={(v) => set(f.key, v)} />
           </div>
         ))}
+        <FieldLabel style={{ marginTop: 12 }}>Photo frame shadow</FieldLabel>
+        <Select value={theme.tapeShadow} onChange={(v) => set('tapeShadow', v as SiteTheme['tapeShadow'])} options={TAPE_SHADOW_OPTIONS} />
+        <p style={{ color: '#6b6a6a', fontSize: 11, marginTop: 8 }}>
+          The taped photo frame is opt-in wherever it appears: per gallery in the gallery settings, and per block in the page
+          builder. Nothing uses it unless you turn it on there.
+        </p>
         <p style={{ color: '#6b6a6a', fontSize: 11, marginTop: 8 }}>Used by the Taped and Polaroid photo styles across the portfolio, galleries, and builder.</p>
       </AccordionRow>
 

--- a/app/lib/siteDesign.ts
+++ b/app/lib/siteDesign.ts
@@ -47,6 +47,7 @@ export const getSiteDesign = cache(async (): Promise<SiteTheme> => {
       colorBorderSolid: doc.colorBorderSolid || DEFAULT_THEME.colorBorderSolid,
       tapeMatColor: doc.tapeMatColor || DEFAULT_THEME.tapeMatColor,
       tapeColor: doc.tapeColor || DEFAULT_THEME.tapeColor,
+      tapeShadow: doc.tapeShadow || DEFAULT_THEME.tapeShadow,
       paperGrain: doc.paperGrain || DEFAULT_THEME.paperGrain,
       photoTreatment: doc.photoTreatment || DEFAULT_THEME.photoTreatment,
       spacingScale: doc.spacingScale || DEFAULT_THEME.spacingScale,

--- a/app/lib/siteTheme.ts
+++ b/app/lib/siteTheme.ts
@@ -16,6 +16,7 @@ export type ScriptChoice = 'parisienne' | 'tangerine'
 // rather than baked into the files themselves.
 export type PaperGrain = 'none' | 'subtle' | 'medium' | 'strong'
 export type PhotoTreatment = 'color' | 'muted' | 'faded' | 'bw'
+export type TapeShadow = 'none' | 'soft' | 'medium' | 'strong'
 
 export interface SiteTheme {
   logoUrl: string
@@ -42,6 +43,7 @@ export interface SiteTheme {
   colorBorderSolid: string
   tapeMatColor: string
   tapeColor: string
+  tapeShadow: TapeShadow
   paperGrain: PaperGrain
   photoTreatment: PhotoTreatment
   spacingScale: 'compact' | 'normal' | 'spacious'
@@ -75,6 +77,7 @@ export const DEFAULT_THEME: SiteTheme = {
   colorBorderSolid: '#1e1e1e',
   tapeMatColor: '#f4efe8',
   tapeColor: 'rgba(214, 209, 206, 0.42)',
+  tapeShadow: 'soft',
   paperGrain: 'none',
   photoTreatment: 'color',
   spacingScale: 'normal',
@@ -127,6 +130,16 @@ const PHOTO_SATURATION: Record<PhotoTreatment, string> = {
   bw: '0',
 }
 
+// Warm, low-alpha shadows rather than near-black. On a bone ground a
+// rgba(0,0,0,0.45) drop reads as grime under the print; these are tinted
+// toward the olive so the frame sits on the paper instead of hovering over it.
+const TAPE_SHADOW: Record<TapeShadow, string> = {
+  none: 'none',
+  soft: '0 4px 14px rgba(60, 55, 40, 0.10)',
+  medium: '0 8px 22px rgba(60, 55, 40, 0.16)',
+  strong: '0 14px 32px rgba(60, 55, 40, 0.24)',
+}
+
 const BTN_RADIUS: Record<SiteTheme['buttonStyle'], string> = {
   sharp: '2px',
   rounded: '8px',
@@ -154,6 +167,7 @@ export function themeToCssVarMap(theme: SiteTheme): Record<string, string> {
     '--color-border-solid': theme.colorBorderSolid,
     '--tape-mat': theme.tapeMatColor,
     '--tape-color': theme.tapeColor,
+    '--tape-shadow': TAPE_SHADOW[theme.tapeShadow],
     '--paper-grain-opacity': GRAIN_OPACITY[theme.paperGrain],
     '--photo-saturation': PHOTO_SATURATION[theme.photoTreatment],
     '--space-scale': String(SPACE_SCALE[theme.spacingScale]),

--- a/globals/SiteDesign.ts
+++ b/globals/SiteDesign.ts
@@ -196,6 +196,23 @@ export const SiteDesign: GlobalConfig = {
       label: 'Tape strip color',
       defaultValue: 'rgba(214, 209, 206, 0.42)',
     },
+    // The frame shadow was the last hardcoded piece of the taped treatment,
+    // and it was tuned for the old charcoal ground: a heavy near-black drop
+    // that reads as dirt on a light paper ground. A select of presets rather
+    // than a raw CSS string, because "0 10px 26px rgba(0,0,0,0.45)" is not a
+    // control Tynnell can reason about.
+    {
+      name: 'tapeShadow',
+      type: 'select',
+      label: 'Photo frame shadow',
+      defaultValue: 'soft',
+      options: [
+        { label: 'None', value: 'none' },
+        { label: 'Soft', value: 'soft' },
+        { label: 'Medium', value: 'medium' },
+        { label: 'Strong', value: 'strong' },
+      ],
+    },
     // Two shell-level finishes (Rising Roots). Both are applied BY the shell
     // rather than baked into any individual photo, so they work on whatever
     // Tynnell uploads later. Both default to off, so this is inert until set.

--- a/payload-types.ts
+++ b/payload-types.ts
@@ -1082,6 +1082,7 @@ export interface SiteDesign {
   colorBorderSolid?: string | null;
   tapeMatColor?: string | null;
   tapeColor?: string | null;
+  tapeShadow?: ('none' | 'soft' | 'medium' | 'strong') | null;
   paperGrain?: ('none' | 'subtle' | 'medium' | 'strong') | null;
   photoTreatment?: ('color' | 'muted' | 'faded' | 'bw') | null;
   spacingScale?: ('compact' | 'normal' | 'spacious') | null;
@@ -1290,6 +1291,7 @@ export interface SiteDesignSelect<T extends boolean = true> {
   colorBorderSolid?: T;
   tapeMatColor?: T;
   tapeColor?: T;
+  tapeShadow?: T;
   paperGrain?: T;
   photoTreatment?: T;
   spacingScale?: T;

--- a/scripts/migrate-db.mjs
+++ b/scripts/migrate-db.mjs
@@ -951,6 +951,29 @@ async function run() {
       `UPDATE "site_design" SET "photo_treatment" = 'color' WHERE "photo_treatment" IS NULL`
     )
     console.log('✓ site_design paper_grain/photo_treatment columns ready')
+
+    // ------------------------------------------------------------------
+    // Migration 20260810_130000: tape frame shadow (TYN-338 follow-on)
+    // The last hardcoded piece of the taped photo treatment. A select, so
+    // the postgres adapter wants a real enum type.
+    // ------------------------------------------------------------------
+
+    await client.query(`
+      DO $$ BEGIN
+        CREATE TYPE "enum_site_design_tape_shadow" AS ENUM
+          ('none', 'soft', 'medium', 'strong');
+      EXCEPTION WHEN duplicate_object THEN NULL;
+      END $$
+    `)
+    await client.query(`
+      ALTER TABLE "site_design"
+        ADD COLUMN IF NOT EXISTS "tape_shadow" "enum_site_design_tape_shadow"
+        DEFAULT 'soft'
+    `)
+    await client.query(
+      `UPDATE "site_design" SET "tape_shadow" = 'soft' WHERE "tape_shadow" IS NULL`
+    )
+    console.log('✓ site_design tape_shadow column ready')
   } finally {
     client.release()
     await pool.end()


### PR DESCRIPTION
Decision made: **keep the taped/polaroid treatment**, available wherever Tynnell wants it rather than applied automatically.

## What was actually broken

Its shadow was the last hardcoded piece of the treatment. TYN-338 exposed the mat and tape-strip colors but not this one, and it was tuned for the old charcoal ground:

```
--tape-shadow: 0 10px 26px rgba(0, 0, 0, 0.45);
```

A near-black drop at 45% reads as grime under the print on bone paper. That, not the mat color, is why taped photos looked wrong after the palette inversion.

## Fix

Adds a `tapeShadow` control (None / Soft / Medium / Strong, default Soft) mapping to warm low-alpha shadows tinted toward the olive, so the frame sits on the paper instead of hovering over it.

A select of presets rather than a raw CSS string, because `0 10px 26px rgba(0,0,0,0.45)` is not a control Tynnell can reason about.

## Opt-in status, checked rather than assumed

The treatment is already per-use on every surface that renders today: per gallery via `Gallery.tapedStyle`, and per block via the builder Photo Gallery style. The `/design` panel now says so, since "where does this even apply?" is the obvious question when looking at the control.

Two surfaces still force it on:

- About headshot, `app/(site)/about/page.module.css` `.storyImage`
- Portfolio teaser cards, `app/components/PortfolioTeaser/PortfolioTeaser.module.css` `.card`

Both sit on the hardcoded render paths that promoted builder pages currently supersede, so neither renders on the live site. Left alone deliberately rather than adding a toggle plumbed to nothing.

## Not changed

Mat and tape-strip colors. They are already adjustable, and the shadow was the part that was actually wrong. Retuning colors without seeing them against real photos would be guessing.

## Verification

Real `next build` (exit 0), ESLint clean, migration applied and confirmed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)