### PR TITLE
docs: audit the admin components summary

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -305,11 +305,19 @@ The Payload admin sidebar is organized into four groups:
 
 - `AdminLogo` / `AdminIcon`: registered in `payload.config.ts` under `admin.components.graphics`
 - `Dashboard`: registered under `admin.components.views.dashboard`
-  - Shows count cards for all collections including Users
-  - Posts card shows published vs. draft split beneath total count
-  - OOO status card fetches `/api/globals/availability` and shows: Out of Office (amber, with internal label + return date), Next Unavailable (grey, upcoming range), or Available (green). All states link to `/admin/globals/availability`.
-  - Recent Activity section (TYN-200): 8 most recently updated photos as a thumbnail strip + 5 most recently updated posts as a list with status + date. Only renders when data exists.
-  - Featured sub-counts (TYN-206): Photos shows "X featured", Galleries shows "X featured", Testimonials shows "X on homepage", in addition to Posts' "published / drafts" split.
+  - **Rebuilt as a Pixieset-style hub, not a stats page.** Four product cards
+    (Portfolio, Website, Blog, Studio), each a labelled list of destinations
+    rather than a document count. Most point at the custom surfaces
+    (`/builder`, `/blog-editor`, `/site-settings`, `/availability`); a few deep
+    link into Payload for collections with no custom screen yet
+    (`/admin/collections/photos`, `/admin/globals/hero-slides`).
+  - OOO status card fetches `/api/globals/availability?depth=0` and links to
+    **`/availability`**, the custom studio page. It deliberately does NOT link to
+    `/admin/globals/availability`, which would break the no-raw-admin rule above.
+  - Recent activity: 8 most recently updated photos, 5 most recently updated
+    **galleries** (not posts), and recent orders via `/api/admin/recent-orders`.
+  - There are no per-collection count cards, no Posts published/draft split, and
+    no "X featured" sub-counts. Earlier revisions had those; this one does not.
 - `PhotoGridView`: registered on `Photos` collection under `admin.components.views.list.Component`
   - Shows gallery membership badges on each photo card: fetches all galleries once on mount (`/api/galleries?limit=300&depth=0`), builds a `Record<number, string[]>` map, renders up to 2 gallery name pills (+N overflow) below the category text (TYN-194)
   - Featured star toggle button (top-right of each photo): gold filled star = featured, translucent dark = unfeatured. Clicks PATCH `/api/photos/:id` inline without navigating away (TYN-202)
@@ -343,6 +351,32 @@ The Payload admin sidebar is organized into four groups:
   custom views, no `viewOnSite` field, and no live preview.
 - `PayloadCssGuard`: imported in `app/(payload)/admin/layout.tsx` to force CSS into client bundle
 - All custom components are `'use client'` with inline styles so they survive hydration failures
+
+### Full registration inventory
+
+The entries above cover the components with non-obvious behaviour. **31 are
+registered in total.** This is the complete list, verified against
+`collections/`, `globals/` and `payload.config.ts`:
+
+| Registered in | Components |
+|---|---|
+| `payload.config.ts` | `AdminLogo`, `AdminIcon` (graphics), `Dashboard` (dashboard view), `EmptyNav` (Nav), `BackToStudio` (actions), `ForcePasswordChange` (providers), `GoogleSignInButton` (beforeLogin) |
+| `Photos.ts` | `PhotoGridView`, `PhotoEditHeader`, `PhotoViewInPortfolioButton` |
+| `Galleries.ts` | `GalleryGridView`, `GalleryPhotoArranger`, `GalleryBulkPhotoPicker`, `CoverPhotoPicker`, `CoverPhotoCell`, `GalleryViewOnSiteButton`, `HeroPhotoPicker` |
+| `Testimonials.ts` | `TestimonialsGridView`, `TestimonialsEditHeader` |
+| `Services.ts` | `ServicesGridView`, `ServicesEditHeader` |
+| `Users.ts` | `UsersGridView`, `UsersEditHeader` |
+| `Projects.ts` | `ProjectsKanbanView`, `ProjectsEditHeader` |
+| `AboutPage.ts` | `AboutPageHeader`, `AboutViewOnSiteButton` |
+| `Availability.ts` | `AvailabilityHeader`, `OooWarnings` |
+| `BookingSettings.ts` | `BookingSettingsHeader` |
+| `HeroSlides.ts` | `HeroSlidesHeader` |
+| not registered | `PayloadCssGuard` (imported directly by the admin layout), `GlobalEditHeader`, `PhotoPickerField`, `AdminViewOnSiteLink`, `InviteUserModal` (used by other components rather than registered) |
+
+The `*EditHeader` family is the 2026-07-02 directive in action: each replaces
+Payload's breadcrumb and `[Untitled]` heading on that collection's document
+screen with a branded strip. `Posts` has none, because the blog editor replaced
+its admin entirely.
 
 **After adding any new admin component**, always regenerate importMap (see above) and commit the result.
 


### PR DESCRIPTION
The remaining doc debt flagged after #109. Every claim checked against `collections/`, `globals/` and `payload.config.ts`.

## The Dashboard entry was substantially wrong

It described a stats page: per-collection count cards, a Posts published/draft split, and "X featured" sub-counts. **None of that exists.** The Dashboard was rebuilt as a Pixieset-style hub with four product cards (Portfolio, Website, Blog, Studio), each a list of destinations rather than a count.

Two specifics worth calling out:

- The doc said the OOO card links to `/admin/globals/availability`. **It links to `/availability`**, the custom studio page. The documented behaviour would have broken the project own no-raw-admin absolute rule, so anyone "fixing" the code to match the doc would have introduced a violation.
- Recent activity is 8 photos + 5 **galleries** + recent orders, not 8 photos + 5 posts.

## Verified correct, left alone

- `PhotoGridView`: the `/api/galleries?limit=300&depth=0` membership fetch and the inline `/api/photos/:id` PATCH
- `GalleryGridView` and `TestimonialsGridView`: inline PATCH toggles
- `TestimonialsGridView`: session-type pills, homepage toggle, name search
- `ServicesGridView`: eyebrow, price, deposit, display order
- `PayloadCssGuard`: imported in `app/(payload)/admin/layout.tsx`
- "All custom components are `use client`" - confirmed across all 36 files

## Added: full registration inventory

The summary documented **10** components. **31 are registered.**

Entirely undocumented until now: the **Projects collection Kanban view**, **UsersGridView**, and the whole ***EditHeader* family** that implements the 2026-07-02 minimize-Payload-chrome directive.

Rather than write prose for 21 more components, the new table lists every registration by config file, so the gap is visible and the list is cheap to keep true. Verified: all 36 named files exist, and the registered count matches.

No em dash appears in any added line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)