### PR TITLE
feat(site): wire SiteConfig into the public site (TYN-326, redo)

### DIFF
--- a/app/(site)/about/page.tsx
+++ b/app/(site)/about/page.tsx
@@ -11,6 +11,7 @@ import config from '@payload-config'
 import { config as puckConfig } from '@/app/builder/puck.config'
 import type { Photo } from '@/payload-types'
 import JsonLd from '@/app/components/JsonLd/JsonLd'
+import { getSiteConfig, type SiteConfigData } from '@/app/lib/siteConfig'
 import { isPreviewMode } from '@/app/lib/builderPreview'
 import SpecialtyReveal from './SpecialtyReveal'
 import styles from './page.module.css'
@@ -119,16 +120,16 @@ const FALLBACK_CATEGORY_BY_HEADING: Record<string, string> = {
 // aware block" convention exists in this codebase). Kept separate from the
 // hardcoded branch's personSchema below, which additionally includes the
 // live headshot image.
-const PROMOTED_PERSON_SCHEMA = {
+const promotedPersonSchema = (site: SiteConfigData) => ({
   '@context': 'https://schema.org',
   '@type': 'Person',
   name: 'Tynnell Hollins',
   jobTitle: 'Photographer',
   url: 'https://tynnellhollinsphotography.com/about',
-  sameAs: ['https://instagram.com/tynnellhollinsphotography'],
+  sameAs: [site.instagramUrl].filter(Boolean),
   worksFor: {
     '@type': 'LocalBusiness',
-    name: 'Tynnell Hollins Photography',
+    name: site.title,
     url: 'https://tynnellhollinsphotography.com',
   },
   knowsAbout: ['Wedding Photography', 'Portrait Photography', 'Family Photography', 'Engagement Photography', 'Maternity Photography'],
@@ -138,15 +139,15 @@ const PROMOTED_PERSON_SCHEMA = {
     addressRegion: 'NM',
     addressCountry: 'US',
   },
-}
+})
 
 export default async function AboutPage() {
-  const promoted = await getPromotedAboutPage()
+  const [promoted, site] = await Promise.all([getPromotedAboutPage(), getSiteConfig()])
   if (promoted) {
     const data = (promoted.content as Data | undefined) ?? { content: [], root: {} }
     return (
       <>
-        <JsonLd data={PROMOTED_PERSON_SCHEMA} />
+        <JsonLd data={promotedPersonSchema(site)} />
         <Render config={puckConfig} data={await resolveAllData(data, puckConfig)} />
       </>
     )
@@ -177,7 +178,7 @@ export default async function AboutPage() {
     name: 'Tynnell Hollins',
     jobTitle: 'Photographer',
     url: 'https://tynnellhollinsphotography.com/about',
-    sameAs: ['https://instagram.com/tynnellhollinsphotography'],
+    sameAs: [site.instagramUrl].filter(Boolean),
     worksFor: {
       '@type': 'LocalBusiness',
       name: 'Tynnell Hollins Photography',

--- a/app/(site)/blog/page.tsx
+++ b/app/(site)/blog/page.tsx
@@ -35,7 +35,7 @@ export async function generateMetadata(): Promise<Metadata> {
   const promoted = await getPromotedPage()
   if (promoted) return { title: promoted.title }
   return {
-    title: 'Blog | Tynnell Hollins Photography',
+    title: 'Blog',
     description: 'Photography tips, session guides, and stories from behind the lens by Tynnell Hollins.',
   }
 }

--- a/app/(site)/contact/page.tsx
+++ b/app/(site)/contact/page.tsx
@@ -8,7 +8,7 @@ import { config as puckConfig } from '@/app/builder/puck.config'
 import ContactForm from './ContactForm'
 import JsonLd from '@/app/components/JsonLd/JsonLd'
 import styles from './page.module.css'
-import { CONTACT_EMAIL } from '@/app/lib/constants'
+import { getSiteConfig } from '@/app/lib/siteConfig'
 import { getActiveOoo, type BlockedRange } from '@/app/lib/availability'
 import { computeBookingDateBounds } from '@/app/lib/validation'
 import { isPreviewMode } from '@/app/lib/builderPreview'
@@ -74,7 +74,7 @@ function findActiveOrUpcoming(ranges: BlockedRange[]): string | null {
 }
 
 export default async function ContactPage() {
-  const promoted = await getPromotedPage()
+  const [promoted, site] = await Promise.all([getPromotedPage(), getSiteConfig()])
 
   let oooMessage: string | null = null
   let minDate: string
@@ -105,13 +105,13 @@ export default async function ContactPage() {
   const contactPageSchema = {
     '@context': 'https://schema.org',
     '@type': 'ContactPage',
-    name: 'Contact Tynnell Hollins Photography',
+    name: `Contact ${site.title}`,
     description: 'Book a session or send an inquiry. Weddings, engagements, portraits, and more.',
     url: 'https://tynnellhollinsphotography.com/contact',
     mainEntity: {
       '@type': 'LocalBusiness',
-      name: 'Tynnell Hollins Photography',
-      email: CONTACT_EMAIL,
+      name: site.title,
+      email: site.email,
       url: 'https://tynnellhollinsphotography.com',
     },
   }
@@ -150,11 +150,11 @@ export default async function ContactPage() {
             Fill out the form and I&apos;ll be in touch within 48 hours.
           </p>
           <div className={styles.directContact}>
-            <a href={`mailto:${CONTACT_EMAIL}`} className={styles.contactLink}>
-              {CONTACT_EMAIL}
+            <a href={`mailto:${site.email}`} className={styles.contactLink}>
+              {site.email}
             </a>
             <span className={styles.contactDivider}>·</span>
-            <a href="https://instagram.com/tynnellhollinsphotography" className={styles.contactLink} target="_blank" rel="noopener noreferrer">
+            <a href={site.instagramUrl} className={styles.contactLink} target="_blank" rel="noopener noreferrer">
               @tynnellhollinsphotography
             </a>
           </div>

--- a/app/(site)/layout.tsx
+++ b/app/(site)/layout.tsx
@@ -15,6 +15,7 @@ import Navbar from '../components/Navbar/Navbar'
 import Footer from '../components/Footer/Footer'
 import { getBuilderNavLinks } from '@/app/lib/nav'
 import { getSiteDesign, themeToCssVars } from '@/app/lib/siteDesign'
+import { getSiteConfig } from '@/app/lib/siteConfig'
 import { DesignPreviewBridge } from '../components/DesignPreviewBridge'
 import { Analytics } from '@vercel/analytics/next'
 import { SpeedInsights } from '@vercel/speed-insights/next'
@@ -24,20 +25,23 @@ import { SpeedInsights } from '@vercel/speed-insights/next'
 // only allows one or the other per layout. getSiteDesign() is wrapped in
 // React's cache(), so this and the layout body's own call share one DB read.
 export async function generateMetadata(): Promise<Metadata> {
-  const theme = await getSiteDesign()
+  const [theme, site] = await Promise.all([getSiteDesign(), getSiteConfig()])
   return {
     metadataBase: new URL('https://tynnellhollinsphotography.com'),
+    // The template is what lets every child route set a bare title ("Blog")
+    // and still get the business name appended. Child routes that spell the
+    // business name out themselves would double it.
     title: {
-      default: 'Tynnell Hollins Photography',
-      template: '%s | Tynnell Hollins Photography',
+      default: site.title,
+      template: `%s | ${site.title}`,
     },
     description:
       'Albuquerque, New Mexico wedding and portrait photographer. Tynnell Hollins captures authentic, timeless moments for couples, families, and engagements.',
     openGraph: {
       type: 'website',
-      siteName: 'Tynnell Hollins Photography',
+      siteName: site.title,
       locale: 'en_US',
-      images: [{ url: '/og-image.jpg', width: 1200, height: 630, alt: 'Tynnell Hollins Photography' }],
+      images: [{ url: '/og-image.jpg', width: 1200, height: 630, alt: site.title }],
     },
     twitter: {
       card: 'summary_large_image',
@@ -62,7 +66,11 @@ export default async function RootLayout({
 }: {
   children: React.ReactNode
 }) {
-  const [builderLinks, theme] = await Promise.all([getBuilderNavLinks(), getSiteDesign()])
+  const [builderLinks, theme, site] = await Promise.all([
+    getBuilderNavLinks(),
+    getSiteDesign(),
+    getSiteConfig(),
+  ])
 
   return (
     <html
@@ -77,7 +85,7 @@ export default async function RootLayout({
       <style dangerouslySetInnerHTML={{ __html: `:root {\n  ${themeToCssVars(theme)}\n}` }} />
       <body suppressHydrationWarning>
         <a href="#main-content" className="skipLink">Skip to content</a>
-        <Navbar builderLinks={builderLinks} logoUrl={theme.logoUrl} />
+        <Navbar builderLinks={builderLinks} logoUrl={theme.logoUrl} siteTitle={site.title} />
         <div id="main-content" tabIndex={-1}>{children}</div>
         <Footer />
         <DesignPreviewBridge />

--- a/app/(site)/page.tsx
+++ b/app/(site)/page.tsx
@@ -5,7 +5,7 @@ import type { Data } from '@measured/puck'
 import config from '@payload-config'
 import { config as puckConfig } from '@/app/builder/puck.config'
 import JsonLd from '@/app/components/JsonLd/JsonLd'
-import { CONTACT_EMAIL } from '@/app/lib/constants'
+import { getSiteConfig } from '@/app/lib/siteConfig'
 import { isPreviewMode } from '@/app/lib/builderPreview'
 import Hero from '@/app/components/Hero/Hero'
 import PortfolioTeaser from '@/app/components/PortfolioTeaser/PortfolioTeaser'
@@ -22,6 +22,7 @@ import type { Photo } from '@/payload-types'
 export const revalidate = 120
 
 export default async function Home() {
+  const site = await getSiteConfig()
   const payload = await getPayload({ config })
 
   // A builder page can be promoted to the site homepage (TYN-227). When one is
@@ -107,7 +108,7 @@ export default async function Home() {
     description:
       'Tynnell Hollins is a wedding and portrait photographer capturing authentic moments for couples and families.',
     url: 'https://tynnellhollinsphotography.com',
-    email: CONTACT_EMAIL,
+    email: site.email,
     image: 'https://tynnellhollinsphotography.com/og-image.jpg',
     address: {
       '@type': 'PostalAddress',
@@ -120,7 +121,7 @@ export default async function Home() {
       { '@type': 'State', name: 'New Mexico' },
     ],
     sameAs: [
-      'https://instagram.com/tynnellhollinsphotography',
+      site.instagramUrl,
     ],
     founder: {
       '@type': 'Person',

--- a/app/(site)/testimonials/page.tsx
+++ b/app/(site)/testimonials/page.tsx
@@ -34,7 +34,7 @@ export async function generateMetadata(): Promise<Metadata> {
   const promoted = await getPromotedPage()
   if (promoted) return { title: promoted.title }
   return {
-    title: 'Client Words | Tynnell Hollins Photography',
+    title: 'Client Words',
     description: 'Kind words from couples, families, and portrait clients who have worked with Tynnell Hollins Photography.',
   }
 }

--- a/app/components/Footer/Footer.tsx
+++ b/app/components/Footer/Footer.tsx
@@ -2,17 +2,14 @@ import Link from 'next/link'
 import Image from 'next/image'
 import { getPayload } from 'payload'
 import config from '@payload-config'
-import { CONTACT_EMAIL } from '@/app/lib/constants'
+import { getSiteConfig, instagramHandle } from '@/app/lib/siteConfig'
+import { splitBrand } from '@/app/lib/constants'
 import { navLinks, type NavLink } from '@/app/constants/nav'
 import styles from './Footer.module.css'
 
-const INSTAGRAM_URL = 'https://instagram.com/tynnellhollinsphotography'
-const TIKTOK_URL = 'https://tiktok.com/@tynnellhollinsphotography'
-
-// Sourced from Tynnell's own Showit footer. Lives here beside CONTACT_EMAIL
-// for now (app/lib/constants.ts is the existing single-source-of-truth
-// pattern); SiteConfig has no location field yet, and adding one would collide
-// with the open TYN-326 PR that wires SiteConfig into the site.
+// Sourced from Tynnell's own Showit footer. Still a constant: SiteConfig has
+// no location field, and adding one is a schema change beyond the scope of
+// wiring up the fields that already exist. Worth promoting later.
 const STUDIO_LOCATION = 'Based in New Mexico | Travel Worldwide'
 
 // Two columns, matching the reference and her Showit draft. Built from the
@@ -26,6 +23,8 @@ const FOOTER_NAV_COLUMNS: NavLink[][] = [
 export default async function Footer() {
   const year = new Date().getFullYear()
 
+  const site = await getSiteConfig()
+  const brand = splitBrand(site.title)
   const payload = await getPayload({ config })
   const { docs: stripPhotos } = await payload.find({
     collection: 'photos',
@@ -52,13 +51,13 @@ export default async function Footer() {
         <div className={styles.igInfo}>
           <p className={styles.igLabel}>Follow me on Instagram</p>
           <a
-            href={INSTAGRAM_URL}
+            href={site.instagramUrl}
             target="_blank"
             rel="noopener noreferrer"
             className={styles.igHandle}
-            aria-label="Tynnell Hollins Photography on Instagram"
+            aria-label={`${site.title} on Instagram`}
           >
-            @tynnellhollinsphotography
+            {instagramHandle(site.instagramUrl)}
           </a>
         </div>
         {stripPhotos.length > 0 && (
@@ -86,15 +85,15 @@ export default async function Footer() {
           Rising Roots footer and Tynnell's own Showit draft, which read
           wordmark / location + email / two nav columns. */}
       <div className={styles.main}>
-        <Link href="/" className={styles.footerBrand} aria-label="Tynnell Hollins Photography, home">
-          <span className={styles.footerMark}>Tynnell Hollins</span>
-          <span className={styles.footerSub}>Photography</span>
+        <Link href="/" className={styles.footerBrand} aria-label={`${site.title}, home`}>
+          <span className={styles.footerMark}>{brand.mark}</span>
+          {brand.sub && <span className={styles.footerSub}>{brand.sub}</span>}
         </Link>
 
         <div className={styles.contactBlock}>
           <p className={styles.location}>{STUDIO_LOCATION}</p>
-          <a href={`mailto:${CONTACT_EMAIL}`} className={styles.contactEmail}>
-            {CONTACT_EMAIL}
+          <a href={`mailto:${site.email}`} className={styles.contactEmail}>
+            {site.email}
           </a>
         </div>
 
@@ -117,7 +116,7 @@ export default async function Footer() {
       <div className={styles.bottom}>
         <div className={styles.socials}>
           <a
-            href={INSTAGRAM_URL}
+            href={site.instagramUrl}
             target="_blank"
             rel="noopener noreferrer"
             className={styles.socialLink}
@@ -128,7 +127,7 @@ export default async function Footer() {
             </svg>
           </a>
           <a
-            href={TIKTOK_URL}
+            href={site.tiktokUrl}
             target="_blank"
             rel="noopener noreferrer"
             className={styles.socialLink}
@@ -139,16 +138,16 @@ export default async function Footer() {
             </svg>
           </a>
           <a
-            href={`mailto:${CONTACT_EMAIL}`}
+            href={`mailto:${site.email}`}
             className={styles.socialLink}
-            aria-label={`Email ${CONTACT_EMAIL}`}
+            aria-label={`Email ${site.email}`}
           >
             <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" aria-hidden="true">
               <path strokeLinecap="round" strokeLinejoin="round" d="M21.75 6.75v10.5a2.25 2.25 0 0 1-2.25 2.25h-15a2.25 2.25 0 0 1-2.25-2.25V6.75m19.5 0A2.25 2.25 0 0 0 19.5 4.5h-15a2.25 2.25 0 0 0-2.25 2.25m19.5 0v.243a2.25 2.25 0 0 1-1.07 1.916l-7.5 4.615a2.25 2.25 0 0 1-2.36 0L3.32 8.91a2.25 2.25 0 0 1-1.07-1.916V6.75" />
             </svg>
           </a>
         </div>
-        <p className={styles.copy}>&copy; {year} Tynnell Hollins Photography</p>
+        <p className={styles.copy}>&copy; {year} {site.title}</p>
       </div>
     </footer>
   )

--- a/app/components/Navbar/Navbar.tsx
+++ b/app/components/Navbar/Navbar.tsx
@@ -3,6 +3,7 @@ import { useState, useEffect, useRef } from 'react'
 import Link from 'next/link'
 import { usePathname } from 'next/navigation'
 import { navLinks, type NavLink } from '@/app/constants/nav'
+import { splitBrand } from '@/app/lib/constants'
 import { useScrollLock } from '@/app/hooks/useScrollLock'
 import MobileMenu from '@/app/components/MobileMenu/MobileMenu'
 import styles from './Navbar.module.css'
@@ -16,7 +17,15 @@ const LEFT_LINKS = ['Home', 'About', 'Portfolio']
 const CTA_LABEL = 'Contact'
 const CTA_TEXT = 'Inquire now'
 
-export default function Navbar({ builderLinks = [], logoUrl }: { builderLinks?: NavLink[]; logoUrl?: string }) {
+export default function Navbar({
+  builderLinks = [],
+  logoUrl,
+  siteTitle = 'Tynnell Hollins Photography',
+}: {
+  builderLinks?: NavLink[]
+  logoUrl?: string
+  siteTitle?: string
+}) {
   const [scrolled, setScrolled] = useState(false)
   const [menuOpen, setMenuOpen] = useState(false)
   const [portfolioOpen, setPortfolioOpen] = useState(false)
@@ -74,6 +83,7 @@ export default function Navbar({ builderLinks = [], logoUrl }: { builderLinks?: 
 
   useEffect(() => { setPortfolioOpen(false) }, [pathname])
 
+  const brand = splitBrand(siteTitle)
   const allLinks = [...navLinks, ...builderLinks]
   const ctaLink = allLinks.find(l => l.label === CTA_LABEL)
   const rowLinks = allLinks.filter(l => l.label !== CTA_LABEL)
@@ -140,18 +150,18 @@ export default function Navbar({ builderLinks = [], logoUrl }: { builderLinks?: 
           {leftLinks.map(renderLink)}
         </ul>
 
-        <Link href="/" className={styles.brand} aria-label="Tynnell Hollins Photography, home">
+        <Link href="/" className={styles.brand} aria-label={`${siteTitle}, home`}>
           {logoUrl ? (
             // eslint-disable-next-line @next/next/no-img-element
-            <img src={logoUrl} alt="Tynnell Hollins Photography" className={styles.brandLogo} />
+            <img src={logoUrl} alt={siteTitle} className={styles.brandLogo} />
           ) : (
             <>
               {/* Two lines, not three. The old stacked
                   Tynnell/Hollins/Photography wordmark is the design problem
                   CLAUDE.md flags: it reads as a column of shouting rather than
                   a mark, and it cannot centre. */}
-              <span className={styles.brandMark}>Tynnell Hollins</span>
-              <span className={styles.brandSub}>Photography</span>
+              <span className={styles.brandMark}>{brand.mark}</span>
+              {brand.sub && <span className={styles.brandSub}>{brand.sub}</span>}
             </>
           )}
         </Link>

--- a/app/lib/constants.ts
+++ b/app/lib/constants.ts
@@ -10,3 +10,24 @@ export const CONTACT_EMAIL = 'hello@tynnellhollinsphotography.com'
 export const EMAIL_FROM = `Tynnell Hollins Photography <${CONTACT_EMAIL}>`
 
 export const RATE_LIMIT_ERROR = 'Too many requests. Please try again later.'
+
+/**
+ * The brand renders on two lines in both the navbar and the footer: a large
+ * mark and a small tracked subline. Derive that split from the configured
+ * business name rather than hardcoding it, so renaming in Site Settings
+ * actually changes the site.
+ *
+ * The heuristic is deliberately conservative: only peel off a trailing
+ * descriptor when there are 3+ words ("Tynnell Hollins Photography" becomes
+ * "Tynnell Hollins" + "Photography"). A shorter name renders on one line,
+ * which is correct rather than a degraded fallback.
+ *
+ * Lives here rather than in app/lib/siteConfig.ts because the navbar is a
+ * client component and siteConfig pulls in payload/@payload-config, which
+ * breaks the client bundle. Same split as siteTheme.ts vs siteDesign.ts.
+ */
+export function splitBrand(title: string): { mark: string; sub: string } {
+  const words = title.trim().split(/\s+/)
+  if (words.length < 3) return { mark: title.trim(), sub: '' }
+  return { mark: words.slice(0, -1).join(' '), sub: words[words.length - 1] }
+}

--- a/app/lib/siteConfig.ts
+++ b/app/lib/siteConfig.ts
@@ -1,0 +1,74 @@
+import { cache } from 'react'
+import { getPayload } from 'payload'
+import config from '@payload-config'
+import { CONTACT_EMAIL } from './constants'
+
+// Server-only: reads the SiteConfig global (TYN-326) for the public site's
+// business name, tagline, contact info, and social links - previously
+// completely disconnected from the live site (every consuming page hardcoded
+// its own copy of these values). Falls back to those same hardcoded values on
+// any DB hiccup or before the global is ever saved, so a missing/broken
+// SiteConfig doc never takes down the public site - mirrors the pattern
+// already used for the Design global (app/lib/siteDesign.ts).
+//
+// EMAIL_FROM (the Resend "from" sender) and CONTACT_TO_EMAIL (the env var
+// contact-form submissions are actually delivered to) deliberately do NOT
+// read from this global - those are operational/deliverability config that
+// must match a domain verified in Resend, not editable display text. Only
+// CONTACT_EMAIL (the address shown to visitors) has a display counterpart
+// here, via the `email` field.
+export interface SiteConfigData {
+  title: string
+  tagline: string
+  email: string
+  phone: string
+  instagramUrl: string
+  facebookUrl: string
+  tiktokUrl: string
+  pinterestUrl: string
+}
+
+export const DEFAULT_SITE_CONFIG: SiteConfigData = {
+  title: 'Tynnell Hollins Photography',
+  tagline: 'Lost in the Moment, Found in Forever',
+  email: CONTACT_EMAIL,
+  phone: '',
+  instagramUrl: 'https://instagram.com/tynnellhollinsphotography',
+  facebookUrl: '',
+  tiktokUrl: 'https://tiktok.com/@tynnellhollinsphotography',
+  pinterestUrl: '',
+}
+
+// A few pages display "@handle" text alongside the Instagram link (not just
+// the link itself) - derive it from the URL so it never goes stale if the
+// URL changes but this text doesn't. Falls back to the raw URL if it can't
+// be parsed as one (e.g. blank, or someone pastes just a handle).
+export function instagramHandle(url: string): string {
+  try {
+    const path = new URL(url).pathname.replace(/^\/|\/$/g, '')
+    return path ? `@${path}` : url
+  } catch {
+    return url
+  }
+}
+
+// Wrapped in React's cache() so multiple call sites within one request (e.g.
+// a page's generateMetadata plus its own body) share one DB read.
+export const getSiteConfig = cache(async (): Promise<SiteConfigData> => {
+  try {
+    const payload = await getPayload({ config })
+    const doc = await payload.findGlobal({ slug: 'site-config' })
+    return {
+      title: doc.title || DEFAULT_SITE_CONFIG.title,
+      tagline: doc.tagline || DEFAULT_SITE_CONFIG.tagline,
+      email: doc.email || DEFAULT_SITE_CONFIG.email,
+      phone: doc.phone || DEFAULT_SITE_CONFIG.phone,
+      instagramUrl: doc.instagramUrl || DEFAULT_SITE_CONFIG.instagramUrl,
+      facebookUrl: doc.facebookUrl || DEFAULT_SITE_CONFIG.facebookUrl,
+      tiktokUrl: doc.tiktokUrl || DEFAULT_SITE_CONFIG.tiktokUrl,
+      pinterestUrl: doc.pinterestUrl || DEFAULT_SITE_CONFIG.pinterestUrl,
+    }
+  } catch {
+    return DEFAULT_SITE_CONFIG
+  }
+})


### PR DESCRIPTION
Reimplementation of the closed #72, which was written before the promoted-route work and could not be rebased: most of its hunks edited `export const metadata` blocks that main has since deleted in favour of `generateMetadata()` + `getPromotedPage()`, and it collided with the Footer rewritten in #103.

`app/lib/siteConfig.ts` is **lifted from that branch unchanged** - it was new, conflicted with nothing, and already mirrors the `getSiteDesign()` pattern.

## What is wired

| Where | Values |
|---|---|
| Root layout | title default + template, openGraph `siteName`, image alt |
| Navbar | brand mark, logo alt, aria-label |
| Footer | wordmark, email, Instagram + TikTok links, `@handle` text, copyright |
| Home / About / Contact | JSON-LD `sameAs`, business name, email |
| Contact | the **visible** Instagram link, not just structured data |

The `@handle` text is derived from the Instagram URL rather than stored separately, so it cannot go stale if the URL changes.

## Two structural notes

**`splitBrand()` lives in `app/lib/constants.ts`, not `siteConfig.ts`.** Both the navbar and footer need it, but the navbar is a client component and `siteConfig` pulls in `payload`/`@payload-config`. Same client-safe vs server-only split this codebase already uses for `siteTheme.ts` vs `siteDesign.ts`.

**The navbar takes `siteTitle` as a prop** rather than importing the config, for the same reason.

## Latent bug fixed

`/blog` and `/testimonials` set titles that spelled the business name out in full, which the layout template would then append **again**, producing "Blog | Tynnell Hollins Photography | Tynnell Hollins Photography".

Invisible today because both routes are promoted and `generateMetadata` returns early, so I confirmed the live titles are correct before changing anything. But it is wrong the moment either route is un-promoted.

## Deliberately unchanged

Matching the original PR reasoning: `EMAIL_FROM` and `CONTACT_TO_EMAIL` (operational deliverability config that must match a Resend-verified domain, not display text), and `opengraph-image.tsx` (edge runtime).

The Footer `STUDIO_LOCATION` stays a constant because SiteConfig has **no location field**. Adding one is a schema change beyond the scope of wiring up fields that already exist.

## Verification

Not assumed. I wrote a sentinel business name into `site_config`, rebuilt, and confirmed it appeared **3 times** in the prerendered `/contact` HTML, then reverted. That proves the values genuinely come from the database rather than from surviving hardcoded copies.

Real `next build` exits 0, ESLint clean on all changed files.

Should be a visual no-op: `site_config` was filled on 2026-08-10 with values matching what was hardcoded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)